### PR TITLE
refactor: change homologation regulation API url

### DIFF
--- a/src/components/molecules/homologation/DaHomologationRegulationResult.tsx
+++ b/src/components/molecules/homologation/DaHomologationRegulationResult.tsx
@@ -7,7 +7,7 @@ import DaLoader from '@/components/atoms/DaLoader'
 import { VehicleAPI } from '@/types/api.type'
 import {
   Regulation,
-  getCertivityRegulationsService,
+  getHomologationRegulationsService,
   supportedCertivityApis,
   supportedCertivityApis_v4_map,
 } from '@/services/certivity.service'
@@ -87,7 +87,7 @@ const HomologationRegulationResult = ({
         if (selectedAPIs.size > 0) {
           // const credentials = await retrieveCertivityCredentials();
 
-          const regulationsResponse = await getCertivityRegulationsService(
+          const regulationsResponse = await getHomologationRegulationsService(
             Array.from(selectedAPIs.values())
               .map((api) => {
                 return supportedCertivityApis.has(api.name)

--- a/src/services/certivity.service.ts
+++ b/src/services/certivity.service.ts
@@ -218,9 +218,9 @@ export const supportedCertivityApis_v4_map: Record<string, string> = {
 // export const getCertivityCredentialsService = async () =>
 //     (await certivityAxios.get<CertivityCredentials>("/certivity/credentials")).data;
 
-export const getCertivityRegulationsService = async (apis: string[]) =>
+export const getHomologationRegulationsService = async (apis: string[]) =>
   (
-    await serverAxios.get<Regulation[]>('/certivity/regulations', {
+    await serverAxios.get<Regulation[]>('/homologation/regulations', {
       params: {
         vehicleApis: apis.join(','),
       },


### PR DESCRIPTION
This fixes #28 by changing the homologation service to /homologation/regulations