### PR TITLE
Feat: add OpenMode props to prototype actions button

### DIFF
--- a/frontend/src/components/molecules/PrototypeRightActionButtons.tsx
+++ b/frontend/src/components/molecules/PrototypeRightActionButtons.tsx
@@ -8,6 +8,7 @@ import { useNavigate, useParams } from 'react-router-dom'
 
 export interface PrototypeRightActionButtonProps {
   tabs: TabConfig[]
+  onClick?: (tabConfig: TabConfig) => void
 }
 
 export const PrototypeRightActionButton = ({
@@ -78,6 +79,7 @@ export const PrototypeRightActionButton = ({
 
 const PrototypeRightActionButtons = ({
   tabs,
+  onClick,
 }: PrototypeRightActionButtonProps) => {
   const { model_id, prototype_id } = useParams()
   const navigate = useNavigate()
@@ -87,15 +89,17 @@ const PrototypeRightActionButtons = ({
       {visibleTabs.map((tabConfig) => {
         return (
           <PrototypeRightActionButton
-            key={`right-actions-${tabConfig}-${tabConfig.label}`}
+            key={`right-actions-btn-${JSON.stringify(tabConfig)}`}
             config={tabConfig}
             onClick={
-              tabConfig.type === 'builtin' || tabConfig.builtin
-                ? undefined
-                : () =>
-                    navigate(
-                      `/model/${model_id}/library/prototype/${prototype_id}/plug?plugid=${tabConfig.plugin}`,
-                    )
+              tabConfig.openMode === 'dialog'
+                ? () => onClick?.(tabConfig)
+                : tabConfig.type === 'builtin' || tabConfig.builtin
+                  ? undefined
+                  : () =>
+                      navigate(
+                        `/model/${model_id}/library/prototype/${prototype_id}/plug?plugid=${tabConfig.plugin}`,
+                      )
             }
           />
         )

--- a/frontend/src/components/organisms/ActionButtonsTab.tsx
+++ b/frontend/src/components/organisms/ActionButtonsTab.tsx
@@ -3,10 +3,7 @@ import { Input } from '@/components/atoms/input'
 import { Label } from '@/components/atoms/label'
 import { Spinner } from '@/components/atoms/spinner'
 import { PrototypeRightActionButton } from '@/components/molecules/PrototypeRightActionButtons'
-import {
-  RightNavPluginButton,
-  StagingConfig,
-} from '@/components/organisms/CustomTabEditor'
+import { RightNavPluginButton } from '@/components/organisms/CustomTabEditor'
 import { cn } from '@/lib/utils'
 import { Paged, Plugin } from '@/services/plugin.service'
 import { DragDropContext, Draggable, Droppable } from '@hello-pangea/dnd'
@@ -44,6 +41,7 @@ const ActionButtonEditor = ({
   onHideIconChange,
   onLabelChange,
   onIconSvgChange,
+  onOpenModeChange,
   onVariantChange,
   onCornersChange,
 }: {
@@ -56,6 +54,7 @@ const ActionButtonEditor = ({
   onHideIconChange: (newHide: boolean) => void
   onLabelChange: (newLabel: string) => void
   onIconSvgChange: (newSvg: string) => void
+  onOpenModeChange: (newMode: 'dialog' | 'page') => void
   onVariantChange: (newVariant: 'tab' | 'primary' | 'outline' | 'ghost') => void
   onCornersChange: (newCorners: 'none' | 'round' | 'full') => void
 }) => {
@@ -225,6 +224,31 @@ const ActionButtonEditor = ({
               </div>
             </div>
           </div>
+          {/* Open as dialog or page */}
+          <div className="flex items-center gap-3">
+            <Label className="text-xs w-20 shrink-0 text-foreground mt-1">
+              Open mode
+            </Label>
+            <div className="flex flex-wrap gap-2">
+              {(['dialog', 'page'] as const).map((mode) => (
+                <button
+                  key={mode}
+                  type="button"
+                  onClick={() => onOpenModeChange(mode)}
+                  className={cn(
+                    'px-3 py-1 text-xs rounded border capitalize transition-colors',
+                    ` ${
+                      (config.openMode || 'page') === mode
+                        ? 'bg-primary text-primary-foreground border-primary'
+                        : 'bg-background text-foreground border-border hover:bg-accent'
+                    }`,
+                  )}
+                >
+                  {mode}
+                </button>
+              ))}
+            </div>
+          </div>
           {/* Preview */}
           <div className="flex items-center gap-3">
             <Label className="text-xs w-20 shrink-0 text-foreground">
@@ -329,7 +353,8 @@ const ActionButtonsTab = ({
                     onHideIconChange={() => {}}
                     onLabelChange={() => {}}
                     onIconSvgChange={() => {}}
-                    onVariantChange={() => {}}
+                    onVariantChange={() => { }}
+                    onOpenModeChange={() => {}}
                     onCornersChange={() => {}}
                   />
                 </div>
@@ -426,6 +451,13 @@ const ActionButtonsTab = ({
                                 ),
                               )
                             }
+                            onOpenModeChange={(newOpenMode) => {
+                              setLocalRightNavPlugins((prev) =>
+                                prev.map((b, idx) =>
+                                  idx === i ? { ...b, openMode: newOpenMode } : b,
+                                ),
+                              )
+                            }}
                             onCornersChange={(newCorners) =>
                               setLocalRightNavPlugins((prev) =>
                                 prev.map((b, idx) =>

--- a/frontend/src/components/organisms/ActionButtonsTab.tsx
+++ b/frontend/src/components/organisms/ActionButtonsTab.tsx
@@ -353,7 +353,7 @@ const ActionButtonsTab = ({
                     onHideIconChange={() => {}}
                     onLabelChange={() => {}}
                     onIconSvgChange={() => {}}
-                    onVariantChange={() => { }}
+                    onVariantChange={() => {}}
                     onOpenModeChange={() => {}}
                     onCornersChange={() => {}}
                   />
@@ -454,7 +454,9 @@ const ActionButtonsTab = ({
                             onOpenModeChange={(newOpenMode) => {
                               setLocalRightNavPlugins((prev) =>
                                 prev.map((b, idx) =>
-                                  idx === i ? { ...b, openMode: newOpenMode } : b,
+                                  idx === i
+                                    ? { ...b, openMode: newOpenMode }
+                                    : b,
                                 ),
                               )
                             }}

--- a/frontend/src/components/organisms/CustomTabEditor.tsx
+++ b/frontend/src/components/organisms/CustomTabEditor.tsx
@@ -62,6 +62,7 @@ export interface TabConfig {
   iconSvg?: string
   builtin?: string
   variant?: 'tab' | 'primary' | 'outline' | 'ghost'
+  openMode?: 'dialog' | 'page'
   hideIcon?: boolean
   corners?: 'none' | 'round' | 'full'
 }
@@ -82,6 +83,7 @@ export interface RightNavPluginButton {
   iconSvg?: string
   hideIcon?: boolean // For staging: whether to hide the icon
   variant?: 'tab' | 'primary' | 'outline' | 'ghost'
+  openMode?: 'dialog' | 'page'
   hidden?: boolean
   corners?: 'none' | 'round' | 'full'
 }

--- a/frontend/src/pages/PagePrototypeDetail.tsx
+++ b/frontend/src/pages/PagePrototypeDetail.tsx
@@ -44,6 +44,7 @@ import usePermissionHook from '@/hooks/usePermissionHook'
 import usePluginPreloader from '@/hooks/usePluginPreloader'
 import useSelfProfileQuery from '@/hooks/useSelfProfile'
 import PagePrototypePlugin from '@/pages/PagePrototypePlugin'
+import PrototypeRightAction from '@/pages/PrototypeRightAction'
 import { configManagementService } from '@/services/configManagement.service'
 import { updateModelService } from '@/services/model.service'
 import { Plugin } from '@/services/plugin.service'
@@ -427,8 +428,9 @@ const PagePrototypeDetail: FC<ViewPrototypeProps> = ({}) => {
             </div>
           )}
           <div className="grow"></div>
-          <PrototypeRightActionButtons
-            tabs={model?.custom_template?.prototype_right_nav_buttons || []}
+          <PrototypeRightAction
+            prototype={prototype}
+            actions={model?.custom_template?.prototype_right_nav_buttons || []}
           />
           {canConfigurePrototypeAddons && (
             <DropdownMenu open={moreMenuOpen} onOpenChange={setMoreMenuOpen}>

--- a/frontend/src/pages/PrototypeRightAction.tsx
+++ b/frontend/src/pages/PrototypeRightAction.tsx
@@ -1,0 +1,55 @@
+import DaDialog from '@/components/molecules/DaDialog'
+import PrototypeRightActionButtons from '@/components/molecules/PrototypeRightActionButtons'
+import { TabConfig } from '@/components/organisms/CustomTabEditor'
+import PrototypeTabStaging from '@/components/organisms/PrototypeTabStaging'
+import PagePrototypePlugin from '@/pages/PagePrototypePlugin'
+import { Prototype } from '@/types/model.type'
+import { useState } from 'react'
+
+export interface PrototypeRightActionProps {
+  prototype: Prototype
+  actions: TabConfig[]
+}
+
+const PrototypeRightAction = ({
+  prototype,
+  actions,
+}: PrototypeRightActionProps) => {
+  const [openDialog, setOpenDialog] = useState('')
+  return (
+    <>
+      {actions.map((action) => {
+        if (action.openMode === 'page') return null
+        const dialogKey = JSON.stringify(action)
+        return (
+          <DaDialog
+            key={`prototype-right-action-dialog-${dialogKey}`}
+            open={openDialog === dialogKey}
+            onOpenChange={(open) => setOpenDialog(open ? dialogKey : '')}
+            dialogTitle={
+              action.builtin ? action.label || 'Staging' : action.label
+            }
+            className="max-w-[95vw] w-[1200px]"
+          >
+            <div className="flex overflow-y-auto max-h-[80vh]  min-h-[20vh] [&>div]:p-0!">
+              {action.builtin ? (
+                <PrototypeTabStaging prototype={prototype} />
+              ) : (
+                <PagePrototypePlugin
+                  pluginSlug={action.plugin}
+                  onSetActiveTab={() => {}}
+                />
+              )}
+            </div>
+          </DaDialog>
+        )
+      })}
+      <PrototypeRightActionButtons
+        tabs={actions}
+        onClick={(action) => setOpenDialog(JSON.stringify(action))}
+      />
+    </>
+  )
+}
+
+export default PrototypeRightAction


### PR DESCRIPTION
This pull request introduces the ability to configure whether right-side prototype action buttons open as a dialog or as a page, and refactors the handling of these actions for improved flexibility and maintainability. The main changes are the addition of an `openMode` property to button configurations, UI controls to set this property, and a new component to handle dialog-based actions.
