### PR TITLE
Use Yarn in dev guide and fix CORS regex example

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -19,6 +19,6 @@ JWT_COOKIE_DOMAIN=your-domain
 ADMIN_EMAILS=admin89@email.com
 ADMIN_PASSWORD=789789789
 
-CORS_ORIGINS=localhost:\\d+,127\\.0\\.0\\.1:\\d+
+CORS_ORIGINS=localhost:\d+,127\\.0\\.0\\.1:\d+
 
 

--- a/development-guide.md
+++ b/development-guide.md
@@ -75,7 +75,7 @@ If you have a remote MongoDB instance, you can use it by setting the `MONGODB_UR
 cd backend
 
 # Install dependencies
-npm install
+yarn install
 
 # Create .env file from example
 cp .env.example .env
@@ -92,7 +92,7 @@ cp .env.example .env
 cd ../frontend
 
 # Install dependencies
-npm install
+yarn install
 
 # Create .env file from example
 cp .env.example .env
@@ -109,13 +109,13 @@ You need **two terminal windows**:
 **Terminal 1 - Backend:**
 ```bash
 cd backend
-npm run dev
+yarn run dev
 ```
 
 **Terminal 2 - Frontend:**
 ```bash
 cd frontend
-npm run dev
+yarn run dev
 ```
 
 That's it! The application should now be running.
@@ -355,17 +355,17 @@ Once both services are running, you can access:
 
 ### General Issues
 
-**Issue:** `npm install fails`
+**Issue:** `yarn install fails`
 
 **Solutions:**
-1. Clear npm cache: `npm cache clean --force`
+1. Clear yarn cache: `yarn cache clean --force`
 2. Delete `node_modules` and `package-lock.json`, then reinstall
 3. Ensure you're using Node.js 18+
 
 **Issue:** `Changes not reflecting (hot reload not working)`
 
 **Solutions:**
-1. Check that you're running `npm run dev` (not `npm start`)
+1. Check that you're running `yarn run dev` (not `yarn start`)
 2. Restart the dev server
 3. Clear browser cache
 


### PR DESCRIPTION
This PR makes two small consistency and correctness updates:

- **Update development guide to use Yarn**
  - Replace npm install with yarn install for both backend and frontend
  - Replace npm run dev with yarn run dev in the run instructions
  - Adjust troubleshooting section to reference yarn install and yarn cache clean --force

- **Fix CORS_ORIGINS example in .env.example**
  - Correct the regex for localhost by removing unnecessary escaping of \d+
  - Keep 127\.0\.0\.1 properly escaped while ensuring the example is copy-paste friendly

These changes improve documentation accuracy and keep the example .env aligned with the actual expected configuration.