### PR TITLE
Fix monaco widget tooltip

### DIFF
--- a/frontend/src/components/molecules/CodeEditor.tsx
+++ b/frontend/src/components/molecules/CodeEditor.tsx
@@ -9,9 +9,8 @@
 import Editor from '@monaco-editor/react'
 import clsx from 'clsx'
 import { Spinner } from '../atoms/spinner'
-import { useEffect, useImperativeHandle, useRef, forwardRef } from 'react'
+import { useEffect, useImperativeHandle, useRef, forwardRef, useState } from 'react'
 import { useMonaco } from '@monaco-editor/react'
-import { useState } from 'react'
 
 export interface CodeEditorProps {
   code: string
@@ -95,7 +94,7 @@ const CodeEditor = forwardRef<CodeEditorHandle, CodeEditorProps>(function CodeEd
   }, [monaco])
 
   return (
-    <div className={clsx('flex flex-col h-full w-full overflow-hidden')}>
+    <div className={clsx('flex flex-col h-full w-full')}>
       {show && (
         <Editor
           key={language}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -141,6 +141,28 @@ select[aria-hidden='true'][tabindex='-1'] {
   transition: width 0.3s ease-in-out;
 }
 
+
+body .workbench-hover-container {
+  z-index: 10000;
+  overflow: visible;
+}
+
+body:has(.monaco-editor .find-widget.visible) .workbench-hover-container {
+  pointer-events: none !important;
+}
+
+body:has(.monaco-editor .find-widget.visible) .workbench-hover-container,
+body:has(.monaco-editor .find-widget.visible) .workbench-hover-container .hover-row,
+body:has(.monaco-editor .find-widget.visible) .workbench-hover-container .hover-contents,
+body:has(.monaco-editor .find-widget.visible) .workbench-hover-container .action-container,
+body:has(.monaco-editor .find-widget.visible) .workbench-hover-container .actions-container {
+  display: flex !important;
+  flex-flow: row nowrap !important;
+  gap: 6px !important;
+  align-items: center !important;
+  white-space: nowrap !important;
+}
+
 /* Animations */
 @keyframes slideOut {
   from {


### PR DESCRIPTION
This pull request makes improvements to the `CodeEditor` component and its styling, specifically to address the behavior and appearance of Monaco Editor's hover and find widgets. The main focus is on better handling of widget stacking and interaction when the find widget is visible.
