### PR TITLE
Enable prototype renaming via button

### DIFF
--- a/frontend/src/components/molecules/DaPrototypeItem.tsx
+++ b/frontend/src/components/molecules/DaPrototypeItem.tsx
@@ -243,9 +243,28 @@ const DaPrototypeItem = ({ prototype, className }: DaPrototypeItemProps) => {
           </div>
         </div>
         <div className="flex items-center w-full space-y-0">
-          <p className="text-base font-semibold line-clamp-1 text-foreground prototype-grid-item-name">
-            {prototype?.name ?? ''}
-          </p>
+          {user ? (
+            <button
+              type="button"
+              className="flex items-center gap-1 min-w-0 text-left cursor-pointer group/rename"
+              onClick={(e) => {
+                e.stopPropagation()
+                e.preventDefault()
+                setNewName(prototype?.name ?? '')
+                setRenameOpen(true)
+              }}
+              aria-label="Rename prototype"
+            >
+              <span className="text-base font-semibold line-clamp-1 text-foreground prototype-grid-item-name">
+                {prototype?.name ?? ''}
+              </span>
+              <TbEdit className="size-4 shrink-0 opacity-0 group-hover:opacity-100 group-hover/rename:opacity-100 pointer-coarse:opacity-100 transition-opacity text-muted-foreground" />
+            </button>
+          ) : (
+            <p className="text-base font-semibold line-clamp-1 text-foreground prototype-grid-item-name">
+              {prototype?.name ?? ''}
+            </p>
+          )}
           <div className="grow"></div>
           {Number(prototype?.executed_turns ?? 0) > 1 && (
             <DaTooltip
@@ -271,7 +290,7 @@ const DaPrototypeItem = ({ prototype, className }: DaPrototypeItemProps) => {
 
   const isAnyDialogOpen = renameOpen || deleteOpen || deployOpen
 
-  if (!enableContextMenu || !user) {
+  if (!user) {
     return cardContent
   }
 
@@ -283,71 +302,75 @@ const DaPrototypeItem = ({ prototype, className }: DaPrototypeItemProps) => {
         }
       }}
     >
-      <ContextMenu>
-        <ContextMenuTrigger asChild>{cardContent}</ContextMenuTrigger>
+      {enableContextMenu ? (
+        <ContextMenu>
+          <ContextMenuTrigger asChild>{cardContent}</ContextMenuTrigger>
 
-        <ContextMenuContent
-          className="w-52"
-          onClick={(e) => e.stopPropagation()}
-          onPointerDown={(e) => e.stopPropagation()}
-        >
-          <ContextMenuItem
-            className="cursor-pointer"
-            onSelect={() => {
-              runAfterMenuClose(() => {
-                setNewName(prototype?.name ?? '')
-                setRenameOpen(true)
-              })
-            }}
+          <ContextMenuContent
+            className="w-52"
+            onClick={(e) => e.stopPropagation()}
+            onPointerDown={(e) => e.stopPropagation()}
           >
-            <TbEdit className="mr-2 size-4" />
-            Rename
-          </ContextMenuItem>
-          <ContextMenuItem
-            className="cursor-pointer p-0!"
-            onSelect={(e) => e.preventDefault()}
-          >
-            <DaImportFile
-              onFileChange={handleImageFileChange}
-              accept=".png,.jpg,.jpeg,.gif,.webp"
-              className="flex w-full items-center px-2 py-1.5 text-sm cursor-pointer"
+            <ContextMenuItem
+              className="cursor-pointer"
+              onSelect={() => {
+                runAfterMenuClose(() => {
+                  setNewName(prototype?.name ?? '')
+                  setRenameOpen(true)
+                })
+              }}
             >
-              <TbPhotoEdit className="mr-2 size-4" />
-              Update Image
-            </DaImportFile>
-          </ContextMenuItem>
-          <ContextMenuSeparator />
-          <ContextMenuItem
-            className="cursor-pointer"
-            onSelect={() => runAfterMenuClose(() => setDeployOpen(true))}
-          >
-            <TbCloudDown className="mr-2 size-4" />
-            Deploy
-          </ContextMenuItem>
-          <ContextMenuItem
-            className="cursor-pointer"
-            onSelect={() =>
-              runAfterMenuClose(() => {
-                if (prototype) {
-                  downloadPrototypeZip(prototype)
-                }
-              })
-            }
-          >
-            <TbDownload className="mr-2 size-4" />
-            Export Prototype
-          </ContextMenuItem>
-          <ContextMenuItem
-            className="cursor-pointer text-red-600 focus:text-red-600 focus:bg-red-50"
-            onSelect={() => runAfterMenuClose(() => setDeleteOpen(true))}
-          >
-            <TbTrashX className="mr-2 size-4" />
-            Delete Prototype
-          </ContextMenuItem>
-        </ContextMenuContent>
-      </ContextMenu>
+              <TbEdit className="mr-2 size-4" />
+              Rename
+            </ContextMenuItem>
+            <ContextMenuItem
+              className="cursor-pointer p-0!"
+              onSelect={(e) => e.preventDefault()}
+            >
+              <DaImportFile
+                onFileChange={handleImageFileChange}
+                accept=".png,.jpg,.jpeg,.gif,.webp"
+                className="flex w-full items-center px-2 py-1.5 text-sm cursor-pointer"
+              >
+                <TbPhotoEdit className="mr-2 size-4" />
+                Update Image
+              </DaImportFile>
+            </ContextMenuItem>
+            <ContextMenuSeparator />
+            <ContextMenuItem
+              className="cursor-pointer"
+              onSelect={() => runAfterMenuClose(() => setDeployOpen(true))}
+            >
+              <TbCloudDown className="mr-2 size-4" />
+              Deploy
+            </ContextMenuItem>
+            <ContextMenuItem
+              className="cursor-pointer"
+              onSelect={() =>
+                runAfterMenuClose(() => {
+                  if (prototype) {
+                    downloadPrototypeZip(prototype)
+                  }
+                })
+              }
+            >
+              <TbDownload className="mr-2 size-4" />
+              Export Prototype
+            </ContextMenuItem>
+            <ContextMenuItem
+              className="cursor-pointer text-red-600 focus:text-red-600 focus:bg-red-50"
+              onSelect={() => runAfterMenuClose(() => setDeleteOpen(true))}
+            >
+              <TbTrashX className="mr-2 size-4" />
+              Delete Prototype
+            </ContextMenuItem>
+          </ContextMenuContent>
+        </ContextMenu>
+      ) : (
+        cardContent
+      )}
 
-      {/* Rename dialog */}
+      {/* Rename dialog — available via both pencil icon and context menu */}
       <DaDialog
         open={renameOpen}
         onOpenChange={withClickSuppression(setRenameOpen)}
@@ -391,28 +414,32 @@ const DaPrototypeItem = ({ prototype, className }: DaPrototypeItemProps) => {
         </div>
       </DaDialog>
 
-      {/* Deploy / Staging dialog */}
-      <DaDialog
-        open={deployOpen}
-        onOpenChange={withClickSuppression(setDeployOpen)}
-        dialogTitle={`Deploy - ${prototype?.name ?? 'Prototype'}`}
-        className="max-w-[95vw] w-[1200px]"
-      >
-        <div className="flex overflow-y-auto max-h-[80vh]">
-          {prototype && <PrototypeTabStaging prototype={prototype} />}
-        </div>
-      </DaDialog>
+      {enableContextMenu && (
+        <>
+          {/* Deploy / Staging dialog */}
+          <DaDialog
+            open={deployOpen}
+            onOpenChange={withClickSuppression(setDeployOpen)}
+            dialogTitle={`Deploy - ${prototype?.name ?? 'Prototype'}`}
+            className="max-w-[95vw] w-[1200px]"
+          >
+            <div className="flex overflow-y-auto max-h-[80vh]">
+              {prototype && <PrototypeTabStaging prototype={prototype} />}
+            </div>
+          </DaDialog>
 
-      {/* Delete confirm dialog */}
-      <DaConfirmPopup
-        onConfirm={handleDelete}
-        title="Delete Prototype"
-        label="This action cannot be undone and will delete all prototype data. Please proceed with caution."
-        confirmText={prototype?.name}
-        state={[deleteOpen, withClickSuppression(setDeleteOpen)]}
-      >
-        <span />
-      </DaConfirmPopup>
+          {/* Delete confirm dialog */}
+          <DaConfirmPopup
+            onConfirm={handleDelete}
+            title="Delete Prototype"
+            label="This action cannot be undone and will delete all prototype data. Please proceed with caution."
+            confirmText={prototype?.name}
+            state={[deleteOpen, withClickSuppression(setDeleteOpen)]}
+          >
+            <span />
+          </DaConfirmPopup>
+        </>
+      )}
     </div>
   )
 }


### PR DESCRIPTION
This pull request updates the `DaPrototypeItem` component to improve usability and clarify access to prototype actions. The changes ensure that only logged-in users see interactive features like renaming, and context menu options are gated behind a feature flag. The most important changes are:

**User access and UI controls:**

* The prototype name is now rendered as a button with an edit (pencil) icon for logged-in users, allowing them to open the rename dialog directly by clicking the name. For non-logged-in users, the name remains plain text.
* The context menu and its associated dialogs (deploy/staging and delete) are only available to logged-in users, and are further gated by the `enableContextMenu` flag. [[1]](diffhunk://#diff-8b9feb56fe8809f88cf179e9057883fed171f585014f05087f9bd786f14c968dL274-R293) [[2]](diffhunk://#diff-8b9feb56fe8809f88cf179e9057883fed171f585014f05087f9bd786f14c968dR305) [[3]](diffhunk://#diff-8b9feb56fe8809f88cf179e9057883fed171f585014f05087f9bd786f14c968dR417-R418) [[4]](diffhunk://#diff-8b9feb56fe8809f88cf179e9057883fed171f585014f05087f9bd786f14c968dR441-R442)

**Dialog and interaction improvements:**

* The rename dialog can now be triggered both from the context menu and the new pencil icon button, making it more accessible.

These changes clarify which actions are available to which users and streamline prototype management interactions.