### PR TITLE
Added filter option to useFetchAssets

### DIFF
--- a/src/hooks/useAssets.ts
+++ b/src/hooks/useAssets.ts
@@ -6,9 +6,9 @@ import {
   updateAssetService,
   shareMyAsset,
   removeUserFromShareList,
-  getAssetById
-} from '@/services/assset.service'
-import { Asset } from '@/types/asset.type'
+  getAssetById,
+} from '@/services/asset.service'
+import { Asset, QueryAssetsParams } from '@/types/asset.type'
 
 export const ASSET_QUERY_KEY = {
   assets: ['assets'],
@@ -18,12 +18,11 @@ export const useAssets = () => {
   const queryClient = useQueryClient()
 
   // Fetch assets
-  const useFetchAssets = () =>
+  const useFetchAssets = (params?: QueryAssetsParams) =>
     useQuery<Asset[]>({
-      queryKey: ASSET_QUERY_KEY.assets,
-      queryFn: listAssetsService,
+      queryKey: [...ASSET_QUERY_KEY.assets, params],
+      queryFn: () => listAssetsService(params),
     })
-
 
   // Create a new asset
   const createAsset = useMutation({

--- a/src/services/asset.service.ts
+++ b/src/services/asset.service.ts
@@ -1,5 +1,5 @@
 import { serverAxios } from './base'
-import { Asset } from '@/types/asset.type'
+import { Asset, QueryAssetsParams } from '@/types/asset.type'
 
 // Type for asset creation/update payload
 interface AssetPayload {
@@ -9,8 +9,17 @@ interface AssetPayload {
 }
 
 // List all assets
-export const listAssetsService = async (): Promise<Asset[]> => {
-  const response = await serverAxios.get('/assets')
+export const listAssetsService = async (
+  params?: QueryAssetsParams,
+): Promise<Asset[]> => {
+  if (params?.type) {
+    params.type = Array.isArray(params.type)
+      ? params.type.join(',')
+      : params.type
+  }
+  const response = await serverAxios.get('/assets', {
+    params,
+  })
   return response.data.results
 }
 
@@ -36,21 +45,29 @@ export const updateAssetService = async (
   return response.data
 }
 
-export const shareMyAsset = async (assetId: string, payload: any): Promise<any> => {
-  const response = await serverAxios.post(`/assets/${assetId}/permissions`, payload)
+export const shareMyAsset = async (
+  assetId: string,
+  payload: any,
+): Promise<any> => {
+  const response = await serverAxios.post(
+    `/assets/${assetId}/permissions`,
+    payload,
+  )
   return response.data
 }
 
-export const removeUserFromShareList =  async (assetId: string, userId: string, role: string): Promise<any> => {
-  const response = await serverAxios.delete(`/assets/${assetId}/permissions?userId=${userId}&role=${role}`)
+export const removeUserFromShareList = async (
+  assetId: string,
+  userId: string,
+  role: string,
+): Promise<any> => {
+  const response = await serverAxios.delete(
+    `/assets/${assetId}/permissions?userId=${userId}&role=${role}`,
+  )
   return response.data
 }
-
 
 export const getAssetById = async (assetId: string): Promise<any> => {
   const response = await serverAxios.get(`/assets/${assetId}`)
   return response.data
 }
-
-
-

--- a/src/types/asset.type.ts
+++ b/src/types/asset.type.ts
@@ -1,6 +1,13 @@
+import { ListQueryParams } from './common.type'
+
 export type Asset = {
   name: string
   type: string
   data: string
   id?: string
+}
+
+export type QueryAssetsParams = Omit<ListQueryParams, 'search'> & {
+  name?: string
+  type?: string | string[]
 }


### PR DESCRIPTION
Added filter option to useFetchAssets for filtering.
Example usage:
```javascript
  const { useFetchAssets } = useAssets()

  // Match all assets (original behavior)
  const { data: matchAll } = useFetchAssets()

  // Match all assets with a specific type
  const { data: singleType } = useFetchAssets({
    type: 'CLOUD_RUNTIME',
  })

  // Match multiple asset types
  const { data: multipleTypes } = useFetchAssets({
    type: ['HARDWARE_KIT', 'CLOUD_RUNTIME'],
  })

```