### PR TITLE
Refactor template tabs and fix overlay issue

### DIFF
--- a/frontend/src/components/atoms/dialog.tsx
+++ b/frontend/src/components/atoms/dialog.tsx
@@ -52,16 +52,6 @@ const DialogContent = React.forwardRef<
         className,
       )}
       {...props}
-      // Radix DismissableLayer sets `pointer-events: none` on <body> when modal dialogs open.
-      // Multiple Radix components (dialog, dropdown-menu, select) each bundle their own
-      // DismissableLayer copy with separate state, causing stale `pointer-events: none` to
-      // persist after close (e.g. opening this dialog from a DropdownMenu).
-      // Fix: clear it on every close animation end. The overlay already blocks outside clicks.
-      onAnimationEnd={() => {
-        if (document.body.style.pointerEvents === 'none') {
-          document.body.style.pointerEvents = ''
-        }
-      }}
     >
       {children}
       {showCloseButton && (

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -37,6 +37,14 @@
   }
 }
 
+/* Radix UI DismissableLayer bug: multiple Radix components (dialog, dropdown-menu, select)
+   each bundle separate DismissableLayer copies that independently set pointer-events: none
+   on <body>. When one opens another (e.g. DropdownMenu → Dialog), the stale value persists
+   after close. The overlay already blocks outside clicks, so body pointer-events is redundant. */
+body {
+  pointer-events: auto !important;
+}
+
 /* ============================================
    CUSTOM PROJECT UTILITIES
    ============================================ */


### PR DESCRIPTION
- Refactor model/prototype tabs layout from grid to flex for better responsiveness.
- Fix overlay issue after closing modal
- Fix create model by using template issue