### PR TITLE
Feat: add support for additional API path in model detail layout

### DIFF
--- a/frontend/src/layouts/ModelDetailLayout.tsx
+++ b/frontend/src/layouts/ModelDetailLayout.tsx
@@ -206,8 +206,11 @@ const ModelDetailLayout = () => {
       content:
         'Browse, explore and enhance the catalogue of Connected Vehicle Interfaces',
       path: 'api',
-      subs: ['/model/:model_id/api', '/model/:model_id/api/:api'],
-      count: vehicleApiCount,
+      subs: [
+        '/model/:model_id/api',
+        '/model/:model_id/api/:api',
+        '/model/:model_id/api/:source/:api',
+      ],      count: vehicleApiCount,
       dataId: 'tab-model-api',
     },
     {


### PR DESCRIPTION
This pull request makes a small update to the `ModelDetailLayout` navigation. The change adds support for an additional API route pattern to the `subs` array, which will help the layout recognize and handle URLs with a `:source` parameter in the path.

* Added `'/model/:model_id/api/:source/:api'` to the `subs` array in `ModelDetailLayout.tsx` to support new API route patterns.