### PR TITLE
Fix staging button missing

### DIFF
--- a/frontend/src/components/molecules/PrototypeRightActionButtons.tsx
+++ b/frontend/src/components/molecules/PrototypeRightActionButtons.tsx
@@ -6,8 +6,14 @@ import { renderTabIcon } from '@/lib/tabUtils'
 import { cn } from '@/lib/utils'
 import { useNavigate, useParams } from 'react-router-dom'
 
+const DEFAULT_STAGING_TAB: TabConfig = {
+  builtin: 'staging',
+  label: 'Staging',
+  type: 'builtin',
+}
+
 export interface PrototypeRightActionButtonProps {
-  tabs: TabConfig[]
+  tabs?: TabConfig[]
   onClick?: (tabConfig: TabConfig) => void
 }
 
@@ -83,10 +89,18 @@ const PrototypeRightActionButtons = ({
 }: PrototypeRightActionButtonProps) => {
   const { model_id, prototype_id } = useParams()
   const navigate = useNavigate()
-  const visibleTabs = tabs.filter((t) => !t.hidden)
+  const rawTabs = tabs ?? []
+  const visibleTabs = rawTabs.filter((t) => !t.hidden)
+  const hasStagingEntry = rawTabs.some((t) => t.builtin === 'staging')
+  const displayTabs =
+    tabs === undefined
+      ? [DEFAULT_STAGING_TAB]
+      : hasStagingEntry
+        ? visibleTabs
+        : [DEFAULT_STAGING_TAB, ...visibleTabs]
   return (
     <div className="flex items-center gap-2">
-      {visibleTabs.map((tabConfig) => {
+      {displayTabs.map((tabConfig) => {
         return (
           <PrototypeRightActionButton
             key={`right-actions-btn-${JSON.stringify(tabConfig)}`}

--- a/frontend/src/components/organisms/CustomTabEditor.tsx
+++ b/frontend/src/components/organisms/CustomTabEditor.tsx
@@ -88,6 +88,30 @@ export interface RightNavPluginButton {
   corners?: 'none' | 'round' | 'full'
 }
 
+export const DEFAULT_STAGING_RIGHT_NAV_BUTTON: RightNavPluginButton = {
+  builtin: 'staging',
+  label: 'Staging',
+}
+
+export function ensureStagingRightNavButton(
+  buttons: RightNavPluginButton[] = [],
+  stagingConfig?: StagingConfig,
+): RightNavPluginButton[] {
+  if (buttons.some((b) => b.builtin === 'staging')) return buttons
+  return [
+    {
+      ...DEFAULT_STAGING_RIGHT_NAV_BUTTON,
+      label: stagingConfig?.label || DEFAULT_STAGING_RIGHT_NAV_BUTTON.label,
+      iconSvg: stagingConfig?.iconSvg,
+      hideIcon: stagingConfig?.hideIcon,
+      variant: stagingConfig?.variant,
+      corners: stagingConfig?.corners,
+      hidden: stagingConfig?.hidden,
+    },
+    ...buttons,
+  ]
+}
+
 export type TabsBorderRadius = 'none' | 'round' | 'full'
 
 interface CustomTabEditorProps {
@@ -140,7 +164,7 @@ const CustomTabEditor: FC<CustomTabEditorProps> = ({
     useState<TabsBorderRadius>(tabsBorderRadius || 'round')
   const [localRightNavPlugins, setLocalRightNavPlugins] = useState<
     RightNavPluginButton[]
-  >(rightNavButtons || [])
+  >(() => ensureStagingRightNavButton(rightNavButtons, stagingConfig))
   // Sidebar plugin state
   const [localSidebarPlugin, setLocalSidebarPlugin] = useState<string | null>(
     sidebarPlugin || null,
@@ -162,7 +186,9 @@ const CustomTabEditor: FC<CustomTabEditorProps> = ({
       setLocalSidebarPlugin(sidebarPlugin || null)
       setLocalTabsVariant(tabsVariant || 'tab')
       setLocalTabsBorderRadius(tabsBorderRadius || 'round')
-      setLocalRightNavPlugins(rightNavButtons || [])
+      setLocalRightNavPlugins(
+        ensureStagingRightNavButton(rightNavButtons, stagingConfig),
+      )
       setActiveDialogTab('tabs')
       setEditingIndex(null)
       setEditingLabel('')
@@ -263,9 +289,10 @@ const CustomTabEditor: FC<CustomTabEditorProps> = ({
       const borderRadiusChanged =
         localTabsBorderRadius !== (tabsBorderRadius || 'round')
       const mergedRightNav: RightNavPluginButton[] = [...localRightNavPlugins]
-      const originalRightNav: RightNavPluginButton[] = [
-        ...(rightNavButtons || []),
-      ]
+      const originalRightNav = ensureStagingRightNavButton(
+        rightNavButtons,
+        stagingConfig,
+      )
       const rightNavChanged =
         JSON.stringify(localRightNavPlugins) !==
         JSON.stringify(originalRightNav)
@@ -301,7 +328,9 @@ const CustomTabEditor: FC<CustomTabEditorProps> = ({
     setLocalSidebarPlugin(sidebarPlugin || null)
     setLocalTabsVariant(tabsVariant || 'tab')
     setLocalTabsBorderRadius(tabsBorderRadius || 'round')
-    setLocalRightNavPlugins(rightNavButtons || [])
+    setLocalRightNavPlugins(
+      ensureStagingRightNavButton(rightNavButtons, stagingConfig),
+    )
     setEditingIndex(null)
     setEditingLabel('')
     setEditingIconSvg('')

--- a/frontend/src/components/organisms/StagingTabButton.tsx
+++ b/frontend/src/components/organisms/StagingTabButton.tsx
@@ -25,7 +25,7 @@ const StagingTabButton = ({
   const stagingIcon = stagingConfig.hideIcon ? null : stagingConfig.iconSvg ? (
     renderTabIcon({ iconSvg: stagingConfig.iconSvg }, null)
   ) : (
-    <span className="size-5 mr-2">
+    <span className="size-5 mr-2 grid place-items-center">
       <TbListCheck />
     </span>
   )

--- a/frontend/src/components/organisms/TemplateForm.tsx
+++ b/frontend/src/components/organisms/TemplateForm.tsx
@@ -44,6 +44,7 @@ import {
   StagingConfig,
   RightNavPluginButton,
   TabsBorderRadius,
+  ensureStagingRightNavButton,
 } from '@/components/organisms/CustomTabEditor'
 import DOMPurify from 'dompurify'
 import { DaSelect, DaSelectItem } from '@/components/atoms/DaSelect'
@@ -169,19 +170,20 @@ export default function TemplateForm({
         ? cfg.prototype_right_nav_buttons
         : []
       const stagingItem = rightNavRaw.find((b) => b.builtin === 'staging')
-      if (stagingItem) {
-        setPrototypeStagingConfig({
-          label: stagingItem.label,
-          iconSvg: stagingItem.iconSvg,
-          hideIcon: stagingItem.hideIcon,
-          variant: stagingItem.variant,
-          hidden: stagingItem.hidden,
-          corners: stagingItem.corners,
-        })
-      } else {
-        setPrototypeStagingConfig({})
-      }
-      setPrototypeRightNavButtons(rightNavRaw)
+      const stagingItemConfig: StagingConfig = stagingItem
+        ? {
+            label: stagingItem.label,
+            iconSvg: stagingItem.iconSvg,
+            hideIcon: stagingItem.hideIcon,
+            variant: stagingItem.variant,
+            hidden: stagingItem.hidden,
+            corners: stagingItem.corners,
+          }
+        : {}
+      setPrototypeStagingConfig(stagingItemConfig)
+      setPrototypeRightNavButtons(
+        ensureStagingRightNavButton(rightNavRaw, stagingItemConfig),
+      )
     } else {
       setForm({
         name: '',
@@ -193,7 +195,7 @@ export default function TemplateForm({
       setModelTabs([])
       setPrototypeTabs([])
       setPrototypeStagingConfig({})
-      setPrototypeRightNavButtons([])
+      setPrototypeRightNavButtons(ensureStagingRightNavButton([]))
       setPrototypeTabsVariant('tab')
       setPrototypeTabsBorderRadius('round')
       setLocalSidebarPlugin(null)
@@ -219,7 +221,7 @@ export default function TemplateForm({
         setModelTabs([])
         setPrototypeTabs([])
         setPrototypeStagingConfig({})
-        setPrototypeRightNavButtons([])
+        setPrototypeRightNavButtons(ensureStagingRightNavButton([]))
         setPrototypeTabsBorderRadius('round')
         setLocalSidebarPlugin(null)
       }
@@ -269,7 +271,21 @@ export default function TemplateForm({
       )
         ? fullConfig.prototype_right_nav_buttons
         : []
-      setPrototypeRightNavButtons(rightNavRaw2)
+      const stagingItem2 = rightNavRaw2.find((b) => b.builtin === 'staging')
+      const stagingItemConfig2: StagingConfig = stagingItem2
+        ? {
+            label: stagingItem2.label,
+            iconSvg: stagingItem2.iconSvg,
+            hideIcon: stagingItem2.hideIcon,
+            variant: stagingItem2.variant,
+            hidden: stagingItem2.hidden,
+            corners: stagingItem2.corners,
+          }
+        : {}
+      setPrototypeStagingConfig(stagingItemConfig2)
+      setPrototypeRightNavButtons(
+        ensureStagingRightNavButton(rightNavRaw2, stagingItemConfig2),
+      )
     }
   }, [open, isCreate, initialData])
 

--- a/frontend/src/pages/PagePrototypeDetail.tsx
+++ b/frontend/src/pages/PagePrototypeDetail.tsx
@@ -74,7 +74,7 @@ const PagePrototypeDetail: FC<ViewPrototypeProps> = ({}) => {
   const pluginId = searchParams.get('plugid')
   const navigate = useNavigate()
   const { data: user } = useSelfProfileQuery()
-  const { data: model } = useCurrentModel()
+  const { data: model, isLoading: isModelLoading } = useCurrentModel()
   const { data: fetchedPrototype, isLoading: isPrototypeLoading } =
     useCurrentPrototype()
   const [prototype, setActivePrototype] = useModelStore((state) => [
@@ -415,7 +415,11 @@ const PagePrototypeDetail: FC<ViewPrototypeProps> = ({}) => {
           <div className="grow"></div>
           <PrototypeRightAction
             prototype={prototype}
-            actions={model?.custom_template?.prototype_right_nav_buttons || []}
+            actions={
+              isModelLoading
+                ? undefined
+                : (model?.custom_template?.prototype_right_nav_buttons ?? [])
+            }
           />
           {canConfigurePrototypeAddons && (
             <DropdownMenu open={moreMenuOpen} onOpenChange={setMoreMenuOpen}>

--- a/frontend/src/pages/PrototypeRightAction.tsx
+++ b/frontend/src/pages/PrototypeRightAction.tsx
@@ -8,7 +8,7 @@ import { useState } from 'react'
 
 export interface PrototypeRightActionProps {
   prototype: Prototype
-  actions: TabConfig[]
+  actions?: TabConfig[]
 }
 
 const PrototypeRightAction = ({
@@ -18,7 +18,7 @@ const PrototypeRightAction = ({
   const [openDialog, setOpenDialog] = useState('')
   return (
     <>
-      {actions.map((action) => {
+      {actions?.map((action) => {
         if (action.openMode === 'page') return null
         const dialogKey = JSON.stringify(action)
         return (


### PR DESCRIPTION
This pull request improves the consistency and reliability of the "Staging" right navigation button and tab across the prototype editor, template form, and prototype detail page. It introduces a utility to ensure the Staging button is always present (unless explicitly hidden)
