### PR TITLE
Feat: add editable prop to PluginPageProps 

### DIFF
--- a/frontend/src/components/organisms/PluginPageRender.tsx
+++ b/frontend/src/components/organisms/PluginPageRender.tsx
@@ -28,6 +28,8 @@ import {
 } from '@/services/extendedApis.service'
 import useRuntimeStore from '@/stores/runtimeStore'
 import { configManagementService } from '@/services/configManagement.service'
+import usePermissionHook from '@/hooks/usePermissionHook'
+import { PERMISSIONS } from '@/data/permission'
 import type { PluginAPI } from '@/types/plugin.types'
 import type { Model, Prototype } from '@/types/model.type'
 import type { CVI, VehicleAPI, VSSRelease, ExtendedApi, ExtendedApiCreate, ExtendedApiRet } from '@/types/api.type'
@@ -67,6 +69,8 @@ const PluginPageRender: React.FC<PluginPageRenderProps> = ({ plugin_id, data, on
   // Extract IDs from data
   const model_id = data?.model?.id
   const prototype_id = data?.prototype?.id
+
+  const [isAuthorized] = usePermissionHook([PERMISSIONS.WRITE_MODEL, model_id])
 
   // Access runtime store for API values
   const { apisValue, setActiveApis } = useRuntimeStore()
@@ -1033,6 +1037,7 @@ const PluginPageRender: React.FC<PluginPageRenderProps> = ({ plugin_id, data, on
         <div key={`plugin-${plugin_id}-${loadedPluginName}`} className="w-full h-full">
           <PluginComponent
             data={data}
+            editable={isAuthorized}
             config={pluginConfig}
             api={pluginAPI}
           />

--- a/frontend/src/types/plugin.types.ts
+++ b/frontend/src/types/plugin.types.ts
@@ -352,6 +352,12 @@ export interface PluginPageProps {
   data?: any
 
   /**
+   * Whether the plugin data is editable by the current user
+   * Controlled by WRITE_MODEL permission on the host side
+   */
+  editable?: boolean
+
+  /**
    * Plugin configuration settings
    */
   config?: {


### PR DESCRIPTION
This pull request introduces permission-based control over plugin editability in the `PluginPageRender` component. The main change is that the plugin's editability is now determined by whether the user has the `WRITE_MODEL` permission for the relevant model, and this information is passed to the plugin as a prop. This helps ensure that only authorized users can edit plugin data.

**Permission handling and plugin editability:**

* Added `usePermissionHook` and `PERMISSIONS` imports to `PluginPageRender.tsx` to enable permission checking.
* Used `usePermissionHook` to determine if the user has the `WRITE_MODEL` permission for the current model, storing the result in `isAuthorized`.
* Passed the `editable` prop to `PluginComponent`, setting it to `isAuthorized` to control editability based on permissions.
* Updated the `PluginPageProps` interface in `plugin.types.ts` to include the new `editable` boolean prop, with documentation explaining its purpose and control by permissions.