### PR TITLE
Feat: Remove manage hardware kit hard code kit.digitalauto.tech

### DIFF
--- a/frontend/src/components/molecules/DaRuntimeConnector.tsx
+++ b/frontend/src/components/molecules/DaRuntimeConnector.tsx
@@ -709,6 +709,20 @@ const DaRuntimeConnector = forwardRef<any, KitConnectProps>(
       }
     }
 
+    // Cleanup timeout on unmount
+    useEffect(() => {
+      return () => {
+        if (kitListTimeoutRef.current) {
+          clearTimeout(kitListTimeoutRef.current)
+          kitListTimeoutRef.current = null
+        }
+        if (socketConnectTimeoutRef.current) {
+          clearTimeout(socketConnectTimeoutRef.current)
+          socketConnectTimeoutRef.current = null
+        }
+      }
+    }, [])
+
     if (forceKitId) {
       let statusIcon = '🟡'
       let statusText = 'Connecting...'
@@ -754,20 +768,6 @@ const DaRuntimeConnector = forwardRef<any, KitConnectProps>(
         </div>
       )
     }
-
-    // Cleanup timeout on unmount
-    useEffect(() => {
-      return () => {
-        if (kitListTimeoutRef.current) {
-          clearTimeout(kitListTimeoutRef.current)
-          kitListTimeoutRef.current = null
-        }
-        if (socketConnectTimeoutRef.current) {
-          clearTimeout(socketConnectTimeoutRef.current)
-          socketConnectTimeoutRef.current = null
-        }
-      }
-    }, [])
 
     return (
       <div>

--- a/frontend/src/components/molecules/DaRuntimeConnector.tsx
+++ b/frontend/src/components/molecules/DaRuntimeConnector.tsx
@@ -369,7 +369,7 @@ const DaRuntimeConnector = forwardRef<any, KitConnectProps>(
       setSocketIo(io(kitServerUrl, effectiveSocketIoConfig))
       // Only re-create socket if kitServerUrl changes, not if config changes
       // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [kitServerUrl])
+    }, [kitServerUrl, JSON.stringify(socketIoConfig)])
 
     useEffect(() => {
       if (!socketio) return

--- a/frontend/src/components/molecules/DaRuntimeConnector.tsx
+++ b/frontend/src/components/molecules/DaRuntimeConnector.tsx
@@ -192,7 +192,6 @@ const DaRuntimeConnector = forwardRef<any, KitConnectProps>(
       if (prototype?.extend?.watch_vars && Array.isArray(prototype?.extend?.watch_vars)) {
         watch_vars = prototype?.extend?.watch_vars.map((v: any) => v.name).join(', ') || ''
       }
-      console.log(`watch_vars`, watch_vars)
       socketio?.emit('messageToKit', {
         cmd: cmd,
         to_kit_id: activeRtId,
@@ -351,11 +350,7 @@ const DaRuntimeConnector = forwardRef<any, KitConnectProps>(
     }, [activeRtId])
 
     useEffect(() => {
-      console.log('Kit server URL:', kitServerUrl)
       if (!kitServerUrl) return
-
-      console.log('[DaRuntimeConnector] Connecting to:', kitServerUrl, 'with config:', effectiveSocketIoConfig)
-
       // Reset timeout flags when starting a new connection
       if (forceKitId) {
         setSocketConnectionTimeout(false)
@@ -423,23 +418,17 @@ const DaRuntimeConnector = forwardRef<any, KitConnectProps>(
         socketConnectTimeoutRef.current = null
       }
       setSocketConnectionTimeout(false)
-      console.log('[DaRuntimeConnector] Socket connected successfully')
-
       registerClient()
       setTimeout(() => {
         if (activeRtIdRef.current || forceKitIdRef.current) {
           const needsRefresh = wasDisconnectedRef.current
           const alreadyHaveList = hasLoadedKitListRef.current
-          console.log('[DaRuntimeConnector] On connect - alreadyHaveList:', alreadyHaveList, ', needsRefresh:', needsRefresh)
-
           // Only request kit list if we don't have it yet or we just disconnected
           if (!alreadyHaveList || needsRefresh) {
-            console.log('[DaRuntimeConnector] Requesting kit list (alreadyHaveList:', alreadyHaveList, ', wasDisconnected:', needsRefresh, ')')
             setHasLoadedKitList(false)
             setKitListRequestTimeout(false)
             const now = Date.now()
             setKitListRequestTime(now)
-            console.log('[DaRuntimeConnector] Sending list-all-kits request at', new Date(now).toISOString())
 
             // Clear any existing timeout
             if (kitListTimeoutRef.current) {
@@ -459,7 +448,6 @@ const DaRuntimeConnector = forwardRef<any, KitConnectProps>(
             // Reset disconnect flag after requesting
             wasDisconnectedRef.current = false
           } else {
-            console.log('[DaRuntimeConnector] Already have kit list, not requesting again')
           }
         }
       }, 1000)
@@ -481,25 +469,10 @@ const DaRuntimeConnector = forwardRef<any, KitConnectProps>(
     }
 
     const onDisconnect = (reason?: string) => {
-      console.log('[DaRuntimeConnector] Socket disconnected - reason:', reason)
       wasDisconnectedRef.current = true
-      if (forceKitId) {
-        console.log('[DaRuntimeConnector] Socket disconnected with forceKitId, will refresh kit list on reconnect')
-      }
     }
 
     const onGetAllKitData = (data: any) => {
-      const receivedTime = Date.now()
-      const requestDuration = kitListRequestTime ? receivedTime - kitListRequestTime : 'N/A'
-      console.log('[DaRuntimeConnector] list-all-kits-result received in', requestDuration, 'ms:', data)
-      if (forceKitId) {
-        const kitIds = data.map((k: any) => k.kit_id)
-        console.log('[DaRuntimeConnector] Available kit IDs:', kitIds)
-        console.log('[DaRuntimeConnector] Looking for forceKitId:', forceKitId)
-        const found = data.find((k: any) => k.kit_id.toLowerCase() === forceKitId.toLowerCase())
-        console.log('[DaRuntimeConnector] Kit found:', found ? 'YES' : 'NO', found)
-      }
-
       // Clear the timeout since we got a response
       if (kitListTimeoutRef.current) {
         clearTimeout(kitListTimeoutRef.current)
@@ -744,22 +717,18 @@ const DaRuntimeConnector = forwardRef<any, KitConnectProps>(
       if (socketConnectionTimeout) {
         statusIcon = '⚪'
         statusText = 'Unreachable'
-        console.log(`[${new Date().toISOString()}] [DaRuntimeConnector] Socket connection timed out - showing Unreachable status`)
       }
       // Check if kit list request timed out (kit-manager unreachable)
       else if (kitListRequestTimeout) {
         statusIcon = '⚪'
         statusText = 'Unreachable'
-        console.log(`[${new Date().toISOString()}] [DaRuntimeConnector] Kit list request timed out - showing Unreachable status`)
       }
       // Check if socket is connected and kit list is loaded
       else if (!socketio?.connected || !hasLoadedKitList) {
         statusIcon = '🟡'
         statusText = 'Connecting...'
-        console.log(`[${new Date().toISOString()}] [DaRuntimeConnector] Waiting for kit list - socketConnected:`, socketio?.connected, 'hasLoadedKitList:', hasLoadedKitList)
       } else {
         // Socket is connected and kit list is loaded, now check the specific runtime
-        console.log('[DaRuntimeConnector] Checking for runtime:', forceKitId, 'in', allRuntimes.length, 'runtimes:', allRuntimes.map((r: Runtime) => r.kit_id))
         const rt = allRuntimes.find(
           (r: Runtime) => r.kit_id.toLowerCase() === forceKitId.toLowerCase(),
         )
@@ -767,26 +736,16 @@ const DaRuntimeConnector = forwardRef<any, KitConnectProps>(
           // Runtime not found in the list at all
           statusIcon = '⚪'
           statusText = 'Unreachable'
-          console.log('[DaRuntimeConnector] Runtime NOT FOUND - showing Unreachable for forceKitId:', forceKitId)
         } else if (!rt.is_online) {
           // Runtime found but is offline
           statusIcon = '🔴'
           statusText = 'Disconnected'
-          console.log('[DaRuntimeConnector] Runtime found but offline - showing Disconnected:', rt.kit_id)
         } else {
           // Runtime found and is online
           statusIcon = '🟢'
           statusText = 'Connected'
-          console.log('[DaRuntimeConnector] Runtime found and online - showing Connected:', rt.kit_id)
         }
       }
-
-      // Debug: Log state changes when forceKitId is set
-      useEffect(() => {
-        if (forceKitId) {
-          console.log(`[${new Date().toISOString()}] [DaRuntimeConnector] State update - socketConnected: ${socketio?.connected}, hasLoadedKitList: ${hasLoadedKitList}, socketTimeout: ${socketConnectionTimeout}, kitListTimeout: ${kitListRequestTimeout}, allRuntimes: ${allRuntimes.length}`)
-        }
-      }, [forceKitId, socketio?.connected, hasLoadedKitList, socketConnectionTimeout, kitListRequestTimeout, allRuntimes.length])
 
       return (
         <div className="flex items-center text-xs gap-1.5">

--- a/frontend/src/components/molecules/DaRuntimeConnector.tsx
+++ b/frontend/src/components/molecules/DaRuntimeConnector.tsx
@@ -6,7 +6,7 @@
 //
 // SPDX-License-Identifier: MIT
 
-import { forwardRef, useState, useEffect, useImperativeHandle } from 'react'
+import { forwardRef, useState, useEffect, useImperativeHandle, useRef, useMemo } from 'react'
 import useRuntimeStore from '@/stores/runtimeStore'
 import { shallow } from 'zustand/shallow'
 import useCurrentPrototype from '@/hooks/useCurrentPrototype'
@@ -14,6 +14,7 @@ import useSelfProfileQuery from '@/hooks/useSelfProfile'
 import { useAssets } from '@/hooks/useAssets'
 
 import { io } from 'socket.io-client'
+import { useSiteConfig } from '@/utils/siteConfig'
 
 export interface Runtime {
   desc: string
@@ -68,13 +69,49 @@ const DaRuntimeConnector = forwardRef<any, KitConnectProps>(
     const [allRuntimes, setAllRuntimes] = useState<any>([])
     const [ticker, setTicker] = useState(0)
 
+    const socketioRef = useRef<any>(null)
+    const activeRtIdRef = useRef<string | undefined>('')
+    const forceKitIdRef = useRef<string | undefined>(forceKitId)
+    const wasDisconnectedRef = useRef<boolean>(false)
+    const hasLoadedKitListRef = useRef<boolean>(false)
+    socketioRef.current = socketio
+    activeRtIdRef.current = activeRtId
+    forceKitIdRef.current = forceKitId
+
     const [rawApisPackage, setRawApisPackage] = useState<any>(null)
     const { data: prototype } = useCurrentPrototype()
     const { data: currentUser } = useSelfProfileQuery()
     const { useFetchAssets } = useAssets()
     const { data: assets } = useFetchAssets()
+
+    // Read RUNTIME_SERVER_CONFIG from site config as fallback for socketIoConfig
+    const runtimeServerConfigRaw = useSiteConfig('RUNTIME_SERVER_CONFIG', '')
+    const siteConfigSocketIoConfig = useMemo(() => {
+      if (!runtimeServerConfigRaw) return {}
+      try {
+        const parsed =
+          typeof runtimeServerConfigRaw === 'string'
+            ? JSON.parse(runtimeServerConfigRaw)
+            : runtimeServerConfigRaw
+        return typeof parsed === 'object' && parsed !== null ? parsed : {}
+      } catch {
+        return {}
+      }
+    }, [runtimeServerConfigRaw])
+
+    // Use prop socketIoConfig, fallback to site config
+    const effectiveSocketIoConfig = useMemo(() => {
+      return socketIoConfig || siteConfigSocketIoConfig || {}
+    }, [socketIoConfig, siteConfigSocketIoConfig])
+
     const [renderRuntimes, setRenderRuntimes] = useState<Runtime[]>([])
     const [hasLoadedKitList, setHasLoadedKitList] = useState(false)
+    hasLoadedKitListRef.current = hasLoadedKitList
+    const [kitListRequestTime, setKitListRequestTime] = useState<number | null>(null)
+    const [kitListRequestTimeout, setKitListRequestTimeout] = useState(false)
+    const [socketConnectionTimeout, setSocketConnectionTimeout] = useState(false)
+    const kitListTimeoutRef = useRef<NodeJS.Timeout | null>(null)
+    const socketConnectTimeoutRef = useRef<NodeJS.Timeout | null>(null)
 
     useImperativeHandle(ref, () => {
       return {
@@ -316,9 +353,28 @@ const DaRuntimeConnector = forwardRef<any, KitConnectProps>(
     useEffect(() => {
       console.log('Kit server URL:', kitServerUrl)
       if (!kitServerUrl) return
-      setSocketIo(io(kitServerUrl, socketIoConfig || {}))
+
+      console.log('[DaRuntimeConnector] Connecting to:', kitServerUrl, 'with config:', effectiveSocketIoConfig)
+
+      // Reset timeout flags when starting a new connection
+      if (forceKitId) {
+        setSocketConnectionTimeout(false)
+        setKitListRequestTimeout(false)
+
+        // Set socket connection timeout (if not connected within 10 seconds, mark as unreachable)
+        if (socketConnectTimeoutRef.current) {
+          clearTimeout(socketConnectTimeoutRef.current)
+        }
+        socketConnectTimeoutRef.current = setTimeout(() => {
+          console.warn('[DaRuntimeConnector] Socket connection timeout (10s) - kit-manager server unreachable')
+          setSocketConnectionTimeout(true)
+        }, 10000)
+      }
+
+      setSocketIo(io(kitServerUrl, effectiveSocketIoConfig))
+      // Only re-create socket if kitServerUrl changes, not if config changes
       // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [kitServerUrl, JSON.stringify(socketIoConfig)])
+    }, [kitServerUrl])
 
     useEffect(() => {
       if (!socketio) return
@@ -361,13 +417,50 @@ const DaRuntimeConnector = forwardRef<any, KitConnectProps>(
     }, [activeRtId])
 
     const onConnected = () => {
-      setHasLoadedKitList(false)
+      // Clear socket connection timeout since we successfully connected
+      if (socketConnectTimeoutRef.current) {
+        clearTimeout(socketConnectTimeoutRef.current)
+        socketConnectTimeoutRef.current = null
+      }
+      setSocketConnectionTimeout(false)
+      console.log('[DaRuntimeConnector] Socket connected successfully')
+
       registerClient()
       setTimeout(() => {
-        if (activeRtId) {
-          socketio?.emit('messageToKit', {
-            cmd: 'list-all-kits',
-          })
+        if (activeRtIdRef.current || forceKitIdRef.current) {
+          const needsRefresh = wasDisconnectedRef.current
+          const alreadyHaveList = hasLoadedKitListRef.current
+          console.log('[DaRuntimeConnector] On connect - alreadyHaveList:', alreadyHaveList, ', needsRefresh:', needsRefresh)
+
+          // Only request kit list if we don't have it yet or we just disconnected
+          if (!alreadyHaveList || needsRefresh) {
+            console.log('[DaRuntimeConnector] Requesting kit list (alreadyHaveList:', alreadyHaveList, ', wasDisconnected:', needsRefresh, ')')
+            setHasLoadedKitList(false)
+            setKitListRequestTimeout(false)
+            const now = Date.now()
+            setKitListRequestTime(now)
+            console.log('[DaRuntimeConnector] Sending list-all-kits request at', new Date(now).toISOString())
+
+            // Clear any existing timeout
+            if (kitListTimeoutRef.current) {
+              clearTimeout(kitListTimeoutRef.current)
+            }
+
+            // Set timeout: if no response in 8 seconds, mark as timeout
+            kitListTimeoutRef.current = setTimeout(() => {
+              console.warn('[DaRuntimeConnector] list-all-kits request timeout (8s) - kit-manager may be unreachable')
+              setKitListRequestTimeout(true)
+            }, 8000)
+
+            socketio?.emit('messageToKit', {
+              cmd: 'list-all-kits',
+            })
+
+            // Reset disconnect flag after requesting
+            wasDisconnectedRef.current = false
+          } else {
+            console.log('[DaRuntimeConnector] Already have kit list, not requesting again')
+          }
         }
       }, 1000)
       if (usedAPIs) {
@@ -387,10 +480,35 @@ const DaRuntimeConnector = forwardRef<any, KitConnectProps>(
       socketio?.emit('unregister_client', {})
     }
 
-    const onDisconnect = () => { }
+    const onDisconnect = (reason?: string) => {
+      console.log('[DaRuntimeConnector] Socket disconnected - reason:', reason)
+      wasDisconnectedRef.current = true
+      if (forceKitId) {
+        console.log('[DaRuntimeConnector] Socket disconnected with forceKitId, will refresh kit list on reconnect')
+      }
+    }
 
     const onGetAllKitData = (data: any) => {
-      setHasLoadedKitList(false)
+      const receivedTime = Date.now()
+      const requestDuration = kitListRequestTime ? receivedTime - kitListRequestTime : 'N/A'
+      console.log('[DaRuntimeConnector] list-all-kits-result received in', requestDuration, 'ms:', data)
+      if (forceKitId) {
+        const kitIds = data.map((k: any) => k.kit_id)
+        console.log('[DaRuntimeConnector] Available kit IDs:', kitIds)
+        console.log('[DaRuntimeConnector] Looking for forceKitId:', forceKitId)
+        const found = data.find((k: any) => k.kit_id.toLowerCase() === forceKitId.toLowerCase())
+        console.log('[DaRuntimeConnector] Kit found:', found ? 'YES' : 'NO', found)
+      }
+
+      // Clear the timeout since we got a response
+      if (kitListTimeoutRef.current) {
+        clearTimeout(kitListTimeoutRef.current)
+        kitListTimeoutRef.current = null
+      }
+
+      setHasLoadedKitList(true)
+      hasLoadedKitListRef.current = true
+      setKitListRequestTimeout(false)
       const getLastPart = (kit_id: string) => {
         const parts = kit_id.split('-')
         return parts[parts.length - 1]
@@ -622,12 +740,26 @@ const DaRuntimeConnector = forwardRef<any, KitConnectProps>(
       let statusIcon = '🟡'
       let statusText = 'Connecting...'
 
-      // First check if socket is connected and kit list is loaded
-      if (!socketio?.connected || !hasLoadedKitList) {
+      // Check if socket connection timed out (socket itself couldn't connect)
+      if (socketConnectionTimeout) {
+        statusIcon = '⚪'
+        statusText = 'Unreachable'
+        console.log(`[${new Date().toISOString()}] [DaRuntimeConnector] Socket connection timed out - showing Unreachable status`)
+      }
+      // Check if kit list request timed out (kit-manager unreachable)
+      else if (kitListRequestTimeout) {
+        statusIcon = '⚪'
+        statusText = 'Unreachable'
+        console.log(`[${new Date().toISOString()}] [DaRuntimeConnector] Kit list request timed out - showing Unreachable status`)
+      }
+      // Check if socket is connected and kit list is loaded
+      else if (!socketio?.connected || !hasLoadedKitList) {
         statusIcon = '🟡'
         statusText = 'Connecting...'
+        console.log(`[${new Date().toISOString()}] [DaRuntimeConnector] Waiting for kit list - socketConnected:`, socketio?.connected, 'hasLoadedKitList:', hasLoadedKitList)
       } else {
         // Socket is connected and kit list is loaded, now check the specific runtime
+        console.log('[DaRuntimeConnector] Checking for runtime:', forceKitId, 'in', allRuntimes.length, 'runtimes:', allRuntimes.map((r: Runtime) => r.kit_id))
         const rt = allRuntimes.find(
           (r: Runtime) => r.kit_id.toLowerCase() === forceKitId.toLowerCase(),
         )
@@ -635,16 +767,26 @@ const DaRuntimeConnector = forwardRef<any, KitConnectProps>(
           // Runtime not found in the list at all
           statusIcon = '⚪'
           statusText = 'Unreachable'
+          console.log('[DaRuntimeConnector] Runtime NOT FOUND - showing Unreachable for forceKitId:', forceKitId)
         } else if (!rt.is_online) {
           // Runtime found but is offline
           statusIcon = '🔴'
           statusText = 'Disconnected'
+          console.log('[DaRuntimeConnector] Runtime found but offline - showing Disconnected:', rt.kit_id)
         } else {
           // Runtime found and is online
           statusIcon = '🟢'
           statusText = 'Connected'
+          console.log('[DaRuntimeConnector] Runtime found and online - showing Connected:', rt.kit_id)
         }
       }
+
+      // Debug: Log state changes when forceKitId is set
+      useEffect(() => {
+        if (forceKitId) {
+          console.log(`[${new Date().toISOString()}] [DaRuntimeConnector] State update - socketConnected: ${socketio?.connected}, hasLoadedKitList: ${hasLoadedKitList}, socketTimeout: ${socketConnectionTimeout}, kitListTimeout: ${kitListRequestTimeout}, allRuntimes: ${allRuntimes.length}`)
+        }
+      }, [forceKitId, socketio?.connected, hasLoadedKitList, socketConnectionTimeout, kitListRequestTimeout, allRuntimes.length])
 
       return (
         <div className="flex items-center text-xs gap-1.5">
@@ -653,6 +795,20 @@ const DaRuntimeConnector = forwardRef<any, KitConnectProps>(
         </div>
       )
     }
+
+    // Cleanup timeout on unmount
+    useEffect(() => {
+      return () => {
+        if (kitListTimeoutRef.current) {
+          clearTimeout(kitListTimeoutRef.current)
+          kitListTimeoutRef.current = null
+        }
+        if (socketConnectTimeoutRef.current) {
+          clearTimeout(socketConnectTimeoutRef.current)
+          socketConnectTimeoutRef.current = null
+        }
+      }
+    }, [])
 
     return (
       <div>

--- a/frontend/src/components/molecules/DaRuntimeConnector.tsx
+++ b/frontend/src/components/molecules/DaRuntimeConnector.tsx
@@ -31,6 +31,7 @@ interface KitConnectProps {
   hideLabel?: boolean
   targetPrefix: string | string[]
   usedAPIs: string[]
+  forceKitId?: string
   onActiveRtChanged?: (newActiveKitId: string | undefined) => void
   onLoadedMockSignals?: (signals: []) => void
   onNewLog?: (log: string) => void
@@ -50,6 +51,7 @@ const DaRuntimeConnector = forwardRef<any, KitConnectProps>(
       kitServerUrl,
       socketIoConfig,
       usedAPIs,
+      forceKitId,
       onActiveRtChanged,
       onLoadedMockSignals,
       onNewLog,
@@ -72,6 +74,7 @@ const DaRuntimeConnector = forwardRef<any, KitConnectProps>(
     const { useFetchAssets } = useAssets()
     const { data: assets } = useFetchAssets()
     const [renderRuntimes, setRenderRuntimes] = useState<Runtime[]>([])
+    const [hasLoadedKitList, setHasLoadedKitList] = useState(false)
 
     useImperativeHandle(ref, () => {
       return {
@@ -311,6 +314,7 @@ const DaRuntimeConnector = forwardRef<any, KitConnectProps>(
     }, [activeRtId])
 
     useEffect(() => {
+      console.log('Kit server URL:', kitServerUrl)
       if (!kitServerUrl) return
       setSocketIo(io(kitServerUrl, socketIoConfig || {}))
       // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -357,6 +361,7 @@ const DaRuntimeConnector = forwardRef<any, KitConnectProps>(
     }, [activeRtId])
 
     const onConnected = () => {
+      setHasLoadedKitList(false)
       registerClient()
       setTimeout(() => {
         if (activeRtId) {
@@ -385,15 +390,24 @@ const DaRuntimeConnector = forwardRef<any, KitConnectProps>(
     const onDisconnect = () => { }
 
     const onGetAllKitData = (data: any) => {
+      setHasLoadedKitList(false)
       const getLastPart = (kit_id: string) => {
         const parts = kit_id.split('-')
         return parts[parts.length - 1]
       }
+     
+      // If forceKitId is set, include all runtimes (even offline) so we can show their status
+      // Otherwise, filter for online runtimes only
       let kits = [...data].filter((kit: any) => {
-        return kit.is_online
+        return forceKitId ? true : kit.is_online
       })
 
+
       let sortedKits = kits.filter((rt) => {
+        // If forceKitId is set, bypass prefix filter and include all runtimes
+        if (forceKitId) {
+          return true
+        }
         const kitIdLower = rt.kit_id.toLowerCase()
         if (Array.isArray(targetPrefix)) {
           return targetPrefix.some(prefix => kitIdLower.startsWith(prefix.toLowerCase()))
@@ -602,6 +616,42 @@ const DaRuntimeConnector = forwardRef<any, KitConnectProps>(
       if (onRuntimeInfoReceived) {
         onRuntimeInfoReceived(payload.data)
       }
+    }
+
+    if (forceKitId) {
+      let statusIcon = '🟡'
+      let statusText = 'Connecting...'
+
+      // First check if socket is connected and kit list is loaded
+      if (!socketio?.connected || !hasLoadedKitList) {
+        statusIcon = '🟡'
+        statusText = 'Connecting...'
+      } else {
+        // Socket is connected and kit list is loaded, now check the specific runtime
+        const rt = allRuntimes.find(
+          (r: Runtime) => r.kit_id.toLowerCase() === forceKitId.toLowerCase(),
+        )
+        if (!rt) {
+          // Runtime not found in the list at all
+          statusIcon = '⚪'
+          statusText = 'Unreachable'
+        } else if (!rt.is_online) {
+          // Runtime found but is offline
+          statusIcon = '🔴'
+          statusText = 'Disconnected'
+        } else {
+          // Runtime found and is online
+          statusIcon = '🟢'
+          statusText = 'Connected'
+        }
+      }
+
+      return (
+        <div className="flex items-center text-xs gap-1.5">
+          <span>{statusIcon}</span>
+          <span>{statusText}</span>
+        </div>
+      )
     }
 
     return (

--- a/frontend/src/components/molecules/dashboard/DaRuntimeControl.tsx
+++ b/frontend/src/components/molecules/dashboard/DaRuntimeControl.tsx
@@ -40,8 +40,6 @@ import PrototypeVarsWatch from './PrototypeVarsWatch'
 import DaRemoteCompileRust from '../remote-compiler/DaRemoteCompileRust'
 import { useSystemUI } from '@/hooks/useSystemUI'
 
-const DEFAULT_KIT_SERVER = 'https://kit.digitalauto.tech'
-
 const AlwaysScrollToBottom = () => {
   const elementRef = useRef<HTMLDivElement>(null)
   useEffect(() => {

--- a/frontend/src/components/organisms/FormHardwareKitManager.tsx
+++ b/frontend/src/components/organisms/FormHardwareKitManager.tsx
@@ -7,6 +7,7 @@
 // SPDX-License-Identifier: MIT
 
 import config from '@/configs/config'
+import { useSiteConfig } from '@/utils/siteConfig'
 import { useEffect, useRef, useState } from 'react'
 import {
     TbDownload,
@@ -201,6 +202,7 @@ const FormHardwareKitManager = ({
     const [edgeConfig, setEdgeConfig] = useState<any>(null)
     const [edgeVss, setEdgeVss] = useState<any>(null)
     const runTimeRef = useRef<any>()
+    const runtimeServerUrl = useSiteConfig('RUNTIME_SERVER_URL')
 
     const CONFIG_PATH = '/app/remote_access/signal-config.json'
     const VSS_PATH = '/app/remote_access/vss.json'
@@ -242,8 +244,9 @@ const FormHardwareKitManager = ({
                 <DaRuntimeConnector
                     isDeployMode={true}
                     targetPrefix={['Kit-', 'PilotCar-']}
-                    kitServerUrl={config?.runtime?.url}
+                    kitServerUrl={runtimeServerUrl}
                     ref={runTimeRef}
+                    forceKitId={kitName}
                     usedAPIs={[]}
                     onActiveRtChanged={() => { }}
                     onLoadedMockSignals={() => { }}

--- a/frontend/src/components/organisms/PluginPageRender.tsx
+++ b/frontend/src/components/organisms/PluginPageRender.tsx
@@ -355,7 +355,7 @@ const PluginPageRender: React.FC<PluginPageRenderProps> = ({ plugin_id, data, on
   // Kit / Runtime operations
   const SIGNAL_CONFIG_PATH = config.runtime?.signalConfigPath || '/app/remote_access/signal-config.json'
   const VSS_PATH = config.runtime?.vssPath || '/app/remote_access/vss.json'
-  const KIT_SERVER_URL = runtimeServerUrl || config.runtime?.url || 'https://kit.digitalauto.teaaach'
+  const KIT_SERVER_URL = runtimeServerUrl || config.runtime?.url || 'https://kit.digitalauto.tech'
   const handleFetchSignalMapping = useCallback((kitName: string): Promise<string> => {
     return new Promise((resolve, reject) => {
       const socket = io(KIT_SERVER_URL)

--- a/frontend/src/components/organisms/PluginPageRender.tsx
+++ b/frontend/src/components/organisms/PluginPageRender.tsx
@@ -34,6 +34,7 @@ import type { PluginAPI } from '@/types/plugin.types'
 import type { Model, Prototype } from '@/types/model.type'
 import type { CVI, VehicleAPI, VSSRelease, ExtendedApi, ExtendedApiCreate, ExtendedApiRet } from '@/types/api.type'
 import type { List } from '@/types/common.type'
+import { useSiteConfig } from '@/utils/siteConfig'
 
 interface PluginPageRenderProps {
   plugin_id: string
@@ -65,6 +66,7 @@ const PluginPageRender: React.FC<PluginPageRenderProps> = ({ plugin_id, data, on
   const [loadedPluginName, setLoadedPluginName] = useState<string | null>(null)
   const [siteConfigs, setSiteConfigs] = useState<{ public: Record<string, any> }>({ public: {} })
   const [pluginMetaConfig, setPluginMetaConfig] = useState<Record<string, any>>({})
+  const runtimeServerUrl = useSiteConfig('RUNTIME_SERVER_URL', config?.runtime?.url)
 
   // Extract IDs from data
   const model_id = data?.model?.id
@@ -353,8 +355,7 @@ const PluginPageRender: React.FC<PluginPageRenderProps> = ({ plugin_id, data, on
   // Kit / Runtime operations
   const SIGNAL_CONFIG_PATH = config.runtime?.signalConfigPath || '/app/remote_access/signal-config.json'
   const VSS_PATH = config.runtime?.vssPath || '/app/remote_access/vss.json'
-  const KIT_SERVER_URL = config.runtime?.url || 'https://kit.digitalauto.tech'
-
+  const KIT_SERVER_URL = runtimeServerUrl || config.runtime?.url || 'https://kit.digitalauto.teaaach'
   const handleFetchSignalMapping = useCallback((kitName: string): Promise<string> => {
     return new Promise((resolve, reject) => {
       const socket = io(KIT_SERVER_URL)


### PR DESCRIPTION
This pull request introduces a new "forceKitId" feature to the `DaRuntimeConnector` component, allowing the UI to track and display the status of a specific runtime (kit), even if it's offline or doesn't match the usual filtering. It also improves configuration flexibility by using the `useSiteConfig` hook to set the runtime server URL in several places. The main changes are grouped below:

### ForceKitId Feature and Runtime Status Display

* Added a new optional `forceKitId` prop to `DaRuntimeConnector`, enabling the component to always include and show the status of a specific kit, regardless of its online status or prefix. The UI now displays a status indicator ("Connected", "Disconnected", "Unreachable", or "Connecting...") for the forced kit. [[1]](diffhunk://#diff-e0d8b62484e9acf8ee1e4e5049e9e11b1815b088029f543a8ac93f8d637d6c2aR34) [[2]](diffhunk://#diff-e0d8b62484e9acf8ee1e4e5049e9e11b1815b088029f543a8ac93f8d637d6c2aR54) [[3]](diffhunk://#diff-e0d8b62484e9acf8ee1e4e5049e9e11b1815b088029f543a8ac93f8d637d6c2aR393-R410) [[4]](diffhunk://#diff-e0d8b62484e9acf8ee1e4e5049e9e11b1815b088029f543a8ac93f8d637d6c2aR621-R656)
* Updated the runtime filtering logic so that when `forceKitId` is set, all runtimes are included (not just online ones), and prefix filtering is bypassed.
* Added and managed a `hasLoadedKitList` state to help determine when the kit list is loaded for accurate status display. [[1]](diffhunk://#diff-e0d8b62484e9acf8ee1e4e5049e9e11b1815b088029f543a8ac93f8d637d6c2aR77) [[2]](diffhunk://#diff-e0d8b62484e9acf8ee1e4e5049e9e11b1815b088029f543a8ac93f8d637d6c2aR364) [[3]](diffhunk://#diff-e0d8b62484e9acf8ee1e4e5049e9e11b1815b088029f543a8ac93f8d637d6c2aR393-R410)

### Configuration Improvements

* Replaced direct usage of the `config.runtime.url` value with the `useSiteConfig` hook in both `FormHardwareKitManager` and `PluginPageRender`, making the runtime server URL configurable via site settings. [[1]](diffhunk://#diff-8d414cc9c18100c04f4a103c106c05fd162b34cebabdcca81c238e60ff7481c8R10) [[2]](diffhunk://#diff-8d414cc9c18100c04f4a103c106c05fd162b34cebabdcca81c238e60ff7481c8R205) [[3]](diffhunk://#diff-8d414cc9c18100c04f4a103c106c05fd162b34cebabdcca81c238e60ff7481c8L245-R249) [[4]](diffhunk://#diff-da6ff398bcba7362914a94ffae896432694b4bb62ec5b21c50f07483195cafc6R37) [[5]](diffhunk://#diff-da6ff398bcba7362914a94ffae896432694b4bb62ec5b21c50f07483195cafc6R69) [[6]](diffhunk://#diff-da6ff398bcba7362914a94ffae896432694b4bb62ec5b21c50f07483195cafc6L356-R358)

### Miscellaneous

* Added a debug log for the kit server URL in `DaRuntimeConnector` for easier troubleshooting.

These changes collectively make the runtime connection UI more robust and configurable, especially for scenarios where a specific kit must be tracked regardless of its online status.