### PR TITLE
chore: remove permission check for Generative AI route

### DIFF
--- a/backend/src/routes/v2/system/genai.route.js
+++ b/backend/src/routes/v2/system/genai.route.js
@@ -10,8 +10,6 @@ const { createProxyMiddleware, fixRequestBody } = require('http-proxy-middleware
 const express = require('express');
 const config = require('../../../config/config');
 const { proxyHandler } = require('../../../config/proxyHandler');
-const { checkPermission } = require('../../../middlewares/permission');
-const { PERMISSIONS } = require('../../../config/roles');
 const auth = require('../../../middlewares/auth');
 
 const {
@@ -20,7 +18,7 @@ const {
 
 const router = express.Router();
 
-router.use(auth(), checkPermission(PERMISSIONS.GENERATIVE_AI));
+router.use(auth());
 
 const proxyMiddleware = genAI.url
   ? createProxyMiddleware({


### PR DESCRIPTION
This pull request simplifies the middleware setup for the `genai.route.js` route by removing the explicit permission check for Generative AI access. Now, only authentication is required to access these routes.

Middleware simplification:

* Removed the import and usage of `checkPermission` and `PERMISSIONS` from `genai.route.js`, so the route now only checks for authentication and not for specific Generative AI permissions. [[1]](diffhunk://#diff-2e3d4fec2b1580ea7e2f09b0ba36f3ec4b991eef33f7fe1c531f495074d37b13L13-L14) [[2]](diffhunk://#diff-2e3d4fec2b1580ea7e2f09b0ba36f3ec4b991eef33f7fe1c531f495074d37b13L23-R21)