### PR TITLE
fix: align duplicate name hint style and add edit-prototype support

### DIFF
--- a/frontend/src/components/atoms/DaDuplicateNameHint.tsx
+++ b/frontend/src/components/atoms/DaDuplicateNameHint.tsx
@@ -24,7 +24,7 @@ const DaDuplicateNameHint = ({
   <p className={cn('text-xs text-destructive mt-1', className)}>
     {message}
     {suggestedName && (
-      <>, try{' '}
+      <>. Please choose another name like:{' '}
         <button
           type="button"
           className="underline hover:opacity-75"

--- a/frontend/src/components/molecules/forms/FormCreateModel.tsx
+++ b/frontend/src/components/molecules/forms/FormCreateModel.tsx
@@ -226,6 +226,7 @@ const FormCreateModel = () => {
             message="A model with this name already exists"
             suggestedName={suggestedName}
             onApplySuggestion={(name) => handleChange('name', name)}
+            className="text-sm text-secondary mt-2"
           />
         )}
       </div>

--- a/frontend/src/components/molecules/forms/FormCreatePrototype.tsx
+++ b/frontend/src/components/molecules/forms/FormCreatePrototype.tsx
@@ -425,13 +425,14 @@ const FormCreatePrototype = ({
         />
         {isDuplicatePrototypeName && (
           <DaDuplicateNameHint
-            message="A prototype with this name already exists"
+            message={`The prototype name '${data.prototypeName}' is already in use for model '${localModel?.name ?? data.modelName}'`}
             suggestedName={suggestedPrototypeName}
             onApplySuggestion={(name) => handleChange('prototypeName', name)}
+            className="text-sm text-secondary mt-2"
           />
         )}
         {error && !isDuplicatePrototypeName && (
-          <p className="mt-2 text-sm text-destructive">{error}</p>
+          <p className="mt-2 text-sm text-secondary">{error}</p>
         )}
       </div>
 

--- a/frontend/src/components/organisms/PrototypeTabInfo.tsx
+++ b/frontend/src/components/organisms/PrototypeTabInfo.tsx
@@ -6,7 +6,7 @@
 //
 // SPDX-License-Identifier: MIT
 
-import React, { useState, useEffect } from 'react'
+import React, { useState, useEffect, useMemo } from 'react'
 import { Prototype } from '../../types/model.type'
 import { DaImage } from '../atoms/DaImage'
 import { Button } from '../atoms/button'
@@ -46,6 +46,8 @@ import { addLog } from '@/services/log.service'
 import useSelfProfileQuery from '@/hooks/useSelfProfile'
 import { toast } from 'react-toastify'
 import { isAxiosError } from 'axios'
+import useDuplicateNameCheck from '@/hooks/useDuplicateNameCheck'
+import DaDuplicateNameHint from '@/components/atoms/DaDuplicateNameHint'
 
 interface PrototypeTabInfoProps {
   prototype: Prototype
@@ -60,9 +62,17 @@ const PrototypeTabInfo: React.FC<PrototypeTabInfoProps> = ({
   const [isEditing, setIsEditing] = useState(false)
   const [localPrototype, setLocalPrototype] = useState(prototype)
   const { data: model } = useCurrentModel()
-  const { refetch: refetchModelPrototypes } = useListModelPrototypes(
+  const { data: modelPrototypes, refetch: refetchModelPrototypes } = useListModelPrototypes(
     model?.id || '',
   )
+
+  const existingPrototypeNames = useMemo(
+    () => modelPrototypes?.filter((p: any) => p.id !== prototype.id).map((p: any) => p.name) ?? [],
+    [modelPrototypes, prototype.id],
+  )
+
+  const { isDuplicate: isDuplicatePrototypeName, suggestedName: suggestedPrototypeName } =
+    useDuplicateNameCheck(localPrototype.name, existingPrototypeNames)
   const { refetch: refetchCurrentPrototype } = useCurrentPrototype()
   const navigate = useNavigate()
   const [isAuthorized, isAdmin] = usePermissionHook(
@@ -232,7 +242,7 @@ const PrototypeTabInfo: React.FC<PrototypeTabInfoProps> = ({
                   <Button variant="outline" onClick={handleCancel} size="sm">
                     Cancel
                   </Button>
-                  <Button onClick={handleSave} size="sm" disabled={isSaving}>
+                  <Button onClick={handleSave} size="sm" disabled={isSaving || isDuplicatePrototypeName}>
                     {isSaving ? 'Saving...' : 'Save'}
                   </Button>
                 </div>
@@ -373,7 +383,15 @@ const PrototypeTabInfo: React.FC<PrototypeTabInfoProps> = ({
                       onChange={(e) => handleChange('name', e.target.value)}
                       className={error ? 'border-secondary' : ''}
                     />
-                    {error && <p className="mt-2 text-sm text-secondary">{error}</p>}
+                    {isDuplicatePrototypeName && (
+                      <DaDuplicateNameHint
+                        message={`The prototype name '${localPrototype.name}' is already in use for model '${model?.name}'`}
+                        suggestedName={suggestedPrototypeName}
+                        onApplySuggestion={(name) => handleChange('name', name)}
+                        className="text-sm text-secondary mt-2"
+                      />
+                    )}
+                    {error && !isDuplicatePrototypeName && <p className="mt-2 text-sm text-secondary">{error}</p>}
                   </div>
                   <div className="flex flex-col gap-2">
                     <Label htmlFor="problem">Problem</Label>

--- a/frontend/src/components/organisms/PrototypeTabInfo.tsx
+++ b/frontend/src/components/organisms/PrototypeTabInfo.tsx
@@ -67,7 +67,7 @@ const PrototypeTabInfo: React.FC<PrototypeTabInfoProps> = ({
   )
 
   const existingPrototypeNames = useMemo(
-    () => modelPrototypes?.filter((p: any) => p.id !== prototype.id).map((p: any) => p.name) ?? [],
+    () => modelPrototypes?.filter((p: Prototype) => p.id !== prototype.id).map((p: Prototype) => p.name) ?? [],
     [modelPrototypes, prototype.id],
   )
 

--- a/frontend/src/pages/PageModelDetail.tsx
+++ b/frontend/src/pages/PageModelDetail.tsx
@@ -273,10 +273,11 @@ const PageModelDetail = () => {
                       message="A model with this name already exists"
                       suggestedName={suggestedName}
                       onApplySuggestion={(name) => { setNewName(name); setNameError('') }}
+                      className="text-sm text-secondary mt-2"
                     />
                   )}
                   {nameError && !isDuplicateName && (
-                    <p className="text-xs text-destructive">{nameError}</p>
+                    <p className="text-sm text-secondary mt-2">{nameError}</p>
                   )}
                 </div>
               ) : (


### PR DESCRIPTION
- Use text-secondary color (amber) consistently across all duplicate name hints instead of text-destructive (red), matching the original PR #333 style
- Update hint message format to match backend error wording: "The prototype name 'x' is already in use for model 'y'. Please choose another name like: z"
- Add real-time duplicate name check to PrototypeTabInfo (edit prototype) with Save button disabled when name conflicts
- Fix same color inconsistency in PageModelDetail (edit model name)