### PR TITLE
Fix/resizer style

### DIFF
--- a/frontend/src/components/organisms/PrototypeSidebar.tsx
+++ b/frontend/src/components/organisms/PrototypeSidebar.tsx
@@ -8,6 +8,7 @@
 
 import { FC, useState, useRef, useCallback, useEffect } from 'react'
 import PagePrototypePlugin from '@/pages/PagePrototypePlugin'
+import { useSystemUI } from '@/hooks/useSystemUI'
 
 interface PrototypeSidebarProps {
   pluginSlug: string
@@ -24,6 +25,7 @@ const PrototypeSidebar: FC<PrototypeSidebarProps> = ({
   minWidthPx = 200,
   onSetActiveTab,
 }) => {
+  const { showPrototypeDashboardFullScreen } = useSystemUI()
   const [width, setWidth] = useState<number | null>(null)
   const [isDragging, setIsDragging] = useState(false)
   const sidebarRef = useRef<HTMLDivElement>(null)
@@ -112,7 +114,7 @@ const PrototypeSidebar: FC<PrototypeSidebarProps> = ({
       </div>
 
       {/* Resize divider + pill-shaped drag thumb */}
-      {!isCollapsed && (
+      {!isCollapsed && !showPrototypeDashboardFullScreen && (
         <div className="relative flex items-center justify-center w-[3px] bg-border shrink-0">
           {/* Invisible wide touch target covering the full height */}
           <div

--- a/frontend/src/components/organisms/PrototypeSidebar.tsx
+++ b/frontend/src/components/organisms/PrototypeSidebar.tsx
@@ -115,7 +115,7 @@ const PrototypeSidebar: FC<PrototypeSidebarProps> = ({
 
       {/* Resize divider + pill-shaped drag thumb */}
       {!isCollapsed && !showPrototypeDashboardFullScreen && (
-        <div className="relative flex items-center justify-center w-[3px] bg-border shrink-0">
+        <div className="group/resizer relative flex items-center justify-center w-[3px] bg-border shrink-0 transition-colors hover:bg-primary">
           {/* Invisible wide touch target covering the full height */}
           <div
             className="absolute inset-y-0 -left-2 -right-2 z-10 cursor-col-resize touch-none"
@@ -124,12 +124,12 @@ const PrototypeSidebar: FC<PrototypeSidebarProps> = ({
           />
           {/* Visible pill thumb — large enough for touch (24x56px) */}
           <div
-            className="absolute z-20 flex flex-col items-center justify-center gap-1 w-6 h-14 rounded-full border border-border bg-background shadow-md cursor-col-resize touch-none hover:bg-accent active:bg-accent"
+            className="absolute z-20 flex flex-col items-center justify-center gap-1 w-6 h-14 rounded-full border border-border bg-background shadow-md cursor-col-resize touch-none transition-colors group-hover/resizer:border-primary group-hover/resizer:bg-background"
             onMouseDown={handleMouseDown}
             onTouchStart={handleTouchStart}
           >
-            <span className="block w-[2px] h-3 rounded-full bg-muted-foreground/50" />
-            <span className="block w-[2px] h-3 rounded-full bg-muted-foreground/50" />
+            <span className="block w-[2px] h-3 rounded-full bg-muted-foreground/50 transition-colors group-hover/resizer:bg-primary" />
+            <span className="block w-[2px] h-3 rounded-full bg-muted-foreground/50 transition-colors group-hover/resizer:bg-primary" />
           </div>
         </div>
       )}


### PR DESCRIPTION
This pull request updates the `PrototypeSidebar` component to improve its behavior and appearance, especially in relation to the application's full-screen mode. The main changes ensure that the sidebar's resizer is hidden when the prototype dashboard is in full-screen, and enhance the resizer's visual feedback on hover.

**Sidebar behavior and UI improvements:**

* The sidebar resizer is now hidden when `showPrototypeDashboardFullScreen` is active, preventing resizing in full-screen mode.
* The resizer's drag thumb and border now have improved hover and active state styling, providing better visual feedback to users.

**Integration with system UI state:**

* The `useSystemUI` hook is now imported and used to access the `showPrototypeDashboardFullScreen` state, integrating the sidebar with global UI state. [[1]](diffhunk://#diff-7fc51c71f2e0827e616fa7c2d81932a3c05287fd47b97ae79e2afc3e87fa5ab5R11) [[2]](diffhunk://#diff-7fc51c71f2e0827e616fa7c2d81932a3c05287fd47b97ae79e2afc3e87fa5ab5R28)