### PR TITLE
Setting up Quevee for SDV Maturity assessment Badges on Eclipse Autowrx - add step "Upload quality manifest to release"

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,3 +63,10 @@ jobs:
           artifacts_documentation: docs/development-guuide.md
           artifacts_coding_guidelines: docs/development-guuide.md
           artifacts_release_process: https://www.eclipse.org/projects/dev_process/#6_4_Releases
+          
+      - name: Upload quality manifest to release
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: ${{ steps.quevee.outputs.manifest_file }}
+          tag: ${{ github.ref }}


### PR DESCRIPTION
Request from Eclipse Foundation to set up the Quevee GitHub action on Eclipse Autowrx, to support the implementation of the Eclipse SDV maturity assessment badges.

Update of the release.yml file with an additional step "Upload quality manifest to release"