### PR TITLE
Fix: pasting overwrites name input in wishlist API form

### DIFF
--- a/src/components/molecules/forms/FormCreateWishlistApi.tsx
+++ b/src/components/molecules/forms/FormCreateWishlistApi.tsx
@@ -342,13 +342,6 @@ const FormCreateWishlistApi = ({
           placeholder="Name"
           className="relative mt-2"
           inputClassName="text-sm"
-          onPaste={(e) => {
-            e.stopPropagation()
-            e.preventDefault()
-            const pastedValue = e.clipboardData.getData('Text')
-            setData((prev) => ({ ...prev, name: pastedValue }))
-            setShowSuggestions(true)
-          }}
         />
         {showSuggestions && filteredSuggestions.length > 0 && (
           <div className="absolute z-50 mt-1 w-[calc(100%-2rem)] max-h-[18vh] overflow-y-auto rounded-md border border-gray-200 bg-white p-1 shadow-lg">


### PR DESCRIPTION
Fixes an issue where pasting text into the name input field of the wishlist API form would overwrite the entire value instead of inserting the text at the cursor position. This was caused by an unnecessary `onPaste` handler that prevented the default paste behavior and incorrectly set the input value to the pasted text. By removing the `onPaste` handler, the default paste behavior is restored, allowing text to be inserted at the cursor position as expected. The existing `onChange` handler ensures that the state is updated and suggestions are shown correctly after pasting.

Resolve issue #12 