### PR TITLE
Exit dashboard fullscreen mode when unmount

### DIFF
--- a/frontend/src/components/molecules/dashboard/DaDashboard.tsx
+++ b/frontend/src/components/molecules/dashboard/DaDashboard.tsx
@@ -76,6 +76,12 @@ const DaDashboard = () => {
     setShowPrototypeDashboardFullScreen,
   } = useSystemUI()
 
+  useEffect(() => {
+    return () => {
+      setShowPrototypeDashboardFullScreen(false)
+    }
+  }, [setShowPrototypeDashboardFullScreen])
+
   const originalWidgetConfigRef = useRef<string>('')
   const [pendingChanges, setPendingChanges] = useState(false)
   const { refetch } = useGetPrototype(prototype?.id || '')

--- a/frontend/src/components/molecules/dashboard/DaRuntimeControl.tsx
+++ b/frontend/src/components/molecules/dashboard/DaRuntimeControl.tsx
@@ -300,10 +300,10 @@ const DaRuntimeControl: FC = () => {
     <div
       data-id="runtime-control-panel"
       className={cn(
-        'bottom-0 right-0 z-10 flex flex-col px-1 py-1',
+        'right-0 z-10 flex flex-col px-1 py-1',
         showPrototypeDashboardFullScreen
-          ? 'fixed top-[58px]'
-          : 'absolute top-0',
+          ? 'fixed top-[58px] bottom-[22.55px]'
+          : 'absolute top-0 bottom-0',
         isExpand ? 'w-[500px]' : 'w-14',
       )}
       style={{

--- a/frontend/src/components/organisms/PrototypeTabDashboard.tsx
+++ b/frontend/src/components/organisms/PrototypeTabDashboard.tsx
@@ -19,7 +19,7 @@ const PrototypeTabDashboard: FC = ({}) => {
       className={cn(
         'w-full h-full relative border bg-white',
         showPrototypeDashboardFullScreen &&
-          'fixed top-0 left-0 w-screen h-screen',
+          'fixed top-0 left-0 w-screen h-[calc(100vh-22.55px)]',
       )}
     >
       <DaDashboard />


### PR DESCRIPTION
This pull request introduces improvements to the dashboard's fullscreen and layout handling to ensure consistent UI behavior, especially regarding the bottom panel's visibility and positioning. The changes focus on ensuring that when the dashboard is in fullscreen mode, the bottom area is properly accounted for and UI elements are reset appropriately.