### PR TITLE
Implement model prototype configuration and access control 

### DIFF
--- a/backend/src/config/predefinedSiteConfigs.js
+++ b/backend/src/config/predefinedSiteConfigs.js
@@ -28,6 +28,7 @@ const PREDEFINED_SITE_CONFIGS = [
     secret: false,
     valueType: 'image_url',
     description: 'Default image used when creating a new model.',
+    category: 'model_prototype',
   },
   {
     key: 'DEFAULT_PROTOTYPE_IMAGE',
@@ -36,6 +37,7 @@ const PREDEFINED_SITE_CONFIGS = [
     secret: false,
     valueType: 'image_url',
     description: 'Default cover image used when creating a new prototype.',
+    category: 'model_prototype',
   },
   {
     key: 'SITE_TITLE',
@@ -101,7 +103,7 @@ const PREDEFINED_SITE_CONFIGS = [
     secret: false,
     valueType: 'boolean',
     description: 'Show or hide the API panel on the Prototype Code tab.',
-    category: 'prototype',
+    category: 'model_prototype',
   },
   {
     key: 'SHOW_CODE_DIFF',
@@ -195,7 +197,7 @@ const PREDEFINED_SITE_CONFIGS = [
     secret: false,
     valueType: 'boolean',
     description: 'Enable or disable the context menu on prototype items.',
-    category: 'prototype',
+    category: 'model_prototype',
   },
   {
     key: 'ALLOW_NON_ADMIN_ADDON_CONFIG',
@@ -204,7 +206,16 @@ const PREDEFINED_SITE_CONFIGS = [
     secret: false,
     valueType: 'boolean',
     description: 'Allow non-admin model owners to add/manage addon tabs.',
-    category: 'prototype',
+    category: 'model_prototype',
+  },
+  {
+    key: 'PUBLIC_MODEL_WRITE_ACCESS',
+    scope: 'site',
+    value: false,
+    secret: false,
+    valueType: 'boolean',
+    description: 'Allow authenticated users to create prototypes on public models they do not own. When disabled, public models are read-only for non-owners.',
+    category: 'model_prototype',
   },
   {
     key: 'GRADIENT_HEADER',

--- a/backend/src/controllers/prototype.controller.js
+++ b/backend/src/controllers/prototype.controller.js
@@ -14,11 +14,28 @@ const { PERMISSIONS } = require('../config/roles');
 const ApiError = require('../utils/ApiError');
 const FeedbackPrototypeDecorator = require('../decorators/FeedbackPrototypeDecorator');
 const FeedbackPrototypeListDecorator = require('../decorators/FeedbackPrototypeListDecorator');
+const { Model } = require('../models');
+const siteConfigUtil = require('../utils/siteConfig');
+
+/**
+ * Throws FORBIDDEN unless the user has WRITE_MODEL permission on the given model,
+ * or PUBLIC_MODEL_WRITE_ACCESS is enabled and the model is public.
+ */
+const assertCanWriteToModel = async (userId, modelId) => {
+  const hasWritePermission = await permissionService.hasPermission(userId, PERMISSIONS.WRITE_MODEL, modelId);
+  if (hasWritePermission) return;
+
+  const publicWriteAccess = await siteConfigUtil.getConfig('PUBLIC_MODEL_WRITE_ACCESS', false);
+  if (publicWriteAccess) {
+    const model = await Model.findById(modelId).select('visibility');
+    if (model?.visibility === 'public') return;
+  }
+
+  throw new ApiError(httpStatus.FORBIDDEN, 'Forbidden');
+};
 
 const createPrototype = catchAsync(async (req, res) => {
-  if (!(await permissionService.hasPermission(req.user.id, PERMISSIONS.WRITE_MODEL, req.body.model_id))) {
-    throw new ApiError(httpStatus.FORBIDDEN, 'Forbidden');
-  }
+  await assertCanWriteToModel(req.user.id, req.body.model_id);
   const prototypeId = await prototypeService.createPrototype(req.user.id, req.body);
   res.status(201).send(prototypeId);
 });
@@ -29,9 +46,8 @@ const bulkCreatePrototypes = catchAsync(async (req, res) => {
     throw new ApiError(httpStatus.BAD_REQUEST, 'All prototypes must belong to the same model');
   }
 
-  if (!(await permissionService.hasPermission(req.user.id, PERMISSIONS.WRITE_MODEL, modelIds.values().next().value))) {
-    throw new ApiError(httpStatus.FORBIDDEN, 'Forbidden');
-  }
+  const targetModelId = modelIds.values().next().value;
+  await assertCanWriteToModel(req.user.id, targetModelId);
 
   const prototypeIds = await prototypeService.bulkCreatePrototypes(req.user.id, req.body);
   res.status(201).send(prototypeIds);

--- a/frontend/src/components/molecules/ConfigList.tsx
+++ b/frontend/src/components/molecules/ConfigList.tsx
@@ -33,8 +33,9 @@ export type SiteConfigHistorySection =
   | 'style'
   | 'secrets'
   | 'staging'
-  | 'prototype'
+  | 'model_prototype'
   | 'genai'
+  | 'privacy'
 
 interface ConfigListProps {
   configs: Config[]

--- a/frontend/src/components/molecules/forms/FormNewPrototype.tsx
+++ b/frontend/src/components/molecules/forms/FormNewPrototype.tsx
@@ -30,6 +30,7 @@ import DaDuplicateNameHint from '@/components/atoms/DaDuplicateNameHint'
 import useDuplicateNameCheck from '@/hooks/useDuplicateNameCheck'
 import { addLog } from '@/services/log.service'
 import { createModelService, listModelsLite } from '@/services/model.service'
+import { useSiteConfig } from '@/utils/siteConfig'
 import { listModelTemplates } from '@/services/modelTemplate.service'
 import { createPrototypeService } from '@/services/prototype.service'
 import { ModelLite, Prototype } from '@/types/model.type'
@@ -68,6 +69,7 @@ const FormNewPrototype = ({
     const navigate = useNavigate()
     const { toast } = useToast()
     const { data: currentUser, isLoading: isCurrentUserLoading } = useSelfProfileQuery()
+    const publicModelWriteAccess = useSiteConfig('PUBLIC_MODEL_WRITE_ACCESS', false) as boolean
 
     const { data: ownedModelsData, isLoading: isFetchingOwnedModels } = useQuery({
         queryKey: ['listModelLiteOwned', currentUser?.id],
@@ -81,16 +83,23 @@ const FormNewPrototype = ({
         enabled: !!currentUser?.id,
     })
 
+    const { data: publicModelsData, isLoading: isFetchingPublicModels } = useQuery({
+        queryKey: ['listModelLitePublic'],
+        queryFn: () => listModelsLite({ visibility: 'public' }, { maxResults: 200 }),
+        enabled: !!publicModelWriteAccess && !!currentUser?.id,
+    })
+
     const allModels = useMemo(() => {
         const owned = ownedModelsData?.results ?? []
         const contributed = contributedModelsData?.results ?? []
+        const publicModels = publicModelWriteAccess ? (publicModelsData?.results ?? []) : []
         const byId = new Map<string, ModelLite>()
-            ;[...owned, ...contributed].forEach((model) => byId.set(model.id, model))
+            ;[...owned, ...contributed, ...publicModels].forEach((model) => byId.set(model.id, model))
         return { results: Array.from(byId.values()) }
-    }, [ownedModelsData?.results, contributedModelsData?.results])
+    }, [ownedModelsData?.results, contributedModelsData?.results, publicModelsData?.results, publicModelWriteAccess])
 
     const isFetchingModels =
-        isCurrentUserLoading || isFetchingOwnedModels || isFetchingContributedModels
+        isCurrentUserLoading || isFetchingOwnedModels || isFetchingContributedModels || (publicModelWriteAccess && isFetchingPublicModels)
 
     const [prototypeName, setPrototypeName] = useState('')
     const [selectedModelId, setSelectedModelId] = useState<string>('')

--- a/frontend/src/components/organisms/ModelPrototypeConfigSection.tsx
+++ b/frontend/src/components/organisms/ModelPrototypeConfigSection.tsx
@@ -28,14 +28,16 @@ import {
     upsertConfigFromHistory,
 } from '@/utils/siteConfigAdmin'
 
-type PrototypeSubTab = 'config' | 'history'
-const PROTOTYPE_HISTORY_SECTION = 'prototype' as SiteConfigHistorySection
+const CATEGORY = 'model_prototype'
 
-const PrototypeConfigSection: React.FC = () => {
+type SubTab = 'config' | 'history'
+const HISTORY_SECTION: SiteConfigHistorySection = CATEGORY
+
+const ModelPrototypeConfigSection: React.FC = () => {
     const { data: self, isLoading: selfLoading } = useSelfProfileQuery()
     const [configs, setConfigs] = useState<Config[]>([])
     const [isLoading, setIsLoading] = useState(false)
-    const [subTab, setSubTab] = useState<PrototypeSubTab>('config')
+    const [subTab, setSubTab] = useState<SubTab>('config')
     const { toast } = useToast()
 
     useEffect(() => {
@@ -48,23 +50,21 @@ const PrototypeConfigSection: React.FC = () => {
         try {
             setIsLoading(true)
 
-            const predefinedPrototypeConfigs = PREDEFINED_SITE_CONFIGS.filter(
-                (config) => config.category === 'prototype',
+            const predefinedConfigs = PREDEFINED_SITE_CONFIGS.filter(
+                (config) => config.category === CATEGORY,
             )
 
-            // Get existing Prototype configs from DB
             const res = await configManagementService.getConfigs({
                 secret: false,
                 scope: 'site',
-                category: 'prototype',
+                category: CATEGORY,
                 limit: 100,
             })
 
             const existingConfigs = res.results || []
             const existingKeys = new Set(existingConfigs.map((config) => config.key))
 
-            // Find missing predefined Prototype configs and create them
-            const missingConfigs = predefinedPrototypeConfigs.filter(
+            const missingConfigs = predefinedConfigs.filter(
                 (config) => !existingKeys.has(config.key),
             )
 
@@ -76,7 +76,7 @@ const PrototypeConfigSection: React.FC = () => {
                 const updatedRes = await configManagementService.getConfigs({
                     secret: false,
                     scope: 'site',
-                    category: 'prototype',
+                    category: CATEGORY,
                     limit: 100,
                 })
 
@@ -88,7 +88,7 @@ const PrototypeConfigSection: React.FC = () => {
             toast({
                 title: 'Load failed',
                 description:
-                    err instanceof Error ? err.message : 'Failed to load Prototype configs',
+                    err instanceof Error ? err.message : 'Failed to load Model & Prototype configs',
                 variant: 'destructive',
             })
         } finally {
@@ -99,7 +99,7 @@ const PrototypeConfigSection: React.FC = () => {
     const handleFactoryReset = async () => {
         if (
             !window.confirm(
-                'Restore all Prototype configs to default values? This will reset Prototype settings to their defaults.',
+                'Restore all Model & Prototype configs to default values? This will reset these settings to their defaults.',
             )
         ) {
             return
@@ -108,34 +108,32 @@ const PrototypeConfigSection: React.FC = () => {
         try {
             setIsLoading(true)
 
-            const predefinedPrototypeConfigs = PREDEFINED_SITE_CONFIGS.filter(
-                (config) => config.category === 'prototype',
+            const predefinedConfigs = PREDEFINED_SITE_CONFIGS.filter(
+                (config) => config.category === CATEGORY,
             )
 
-            // Delete all Prototype configs
             const allConfigs = await configManagementService.getConfigs({
                 secret: false,
                 scope: 'site',
-                category: 'prototype',
+                category: CATEGORY,
                 limit: 100,
             })
 
             const { failed } = await deleteConfigsById(allConfigs.results || [])
             failed.forEach((f) =>
-                console.warn('Failed to delete Prototype config', f.key, f.reason),
+                console.warn('Failed to delete config', f.key, f.reason),
             )
 
-            // Recreate defaults
-            if (predefinedPrototypeConfigs.length > 0) {
+            if (predefinedConfigs.length > 0) {
                 await configManagementService.bulkUpsertConfigs({
-                    configs: predefinedPrototypeConfigs,
+                    configs: predefinedConfigs,
                 })
             }
 
             toast({
                 title: 'Restored',
                 description:
-                    'Prototype configs restored to default values. Reloading page...',
+                    'Model & Prototype configs restored to default values. Reloading page...',
             })
 
             reloadSoon()
@@ -145,7 +143,7 @@ const PrototypeConfigSection: React.FC = () => {
                 description:
                     err instanceof Error
                         ? err.message
-                        : 'Failed to reset Prototype configs',
+                        : 'Failed to reset Model & Prototype configs',
                 variant: 'destructive',
             })
             setIsLoading(false)
@@ -158,7 +156,7 @@ const PrototypeConfigSection: React.FC = () => {
             const { valueBefore, targetValue } = await upsertConfigFromHistory({
                 entry,
                 scope: 'site',
-                category: 'prototype',
+                category: CATEGORY,
             })
 
             pushSiteConfigEdit({
@@ -166,7 +164,7 @@ const PrototypeConfigSection: React.FC = () => {
                 valueBefore,
                 valueAfter: targetValue,
                 valueType: entry.valueType,
-                section: 'prototype',
+                section: CATEGORY,
             })
 
             toast({
@@ -181,7 +179,7 @@ const PrototypeConfigSection: React.FC = () => {
                 description:
                     err instanceof Error
                         ? err.message
-                        : 'Failed to restore Prototype configuration',
+                        : 'Failed to restore configuration',
                 variant: 'destructive',
             })
             setIsLoading(false)
@@ -193,10 +191,10 @@ const PrototypeConfigSection: React.FC = () => {
             <div className="px-6 py-4 border-b border-border flex items-center justify-between">
                 <div className="flex flex-col">
                     <h2 className="text-lg font-semibold text-foreground">
-                        Prototype Configuration
+                        Model & Prototype Configuration
                     </h2>
                     <p className="text-sm text-muted-foreground mt-1">
-                        Configure Prototype-specific behavior and feature visibility
+                        Configure Model and Prototype behavior, defaults, and access control
                     </p>
                 </div>
                 <Button
@@ -243,7 +241,7 @@ const PrototypeConfigSection: React.FC = () => {
                 ) : subTab === 'history' ? (
                     <div className="px-0">
                         <SiteConfigEditHistory
-                            section={PROTOTYPE_HISTORY_SECTION}
+                            section={HISTORY_SECTION}
                             onRestoreEntry={handleRestoreHistoryEntry}
                         />
                     </div>
@@ -254,7 +252,7 @@ const PrototypeConfigSection: React.FC = () => {
                         onDelete={() => { }}
                         isLoading={isLoading}
                         onUpdated={loadConfigs}
-                        historySection={PROTOTYPE_HISTORY_SECTION}
+                        historySection={HISTORY_SECTION}
                     />
                 )}
             </div>
@@ -262,4 +260,4 @@ const PrototypeConfigSection: React.FC = () => {
     )
 }
 
-export default PrototypeConfigSection
+export default ModelPrototypeConfigSection

--- a/frontend/src/components/organisms/PublicConfigSection.tsx
+++ b/frontend/src/components/organisms/PublicConfigSection.tsx
@@ -18,7 +18,7 @@ import useSelfProfileQuery from '@/hooks/useSelfProfile'
 import {
   PREDEFINED_SITE_CONFIGS,
   PREDEFINED_GENAI_CONFIG_KEYS,
-  PREDEFINED_PROTOTYPE_CONFIG_KEYS,
+  PREDEFINED_MODEL_PROTOTYPE_CONFIG_KEYS,
   PREDEFINED_PRIVACY_CONFIG_KEYS,
 } from '@/pages/SiteConfigManagement'
 import { pushSiteConfigEdit } from '@/utils/siteConfigHistory'
@@ -47,11 +47,11 @@ const PublicConfigSection: React.FC = () => {
 
   const isGenAIKey = (key: string) =>
     PREDEFINED_GENAI_CONFIG_KEYS.includes(key)
-  const isPrototypeKey = (key: string) =>
-    PREDEFINED_PROTOTYPE_CONFIG_KEYS.includes(key)
+  const isModelPrototypeKey = (key: string) =>
+    PREDEFINED_MODEL_PROTOTYPE_CONFIG_KEYS.includes(key)
   const isPrivacyKey = (key: string) =>
     PREDEFINED_PRIVACY_CONFIG_KEYS.includes(key)
-  const isSpecialSectionKey = (key: string) => isGenAIKey(key) || isPrototypeKey(key) || isPrivacyKey(key)
+  const isSpecialSectionKey = (key: string) => isGenAIKey(key) || isModelPrototypeKey(key) || isPrivacyKey(key)
 
   useEffect(() => {
     if (selfLoading || !self) return

--- a/frontend/src/pages/SiteConfigManagement.tsx
+++ b/frontend/src/pages/SiteConfigManagement.tsx
@@ -17,7 +17,7 @@ import SSOConfigSection from '@/components/organisms/SSOConfigSection'
 import EmailConfigSection from '@/components/organisms/EmailConfigSection'
 import StagingConfigSection from '@/components/organisms/StagingConfigSection'
 import GenAIConfigSection from '@/components/organisms/GenAIConfigSection'
-import PrototypeConfigSection from '../components/organisms/PrototypeConfigSection'
+import ModelPrototypeConfigSection from '../components/organisms/ModelPrototypeConfigSection'
 import PrivacyPolicySection from '../components/organisms/PrivacyPolicySection'
 
 // Keys that should be excluded from the site-config page
@@ -39,6 +39,7 @@ export const PREDEFINED_SITE_CONFIGS: any[] = [
     secret: false,
     valueType: 'image_url',
     description: 'Default image used when creating a new model.',
+    category: 'model_prototype',
   },
   {
     key: 'DEFAULT_PROTOTYPE_IMAGE',
@@ -47,6 +48,7 @@ export const PREDEFINED_SITE_CONFIGS: any[] = [
     secret: false,
     valueType: 'image_url',
     description: 'Default cover image used when creating a new prototype.',
+    category: 'model_prototype',
   },
   {
     key: 'SITE_TITLE',
@@ -107,7 +109,7 @@ export const PREDEFINED_SITE_CONFIGS: any[] = [
     secret: false,
     valueType: 'boolean',
     description: 'Show or hide the API panel on the Prototype Code tab.',
-    category: 'prototype',
+    category: 'model_prototype',
   },
   {
     key: 'SHOW_CODE_DIFF',
@@ -207,7 +209,7 @@ export const PREDEFINED_SITE_CONFIGS: any[] = [
     valueType: 'boolean',
     description:
       'Enable or disable the context menu on prototype items in the prototype list. When enabled, right-clicking on a prototype will show a menu context.',
-    category: 'prototype',
+    category: 'model_prototype',
   },
   {
     key: 'ALLOW_NON_ADMIN_ADDON_CONFIG',
@@ -217,7 +219,17 @@ export const PREDEFINED_SITE_CONFIGS: any[] = [
     valueType: 'boolean',
     description:
       'Allow non-admin model owners to add/manage addon tabs on model and prototype detail pages. Admin users can always configure addon tabs regardless of this setting.',
-    category: 'prototype',
+    category: 'model_prototype',
+  },
+  {
+    key: 'PUBLIC_MODEL_WRITE_ACCESS',
+    scope: 'site',
+    value: false,
+    secret: false,
+    valueType: 'boolean',
+    description:
+      'Allow authenticated users to create prototypes on public models they do not own. When disabled, public models are read-only for non-owners.',
+    category: 'model_prototype',
   },
   {
     key: 'GRADIENT_HEADER',
@@ -238,8 +250,8 @@ export const PREDEFINED_PRIVACY_CONFIG_KEYS: string[] = PREDEFINED_SITE_CONFIGS.
   (config) => config.category === 'privacy',
 ).map((config) => config.key)
 
-export const PREDEFINED_PROTOTYPE_CONFIG_KEYS: string[] = PREDEFINED_SITE_CONFIGS.filter(
-  (config) => config.category === 'prototype',
+export const PREDEFINED_MODEL_PROTOTYPE_CONFIG_KEYS: string[] = PREDEFINED_SITE_CONFIGS.filter(
+  (config) => config.category === 'model_prototype',
 ).map((config) => config.key)
 
 export const PREDEFINED_AUTH_CONFIGS: any[] = [
@@ -294,7 +306,7 @@ const SiteConfigManagement: React.FC = () => {
     | 'sso'
     | 'email'
     | 'staging'
-    | 'prototype'
+    | 'model_prototype'
     | 'genai'
     | 'privacy'
   const validSections: SectionTab[] = [
@@ -306,7 +318,7 @@ const SiteConfigManagement: React.FC = () => {
     'sso',
     'email',
     'staging',
-    'prototype',
+    'model_prototype',
     'genai',
     'privacy',
   ]
@@ -393,13 +405,13 @@ const SiteConfigManagement: React.FC = () => {
                   Auth Config
                 </button>
                 <button
-                  onClick={() => handleTabChange('prototype')}
-                  className={`w-full text-left px-4 py-3 rounded-md text-sm font-medium transition-colors ${activeTab === 'prototype'
+                  onClick={() => handleTabChange('model_prototype')}
+                  className={`w-full text-left px-4 py-3 rounded-md text-sm font-medium transition-colors ${activeTab === 'model_prototype'
                     ? 'bg-primary text-primary-foreground'
                     : 'text-foreground hover:bg-muted'
                     }`}
                 >
-                  Prototype Config
+                  Model & Prototype
                 </button>
                 <button
                   onClick={() => handleTabChange('genai')}
@@ -471,7 +483,7 @@ const SiteConfigManagement: React.FC = () => {
               {activeTab === 'style' && <SiteStyleSection />}
               {activeTab === 'email' && <EmailConfigSection />}
               {activeTab === 'secrets' && <SecretConfigSection />}
-              {activeTab === 'prototype' && <PrototypeConfigSection />}
+              {activeTab === 'model_prototype' && <ModelPrototypeConfigSection />}
               {activeTab === 'genai' && <GenAIConfigSection />}
               {activeTab === 'privacy' && <PrivacyPolicySection />}
             </div>

--- a/frontend/src/services/model.service.ts
+++ b/frontend/src/services/model.service.ts
@@ -13,9 +13,11 @@ import { VehicleAPI } from '@/types/api.type'
 
 export const listModelsLite = async (
   params?: Record<string, unknown>,
+  options?: { maxResults?: number },
 ): Promise<List<ModelLite>> => {
   let page = 1
   const limit = 10
+  const maxResults = options?.maxResults ?? Infinity
   let allResults: ModelLite[] = []
   let totalPages = 1
 
@@ -42,7 +44,11 @@ export const listModelsLite = async (
     allResults = [...allResults, ...response.data.results]
     totalPages = response.data.totalPages
     page++
-  } while (page <= totalPages)
+  } while (page <= totalPages && allResults.length < maxResults)
+
+  if (allResults.length > maxResults) {
+    allResults = allResults.slice(0, maxResults)
+  }
 
   return {
     results: allResults,

--- a/frontend/src/utils/siteConfig.ts
+++ b/frontend/src/utils/siteConfig.ts
@@ -23,6 +23,7 @@ const DEFAULT_SITE_CONFIGS: Record<string, any> = {
   SITE_FAVICON: '/imgs/favicon.ico',
   SITE_THEME_COLOR: '#198100',
   GRADIENT_HEADER: false,
+  PUBLIC_MODEL_WRITE_ACCESS: false,
   GENAI_SDV_APP_ENDPOINT:
     'https://workflow.digital.auto/webhook/c0ba14bc-c6a3-4319-ad0a-ad89b1460b36',
 }

--- a/frontend/src/utils/siteConfigHistory.ts
+++ b/frontend/src/utils/siteConfigHistory.ts
@@ -8,6 +8,12 @@
 const HISTORY_KEY_PREFIX = 'site-config-edit-history-'
 const MAX_HISTORY_PER_SECTION = 5
 
+// One-time migration map: old section key → new section key.
+// getSiteConfigEditHistory will merge and clean up old keys automatically.
+const SECTION_MIGRATIONS: Record<string, string> = {
+  prototype: 'model_prototype',
+}
+
 export interface SiteConfigEditEntry {
   key: string
   valueBefore?: unknown
@@ -22,13 +28,33 @@ function storageKey(section: string): string {
   return HISTORY_KEY_PREFIX + section
 }
 
-// Get the 5 most recent edit entries for a given section (tab).
+// Get the most recent edit entries for a given section (tab).
+// Automatically migrates entries from any renamed predecessor section.
 export function getSiteConfigEditHistory(section: string): SiteConfigEditEntry[] {
   try {
     const raw = localStorage.getItem(storageKey(section))
-    if (!raw) return []
-    const parsed = JSON.parse(raw) as SiteConfigEditEntry[]
-    return Array.isArray(parsed) ? parsed : []
+    let entries: SiteConfigEditEntry[] = []
+    if (raw) {
+      const parsed = JSON.parse(raw)
+      if (Array.isArray(parsed)) entries = parsed
+    }
+
+    const oldSection = Object.entries(SECTION_MIGRATIONS).find(([, v]) => v === section)?.[0]
+    if (oldSection) {
+      const oldRaw = localStorage.getItem(storageKey(oldSection))
+      if (oldRaw) {
+        const oldParsed = JSON.parse(oldRaw)
+        if (Array.isArray(oldParsed) && oldParsed.length > 0) {
+          entries = [...entries, ...oldParsed]
+            .sort((a, b) => b.timestamp - a.timestamp)
+            .slice(0, MAX_HISTORY_PER_SECTION)
+          localStorage.setItem(storageKey(section), JSON.stringify(entries))
+          localStorage.removeItem(storageKey(oldSection))
+        }
+      }
+    }
+
+    return entries
   } catch {
     return []
   }


### PR DESCRIPTION
This pull request introduces a new site-wide configuration option, `PUBLIC_MODEL_WRITE_ACCESS`, which allows authenticated users to create prototypes on public models they do not own. The backend and frontend have been updated to support this feature, including permission checks and UI changes. Additionally, the configuration category previously called `prototype` has been renamed to `model_prototype` throughout the codebase for clarity and consistency.

**New Feature: Public Model Write Access**
* Added the `PUBLIC_MODEL_WRITE_ACCESS` site config, allowing authenticated users to create prototypes on public models they do not own if enabled.
* Updated backend permission checks (`prototype.controller.js`) to allow prototype creation on public models based on this config. [[1]](diffhunk://#diff-e2c702881512cc2fdf15ec8d2894fec865fc44cb2398aca7f741f0ffa68d3fceR17-R38) [[2]](diffhunk://#diff-e2c702881512cc2fdf15ec8d2894fec865fc44cb2398aca7f741f0ffa68d3fceL32-R50)
* Updated frontend (`FormNewPrototype.tsx`) to show public models as prototype targets when the config is enabled. [[1]](diffhunk://#diff-4a347825b41aa8f4ba82299d171b8210c294da3bfcb0827152f0d793935961c4R72) [[2]](diffhunk://#diff-4a347825b41aa8f4ba82299d171b8210c294da3bfcb0827152f0d793935961c4R86-R102)

**Configuration Refactor: Category Renaming**
* Renamed the site config category from `prototype` to `model_prototype` in backend and frontend, including config definitions, queries, and UI labels. [[1]](diffhunk://#diff-396f40848ac65f740796e8d38688c6aa6d5d843e1fcf6952208d3a47a9d3329cL104-R106) [[2]](diffhunk://#diff-396f40848ac65f740796e8d38688c6aa6d5d843e1fcf6952208d3a47a9d3329cL198-R200) [[3]](diffhunk://#diff-396f40848ac65f740796e8d38688c6aa6d5d843e1fcf6952208d3a47a9d3329cL207-R218) [[4]](diffhunk://#diff-acd409a93cf83e2d01ff4d9904377efdd7cdcde50f82d0d6f958a9fea2993c8bL36-R38) [[5]](diffhunk://#diff-3523b4601a992fa2e543f9318e47dee0e1b294785d12badaa0caadd2f9b52016L31-R40) [[6]](diffhunk://#diff-3523b4601a992fa2e543f9318e47dee0e1b294785d12badaa0caadd2f9b52016L51-R67) [[7]](diffhunk://#diff-3523b4601a992fa2e543f9318e47dee0e1b294785d12badaa0caadd2f9b52016L79-R79) [[8]](diffhunk://#diff-3523b4601a992fa2e543f9318e47dee0e1b294785d12badaa0caadd2f9b52016L111-R136) [[9]](diffhunk://#diff-3523b4601a992fa2e543f9318e47dee0e1b294785d12badaa0caadd2f9b52016L161-R167) [[10]](diffhunk://#diff-3523b4601a992fa2e543f9318e47dee0e1b294785d12badaa0caadd2f9b52016L246-R244) [[11]](diffhunk://#diff-3523b4601a992fa2e543f9318e47dee0e1b294785d12badaa0caadd2f9b52016L257-R263)

**UI Updates**
* Updated the configuration management UI to reference "Model & Prototype" instead of just "Prototype", including section titles, descriptions, and reset dialogs. [[1]](diffhunk://#diff-3523b4601a992fa2e543f9318e47dee0e1b294785d12badaa0caadd2f9b52016L91-R91) [[2]](diffhunk://#diff-3523b4601a992fa2e543f9318e47dee0e1b294785d12badaa0caadd2f9b52016L102-R102) [[3]](diffhunk://#diff-3523b4601a992fa2e543f9318e47dee0e1b294785d12badaa0caadd2f9b52016L148-R146) [[4]](diffhunk://#diff-3523b4601a992fa2e543f9318e47dee0e1b294785d12badaa0caadd2f9b52016L196-R197) [[5]](diffhunk://#diff-3523b4601a992fa2e543f9318e47dee0e1b294785d12badaa0caadd2f9b52016L184-R182)
* Renamed `PrototypeConfigSection` to `ModelPrototypeConfigSection` for clarity. [[1]](diffhunk://#diff-3523b4601a992fa2e543f9318e47dee0e1b294785d12badaa0caadd2f9b52016L31-R40) [[2]](diffhunk://#diff-3523b4601a992fa2e543f9318e47dee0e1b294785d12badaa0caadd2f9b52016L257-R263)

**Public Config Section Updates**
* Updated references to prototype config keys to use the new `PREDEFINED_MODEL_PROTOTYPE_CONFIG_KEYS` constant. [[1]](diffhunk://#diff-dbfa7fee18be1a1619853ccad7a3ed470f64f1850f7e271c3ef49788f1fc4fcaL21-R21) [[2]](diffhunk://#diff-dbfa7fee18be1a1619853ccad7a3ed470f64f1850f7e271c3ef49788f1fc4fcaL50-R54)

These changes improve flexibility for public model collaboration and clarify configuration management around models and prototypes.