### PR TITLE
Add gradient header support to DaDashboard component

### DIFF
--- a/frontend/src/components/molecules/dashboard/DaDashboard.tsx
+++ b/frontend/src/components/molecules/dashboard/DaDashboard.tsx
@@ -53,6 +53,7 @@ import { useSiteConfig } from '@/utils/siteConfig'
 const DaDashboard = () => {
   const { data: model } = useCurrentModel()
   const logoUrl = useSiteConfig('SITE_LOGO_WIDE', '/imgs/logo-wide.png')
+  const gradientHeader = useSiteConfig('GRADIENT_HEADER', false)
   const [
     prototype,
     setActivePrototype,
@@ -312,13 +313,29 @@ const DaDashboard = () => {
     <div className="w-full h-full relative border bg-white">
       <div
         className={cn(
-          'absolute z-10 left-0 px-2 top-0 flex gap-1 w-full py-1 shadow-xl bg-white items-center',
+          'absolute z-10 left-0 px-2 top-0 flex gap-1 w-full py-1 shadow-xl items-center',
           showPrototypeDashboardFullScreen && 'h-[56px]',
+          showPrototypeDashboardFullScreen && gradientHeader ? '' : 'bg-white',
         )}
+        style={
+          showPrototypeDashboardFullScreen && gradientHeader
+            ? {
+                background: 'linear-gradient(90deg, var(--primary) 0%, var(--secondary) 100%)',
+                color: 'var(--primary-foreground)',
+              }
+            : undefined
+        }
       >
         {showPrototypeDashboardFullScreen && (
           <Link to="/" className="w-fit h-[56px] flex items-center px-2">
-            <DaImage src={logoUrl} className="object-contain" style={{ height: '28px' }} />
+            <DaImage
+              src={logoUrl}
+              className="object-contain"
+              style={{
+                height: '28px',
+                filter: gradientHeader ? 'brightness(0) invert(1)' : undefined,
+              }}
+            />
           </Link>
         )}
         {isAuthorized && (


### PR DESCRIPTION
This pull request updates the `DaDashboard` component to add support for an optional gradient header in fullscreen mode, based on a new site configuration setting. The most important changes are:

**UI Theming Enhancements:**

* Added support for a `GRADIENT_HEADER` site config option, enabling a gradient background and adjusted text color for the dashboard header in fullscreen mode. [[1]](diffhunk://#diff-ba057e561595cb29932fc1af30b1335b6bf78f8936d3d432561df529316ab0e7R56) [[2]](diffhunk://#diff-ba057e561595cb29932fc1af30b1335b6bf78f8936d3d432561df529316ab0e7L315-R338)
* Updated the logo (`DaImage`) to invert its colors when the gradient header is active, ensuring visibility against the new background.

**Configuration Management:**

* Utilized the `useSiteConfig` hook to retrieve the new `GRADIENT_HEADER` setting, defaulting to `false` if not set.