### PR TITLE
Enhance prototype owner control with context menu permissions

### DIFF
--- a/frontend/src/components/molecules/DaPrototypeItem.tsx
+++ b/frontend/src/components/molecules/DaPrototypeItem.tsx
@@ -51,7 +51,7 @@ import { Input } from '../atoms/input'
 import useCurrentModel from '@/hooks/useCurrentModel'
 import useListModelPrototypes from '@/hooks/useListModelPrototypes'
 import PrototypeTabStaging from '@/components/organisms/PrototypeTabStaging'
-import { toast } from 'react-toastify'
+import { useToast } from '@/components/molecules/toaster/use-toast'
 
 interface DaPrototypeItemProps {
   prototype?: Prototype
@@ -65,6 +65,7 @@ const DaPrototypeItem = ({ prototype, className }: DaPrototypeItemProps) => {
   const { data: existingPrototypes, refetch: refetchModelPrototypes } =
     useListModelPrototypes(model?.id || '')
   const navigate = useNavigate()
+  const { toast } = useToast()
 
   const isOwner =
     !!user &&
@@ -376,9 +377,11 @@ const DaPrototypeItem = ({ prototype, className }: DaPrototypeItemProps) => {
         <div
           onContextMenu={(e) => {
             e.preventDefault()
-            toast.info(
-              `You do not have permission to edit "${prototype?.name ?? 'this prototype'}".`,
-            )
+            toast({
+              title: 'Permission denied',
+              description: `You do not have permission to edit "${prototype?.name ?? 'this prototype'}".`,
+              duration: 3000,
+            })
           }}
         >
           {cardContent}

--- a/frontend/src/components/molecules/DaPrototypeItem.tsx
+++ b/frontend/src/components/molecules/DaPrototypeItem.tsx
@@ -51,6 +51,7 @@ import { Input } from '../atoms/input'
 import useCurrentModel from '@/hooks/useCurrentModel'
 import useListModelPrototypes from '@/hooks/useListModelPrototypes'
 import PrototypeTabStaging from '@/components/organisms/PrototypeTabStaging'
+import { toast } from 'react-toastify'
 
 interface DaPrototypeItemProps {
   prototype?: Prototype
@@ -64,6 +65,11 @@ const DaPrototypeItem = ({ prototype, className }: DaPrototypeItemProps) => {
   const { data: existingPrototypes, refetch: refetchModelPrototypes } =
     useListModelPrototypes(model?.id || '')
   const navigate = useNavigate()
+
+  const isOwner =
+    !!user &&
+    (user.id === prototype?.created_by?.id ||
+      user.id === model?.created_by?.id)
 
   // Rename state
   const [renameOpen, setRenameOpen] = useState(false)
@@ -213,7 +219,7 @@ const DaPrototypeItem = ({ prototype, className }: DaPrototypeItemProps) => {
                 </div>
               )}
               <div className="grow"></div>
-              {user && !enableContextMenu && (
+              {user && !isOwner && (
                 <div className="flex w-fit justify-end items-center gap-2 ml-2">
                   <DaTooltip tooltipMessage="View Code" tooltipDelay={300}>
                     <Link
@@ -243,7 +249,7 @@ const DaPrototypeItem = ({ prototype, className }: DaPrototypeItemProps) => {
           </div>
         </div>
         <div className="flex items-center w-full space-y-0">
-          {user ? (
+          {isOwner ? (
             <button
               type="button"
               className="flex items-center gap-1 min-w-0 text-left cursor-pointer group/rename"
@@ -302,7 +308,7 @@ const DaPrototypeItem = ({ prototype, className }: DaPrototypeItemProps) => {
         }
       }}
     >
-      {enableContextMenu ? (
+      {enableContextMenu && isOwner ? (
         <ContextMenu>
           <ContextMenuTrigger asChild>{cardContent}</ContextMenuTrigger>
 
@@ -366,6 +372,17 @@ const DaPrototypeItem = ({ prototype, className }: DaPrototypeItemProps) => {
             </ContextMenuItem>
           </ContextMenuContent>
         </ContextMenu>
+      ) : enableContextMenu ? (
+        <div
+          onContextMenu={(e) => {
+            e.preventDefault()
+            toast.info(
+              `You do not have permission to edit "${prototype?.name ?? 'this prototype'}".`,
+            )
+          }}
+        >
+          {cardContent}
+        </div>
       ) : (
         cardContent
       )}
@@ -414,7 +431,7 @@ const DaPrototypeItem = ({ prototype, className }: DaPrototypeItemProps) => {
         </div>
       </DaDialog>
 
-      {enableContextMenu && (
+      {enableContextMenu && isOwner && (
         <>
           {/* Deploy / Staging dialog */}
           <DaDialog


### PR DESCRIPTION
This pull request updates the `DaPrototypeItem` component to enforce ownership-based permissions for editing and context menu actions. Only the owner of a prototype or the associated model can access editing features and the context menu. Non-owners attempting to use the context menu will now receive a notification instead of being able to interact with edit options.

**Permission Enforcement and User Feedback:**

* Added an `isOwner` check to determine if the current user is the owner of the prototype or its parent model, and updated all relevant UI logic to use this check.
* Restricted edit buttons and context menu access to owners only; non-owners will see a notification via `react-toastify` if they attempt to use the context menu. [[1]](diffhunk://#diff-8b9feb56fe8809f88cf179e9057883fed171f585014f05087f9bd786f14c968dL246-R252) [[2]](diffhunk://#diff-8b9feb56fe8809f88cf179e9057883fed171f585014f05087f9bd786f14c968dL305-R311) [[3]](diffhunk://#diff-8b9feb56fe8809f88cf179e9057883fed171f585014f05087f9bd786f14c968dR375-R385) [[4]](diffhunk://#diff-8b9feb56fe8809f88cf179e9057883fed171f585014f05087f9bd786f14c968dL417-R434)
* Updated the UI to hide edit-related controls from non-owners, ensuring a clearer and more secure user experience.

**Dependency Update:**

* Imported the `toast` function from `react-toastify` to provide user notifications for permission errors.