### PR TITLE
Refactor: update category from 'prototype' to 'model_prototype'

### DIFF
--- a/backend/src/config/predefinedSiteConfigs.js
+++ b/backend/src/config/predefinedSiteConfigs.js
@@ -28,6 +28,7 @@ const PREDEFINED_SITE_CONFIGS = [
     secret: false,
     valueType: 'image_url',
     description: 'Default image used when creating a new model.',
+    category: 'model_prototype',
   },
   {
     key: 'DEFAULT_PROTOTYPE_IMAGE',
@@ -36,6 +37,7 @@ const PREDEFINED_SITE_CONFIGS = [
     secret: false,
     valueType: 'image_url',
     description: 'Default cover image used when creating a new prototype.',
+    category: 'model_prototype',
   },
   {
     key: 'SITE_TITLE',
@@ -101,7 +103,7 @@ const PREDEFINED_SITE_CONFIGS = [
     secret: false,
     valueType: 'boolean',
     description: 'Show or hide the API panel on the Prototype Code tab.',
-    category: 'prototype',
+    category: 'model_prototype',
   },
   {
     key: 'SHOW_CODE_DIFF',
@@ -195,7 +197,7 @@ const PREDEFINED_SITE_CONFIGS = [
     secret: false,
     valueType: 'boolean',
     description: 'Enable or disable the context menu on prototype items.',
-    category: 'prototype',
+    category: 'model_prototype',
   },
   {
     key: 'ALLOW_NON_ADMIN_ADDON_CONFIG',
@@ -204,7 +206,7 @@ const PREDEFINED_SITE_CONFIGS = [
     secret: false,
     valueType: 'boolean',
     description: 'Allow non-admin model owners to add/manage addon tabs.',
-    category: 'prototype',
+    category: 'model_prototype',
   },
   {
     key: 'GRADIENT_HEADER',

--- a/frontend/src/components/molecules/ConfigList.tsx
+++ b/frontend/src/components/molecules/ConfigList.tsx
@@ -33,7 +33,7 @@ export type SiteConfigHistorySection =
   | 'style'
   | 'secrets'
   | 'staging'
-  | 'prototype'
+  | 'model_prototype'
   | 'genai'
 
 interface ConfigListProps {

--- a/frontend/src/components/organisms/PrototypeConfigSection.tsx
+++ b/frontend/src/components/organisms/PrototypeConfigSection.tsx
@@ -29,7 +29,7 @@ import {
 } from '@/utils/siteConfigAdmin'
 
 type PrototypeSubTab = 'config' | 'history'
-const PROTOTYPE_HISTORY_SECTION = 'prototype' as SiteConfigHistorySection
+const PROTOTYPE_HISTORY_SECTION = 'model_prototype' as SiteConfigHistorySection
 
 const PrototypeConfigSection: React.FC = () => {
     const { data: self, isLoading: selfLoading } = useSelfProfileQuery()
@@ -49,14 +49,14 @@ const PrototypeConfigSection: React.FC = () => {
             setIsLoading(true)
 
             const predefinedPrototypeConfigs = PREDEFINED_SITE_CONFIGS.filter(
-                (config) => config.category === 'prototype',
+                (config) => config.category === 'model_prototype',
             )
 
             // Get existing Prototype configs from DB
             const res = await configManagementService.getConfigs({
                 secret: false,
                 scope: 'site',
-                category: 'prototype',
+                category: 'model_prototype',
                 limit: 100,
             })
 
@@ -76,7 +76,7 @@ const PrototypeConfigSection: React.FC = () => {
                 const updatedRes = await configManagementService.getConfigs({
                     secret: false,
                     scope: 'site',
-                    category: 'prototype',
+                    category: 'model_prototype',
                     limit: 100,
                 })
 
@@ -88,7 +88,7 @@ const PrototypeConfigSection: React.FC = () => {
             toast({
                 title: 'Load failed',
                 description:
-                    err instanceof Error ? err.message : 'Failed to load Prototype configs',
+                    err instanceof Error ? err.message : 'Failed to load Model & Prototype configs',
                 variant: 'destructive',
             })
         } finally {
@@ -99,7 +99,7 @@ const PrototypeConfigSection: React.FC = () => {
     const handleFactoryReset = async () => {
         if (
             !window.confirm(
-                'Restore all Prototype configs to default values? This will reset Prototype settings to their defaults.',
+                'Restore all Model & Prototype configs to default values? This will reset Model & Prototype settings to their defaults.',
             )
         ) {
             return
@@ -109,14 +109,14 @@ const PrototypeConfigSection: React.FC = () => {
             setIsLoading(true)
 
             const predefinedPrototypeConfigs = PREDEFINED_SITE_CONFIGS.filter(
-                (config) => config.category === 'prototype',
+                (config) => config.category === 'model_prototype',
             )
 
             // Delete all Prototype configs
             const allConfigs = await configManagementService.getConfigs({
                 secret: false,
                 scope: 'site',
-                category: 'prototype',
+                category: 'model_prototype',
                 limit: 100,
             })
 
@@ -135,7 +135,7 @@ const PrototypeConfigSection: React.FC = () => {
             toast({
                 title: 'Restored',
                 description:
-                    'Prototype configs restored to default values. Reloading page...',
+                    'Model & Prototype configs restored to default values. Reloading page...',
             })
 
             reloadSoon()
@@ -145,7 +145,7 @@ const PrototypeConfigSection: React.FC = () => {
                 description:
                     err instanceof Error
                         ? err.message
-                        : 'Failed to reset Prototype configs',
+                        : 'Failed to reset Model & Prototype configs',
                 variant: 'destructive',
             })
             setIsLoading(false)
@@ -158,7 +158,7 @@ const PrototypeConfigSection: React.FC = () => {
             const { valueBefore, targetValue } = await upsertConfigFromHistory({
                 entry,
                 scope: 'site',
-                category: 'prototype',
+                category: 'model_prototype',
             })
 
             pushSiteConfigEdit({
@@ -166,7 +166,7 @@ const PrototypeConfigSection: React.FC = () => {
                 valueBefore,
                 valueAfter: targetValue,
                 valueType: entry.valueType,
-                section: 'prototype',
+                section: 'model_prototype',
             })
 
             toast({
@@ -181,7 +181,7 @@ const PrototypeConfigSection: React.FC = () => {
                 description:
                     err instanceof Error
                         ? err.message
-                        : 'Failed to restore Prototype configuration',
+                        : 'Failed to restore Model & Prototype configuration',
                 variant: 'destructive',
             })
             setIsLoading(false)
@@ -193,10 +193,10 @@ const PrototypeConfigSection: React.FC = () => {
             <div className="px-6 py-4 border-b border-border flex items-center justify-between">
                 <div className="flex flex-col">
                     <h2 className="text-lg font-semibold text-foreground">
-                        Prototype Configuration
+                        Model & Prototype Configuration
                     </h2>
                     <p className="text-sm text-muted-foreground mt-1">
-                        Configure Prototype-specific behavior and feature visibility
+                        Configure Model & Prototype behavior and feature visibility
                     </p>
                 </div>
                 <Button

--- a/frontend/src/pages/SiteConfigManagement.tsx
+++ b/frontend/src/pages/SiteConfigManagement.tsx
@@ -39,6 +39,7 @@ export const PREDEFINED_SITE_CONFIGS: any[] = [
     secret: false,
     valueType: 'image_url',
     description: 'Default image used when creating a new model.',
+    category: 'model_prototype',
   },
   {
     key: 'DEFAULT_PROTOTYPE_IMAGE',
@@ -47,6 +48,7 @@ export const PREDEFINED_SITE_CONFIGS: any[] = [
     secret: false,
     valueType: 'image_url',
     description: 'Default cover image used when creating a new prototype.',
+    category: 'model_prototype',
   },
   {
     key: 'SITE_TITLE',
@@ -107,7 +109,7 @@ export const PREDEFINED_SITE_CONFIGS: any[] = [
     secret: false,
     valueType: 'boolean',
     description: 'Show or hide the API panel on the Prototype Code tab.',
-    category: 'prototype',
+    category: 'model_prototype',
   },
   {
     key: 'SHOW_CODE_DIFF',
@@ -207,7 +209,7 @@ export const PREDEFINED_SITE_CONFIGS: any[] = [
     valueType: 'boolean',
     description:
       'Enable or disable the context menu on prototype items in the prototype list. When enabled, right-clicking on a prototype will show a menu context.',
-    category: 'prototype',
+    category: 'model_prototype',
   },
   {
     key: 'ALLOW_NON_ADMIN_ADDON_CONFIG',
@@ -217,7 +219,7 @@ export const PREDEFINED_SITE_CONFIGS: any[] = [
     valueType: 'boolean',
     description:
       'Allow non-admin model owners to add/manage addon tabs on model and prototype detail pages. Admin users can always configure addon tabs regardless of this setting.',
-    category: 'prototype',
+    category: 'model_prototype',
   },
   {
     key: 'GRADIENT_HEADER',
@@ -239,7 +241,7 @@ export const PREDEFINED_PRIVACY_CONFIG_KEYS: string[] = PREDEFINED_SITE_CONFIGS.
 ).map((config) => config.key)
 
 export const PREDEFINED_PROTOTYPE_CONFIG_KEYS: string[] = PREDEFINED_SITE_CONFIGS.filter(
-  (config) => config.category === 'prototype',
+  (config) => config.category === 'model_prototype',
 ).map((config) => config.key)
 
 export const PREDEFINED_AUTH_CONFIGS: any[] = [
@@ -294,7 +296,7 @@ const SiteConfigManagement: React.FC = () => {
     | 'sso'
     | 'email'
     | 'staging'
-    | 'prototype'
+    | 'model_prototype'
     | 'genai'
     | 'privacy'
   const validSections: SectionTab[] = [
@@ -306,7 +308,7 @@ const SiteConfigManagement: React.FC = () => {
     'sso',
     'email',
     'staging',
-    'prototype',
+    'model_prototype',
     'genai',
     'privacy',
   ]
@@ -393,13 +395,13 @@ const SiteConfigManagement: React.FC = () => {
                   Auth Config
                 </button>
                 <button
-                  onClick={() => handleTabChange('prototype')}
-                  className={`w-full text-left px-4 py-3 rounded-md text-sm font-medium transition-colors ${activeTab === 'prototype'
+                  onClick={() => handleTabChange('model_prototype')}
+                  className={`w-full text-left px-4 py-3 rounded-md text-sm font-medium transition-colors ${activeTab === 'model_prototype'
                     ? 'bg-primary text-primary-foreground'
                     : 'text-foreground hover:bg-muted'
                     }`}
                 >
-                  Prototype Config
+                  Model & Prototype
                 </button>
                 <button
                   onClick={() => handleTabChange('genai')}
@@ -471,7 +473,7 @@ const SiteConfigManagement: React.FC = () => {
               {activeTab === 'style' && <SiteStyleSection />}
               {activeTab === 'email' && <EmailConfigSection />}
               {activeTab === 'secrets' && <SecretConfigSection />}
-              {activeTab === 'prototype' && <PrototypeConfigSection />}
+              {activeTab === 'model_prototype' && <PrototypeConfigSection />}
               {activeTab === 'genai' && <GenAIConfigSection />}
               {activeTab === 'privacy' && <PrivacyPolicySection />}
             </div>


### PR DESCRIPTION
This pull request standardizes the naming and categorization of configuration related to prototypes by renaming the `prototype` category to `model_prototype` throughout both the backend and frontend codebases. It also updates user-facing labels and improves the formatting of some descriptions for clarity. These changes help ensure consistency and reduce ambiguity between model and prototype configuration settings.

**Category renaming and standardization:**

* Renamed all instances of the `prototype` category to `model_prototype` in configuration definitions and queries in both backend (`predefinedSiteConfigs.js`) and frontend (`SiteConfigManagement.tsx`). [[1]](diffhunk://#diff-396f40848ac65f740796e8d38688c6aa6d5d843e1fcf6952208d3a47a9d3329cR31) [[2]](diffhunk://#diff-396f40848ac65f740796e8d38688c6aa6d5d843e1fcf6952208d3a47a9d3329cR40) [[3]](diffhunk://#diff-396f40848ac65f740796e8d38688c6aa6d5d843e1fcf6952208d3a47a9d3329cL104-R106) [[4]](diffhunk://#diff-396f40848ac65f740796e8d38688c6aa6d5d843e1fcf6952208d3a47a9d3329cL198-R200) [[5]](diffhunk://#diff-396f40848ac65f740796e8d38688c6aa6d5d843e1fcf6952208d3a47a9d3329cL207-R209) [[6]](diffhunk://#diff-06ac5254117da1cbba8dcad2217658509e1a669b157fdb9ead21074bca889c69R46) [[7]](diffhunk://#diff-06ac5254117da1cbba8dcad2217658509e1a669b157fdb9ead21074bca889c69R55) [[8]](diffhunk://#diff-06ac5254117da1cbba8dcad2217658509e1a669b157fdb9ead21074bca889c69L110-R127) [[9]](diffhunk://#diff-06ac5254117da1cbba8dcad2217658509e1a669b157fdb9ead21074bca889c69L210-R220) [[10]](diffhunk://#diff-06ac5254117da1cbba8dcad2217658509e1a669b157fdb9ead21074bca889c69L220-R230) [[11]](diffhunk://#diff-06ac5254117da1cbba8dcad2217658509e1a669b157fdb9ead21074bca889c69L233-R255) [[12]](diffhunk://#diff-06ac5254117da1cbba8dcad2217658509e1a669b157fdb9ead21074bca889c69L297-R313) [[13]](diffhunk://#diff-06ac5254117da1cbba8dcad2217658509e1a669b157fdb9ead21074bca889c69L309-R325) [[14]](diffhunk://#diff-acd409a93cf83e2d01ff4d9904377efdd7cdcde50f82d0d6f958a9fea2993c8bL36-R36) [[15]](diffhunk://#diff-9d366d686fa07ae9866a07039c4600d1eda22f44e193ab6f29c1090177514772L32-R32) [[16]](diffhunk://#diff-9d366d686fa07ae9866a07039c4600d1eda22f44e193ab6f29c1090177514772L52-R59) [[17]](diffhunk://#diff-9d366d686fa07ae9866a07039c4600d1eda22f44e193ab6f29c1090177514772L79-R79) [[18]](diffhunk://#diff-9d366d686fa07ae9866a07039c4600d1eda22f44e193ab6f29c1090177514772L112-R119) [[19]](diffhunk://#diff-9d366d686fa07ae9866a07039c4600d1eda22f44e193ab6f29c1090177514772L161-R169)

* Updated all related utility arrays and filtering logic to use the new `model_prototype` category, such as `PREDEFINED_PROTOTYPE_CONFIG_KEYS`.

**User interface and messaging updates:**

* Changed all user-facing labels, headings, and toast messages from "Prototype" to "Model & Prototype" for clarity in `PrototypeConfigSection.tsx`. [[1]](diffhunk://#diff-9d366d686fa07ae9866a07039c4600d1eda22f44e193ab6f29c1090177514772L91-R91) [[2]](diffhunk://#diff-9d366d686fa07ae9866a07039c4600d1eda22f44e193ab6f29c1090177514772L102-R102) [[3]](diffhunk://#diff-9d366d686fa07ae9866a07039c4600d1eda22f44e193ab6f29c1090177514772L138-R138) [[4]](diffhunk://#diff-9d366d686fa07ae9866a07039c4600d1eda22f44e193ab6f29c1090177514772L148-R148) [[5]](diffhunk://#diff-9d366d686fa07ae9866a07039c4600d1eda22f44e193ab6f29c1090177514772L184-R184) [[6]](diffhunk://#diff-9d366d686fa07ae9866a07039c4600d1eda22f44e193ab6f29c1090177514772L196-R199)

**Formatting improvements:**

* Improved the formatting of long description strings for better readability in the config definitions. [[1]](diffhunk://#diff-06ac5254117da1cbba8dcad2217658509e1a669b157fdb9ead21074bca889c69L78-R85) [[2]](diffhunk://#diff-06ac5254117da1cbba8dcad2217658509e1a669b157fdb9ead21074bca889c69L101-R109) [[3]](diffhunk://#diff-06ac5254117da1cbba8dcad2217658509e1a669b157fdb9ead21074bca889c69L110-R127) [[4]](diffhunk://#diff-06ac5254117da1cbba8dcad2217658509e1a669b157fdb9ead21074bca889c69L189-R199) [[5]](diffhunk://#diff-06ac5254117da1cbba8dcad2217658509e1a669b157fdb9ead21074bca889c69L253-R267) [[6]](diffhunk://#diff-06ac5254117da1cbba8dcad2217658509e1a669b157fdb9ead21074bca889c69L262-R277) [[7]](diffhunk://#diff-06ac5254117da1cbba8dcad2217658509e1a669b157fdb9ead21074bca889c69L271-R287)

**Other minor changes:**

* Added missing trailing commas and adjusted array formatting for consistency.