### PR TITLE
Update redirect URL for SDV Guide

### DIFF
--- a/instance/home.tsx
+++ b/instance/home.tsx
@@ -99,7 +99,7 @@ const home = [
 
         imageURL:
           'https://bewebstudio.digitalauto.tech/data/projects/nTcRsgxcDWgr/image.avif',
-        redirectURL: 'https://sdv.guide/',
+        redirectURL: 'https://www.sdv.guide/',
       },
       {
         title: 'Version v2.0 release',


### PR DESCRIPTION
- This close #158: Changed the redirectURL for the SDV Guide project from 'https://sdv.guide/' to 'https://www.sdv.guide/' to ensure correct navigation.