### PR TITLE
Fix: prototype sidebar resize gesture lost when cursor passes over plugin/iframe

### DIFF
--- a/frontend/src/components/organisms/PrototypeSidebar.tsx
+++ b/frontend/src/components/organisms/PrototypeSidebar.tsx
@@ -115,7 +115,7 @@ const PrototypeSidebar: FC<PrototypeSidebarProps> = ({
 
       {/* Resize divider + pill-shaped drag thumb */}
       {!isCollapsed && !showPrototypeDashboardFullScreen && (
-        <div className="group/resizer relative flex items-center justify-center w-[3px] bg-border shrink-0 transition-colors hover:bg-primary">
+        <div className="group/resizer relative z-10 flex items-center justify-center w-[3px] bg-border shrink-0 transition-colors hover:bg-primary">
           {/* Invisible wide touch target covering the full height */}
           <div
             className="absolute inset-y-0 -left-2 -right-2 z-10 cursor-col-resize touch-none"
@@ -132,6 +132,10 @@ const PrototypeSidebar: FC<PrototypeSidebarProps> = ({
             <span className="block w-[2px] h-3 rounded-full bg-muted-foreground/50 transition-colors group-hover/resizer:bg-primary" />
           </div>
         </div>
+      )}
+
+      {isDragging && (
+        <div className="fixed inset-0 z-[9999] cursor-col-resize" />
       )}
     </div>
   )


### PR DESCRIPTION
This pull request makes minor improvements to the `PrototypeSidebar` component, focusing on the sidebar's drag-and-resize functionality and user experience.

Enhancements to sidebar drag-and-resize UX:

* Added a high `z-index` (`z-10`) to the sidebar resizer to ensure it appears above other elements and improves interaction reliability.
* When the sidebar is being dragged (`isDragging` is true), a full-screen, high `z-index` overlay with a column-resize cursor is rendered to provide clear visual feedback and capture mouse events during the drag operation.