### PR TITLE
Fix feedback tab missing

### DIFF
--- a/frontend/src/components/molecules/PrototypeTabs.tsx
+++ b/frontend/src/components/molecules/PrototypeTabs.tsx
@@ -29,13 +29,31 @@ interface PrototypeTabsProps {
 
 
 // Default builtin tabs
-const DEFAULT_BUILTIN_TABS: TabConfig[] = [
+export const DEFAULT_BUILTIN_TABS: TabConfig[] = [
   { type: 'builtin', key: 'overview', label: 'Overview' },
   { type: 'builtin', key: 'journey', label: 'Customer Journey' },
   { type: 'builtin', key: 'code', label: 'SDV Code' },
   { type: 'builtin', key: 'dashboard', label: 'Dashboard' },
   { type: 'builtin', key: 'feedback', label: 'Feedback' },
 ]
+
+export function ensureDefaultBuiltinTabs(tabs: TabConfig[]): TabConfig[] {
+  const customTabs = tabs.filter((t) => t.type === 'custom')
+  const existingBuiltins = tabs.filter((t) => t.type === 'builtin')
+  const existingByKey = new Map(existingBuiltins.map((b) => [b.key, b]))
+
+  const mergedBuiltins = DEFAULT_BUILTIN_TABS.map(
+    (defaultTab) => existingByKey.get(defaultTab.key) ?? defaultTab,
+  )
+
+  const allPresent =
+    existingBuiltins.length === DEFAULT_BUILTIN_TABS.length &&
+    DEFAULT_BUILTIN_TABS.every((d) => existingByKey.has(d.key))
+
+  if (allPresent) return tabs
+
+  return [...mergedBuiltins, ...customTabs]
+}
 
 // Migration helper: convert old format to new format
 export const migrateTabConfig = (oldTabs?: Array<{ label: string; plugin: string }>): TabConfig[] => {
@@ -46,7 +64,7 @@ export const migrateTabConfig = (oldTabs?: Array<{ label: string; plugin: string
   // Check if it's already in new format (has 'type' property)
   const firstTab = oldTabs[0] as any
   if (firstTab && 'type' in firstTab) {
-    return oldTabs as TabConfig[]
+    return ensureDefaultBuiltinTabs(oldTabs as TabConfig[])
   }
 
   // Old format: prepend default builtin tabs.

--- a/frontend/src/components/organisms/CustomTabEditor.tsx
+++ b/frontend/src/components/organisms/CustomTabEditor.tsx
@@ -55,7 +55,7 @@ export interface CustomTab {
 
 export interface TabConfig {
   type: 'builtin' | 'custom'
-  key?: string // For builtin: 'overview' | 'journey' | 'code' | 'dashboard'
+  key?: string // For builtin: 'overview' | 'journey' | 'code' | 'dashboard' | 'feedback'
   label: string
   plugin?: string // For custom tabs only
   hidden?: boolean // If true, tab is hidden

--- a/frontend/src/components/organisms/TemplateForm.tsx
+++ b/frontend/src/components/organisms/TemplateForm.tsx
@@ -39,6 +39,7 @@ import {
 import { MdOutlineDoubleArrow } from 'react-icons/md'
 import { toast } from 'react-toastify'
 import { listPlugins, type Plugin } from '@/services/plugin.service'
+import { getTabConfig } from '@/components/molecules/PrototypeTabs'
 import {
   TabConfig,
   StagingConfig,
@@ -53,21 +54,6 @@ import {
   Droppable,
   DropResult,
 } from '@hello-pangea/dnd'
-
-// Template-safe normalizer: preserves full TabConfig without injecting default builtin tabs.
-// Used only inside TemplateForm so that the saved template contains exactly what was configured,
-// and builtin tabs that are not explicitly listed are NOT auto-added on the new model.
-const normalizeTabsForTemplate = (tabs?: any[]): TabConfig[] => {
-  if (!tabs || tabs.length === 0) return []
-  // Already new format (has 'type' field) — return as-is
-  if ('type' in tabs[0]) return tabs as TabConfig[]
-  // Old format ({ label, plugin }): convert to custom type only, no builtin defaults
-  return tabs.map((tab) => ({
-    type: 'custom' as const,
-    label: tab.label || '',
-    plugin: tab.plugin || '',
-  }))
-}
 
 type Props = {
   templateId?: string
@@ -154,11 +140,7 @@ export default function TemplateForm({
             }))
           : [],
       )
-      setPrototypeTabs(
-        Array.isArray(cfg.prototype_tabs)
-          ? normalizeTabsForTemplate(cfg.prototype_tabs)
-          : [],
-      )
+      setPrototypeTabs(getTabConfig(cfg.prototype_tabs))
       setPrototypeTabsVariant(cfg.prototype_tabs_variant || 'tab')
       setPrototypeTabsBorderRadius(cfg.prototype_tabs_border_radius || 'round')
       setLocalSidebarPlugin(cfg.prototype_sidebar_plugin || null)
@@ -191,7 +173,7 @@ export default function TemplateForm({
         config: {},
       })
       setModelTabs([])
-      setPrototypeTabs([])
+      setPrototypeTabs(getTabConfig([]))
       setPrototypeStagingConfig({})
       setPrototypeRightNavButtons([])
       setPrototypeTabsVariant('tab')
@@ -217,7 +199,7 @@ export default function TemplateForm({
           config: {},
         })
         setModelTabs([])
-        setPrototypeTabs([])
+        setPrototypeTabs(getTabConfig([]))
         setPrototypeStagingConfig({})
         setPrototypeRightNavButtons([])
         setPrototypeTabsBorderRadius('round')
@@ -257,7 +239,7 @@ export default function TemplateForm({
         })),
       )
       // Preserve full TabConfig structure (type, key, hidden) without adding default builtin tabs
-      setPrototypeTabs(normalizeTabsForTemplate(prototypeTabsFromConfig))
+      setPrototypeTabs(getTabConfig(prototypeTabsFromConfig))
       setPrototypeTabsVariant(fullConfig.prototype_tabs_variant || 'tab')
       setPrototypeTabsBorderRadius(
         fullConfig.prototype_tabs_border_radius || 'round',


### PR DESCRIPTION
This pull request improves how tab configurations are managed and migrated in the frontend, with a focus on ensuring consistency and correctness when handling default and custom tabs. The main changes are the introduction of a utility to guarantee all default builtin tabs are present, updates to the migration logic, and refactoring of tab normalization in the template form.