### PR TITLE
docs(architecture): code-verify fixes (counts, rate-limit, token lifetime, startup, toJSON)

### DIFF
--- a/docs/architecture/auth-security.md
+++ b/docs/architecture/auth-security.md
@@ -12,7 +12,7 @@ the gap is flagged.
 
 | Token | Where it lives | Lifetime (default) | Persisted? |
 |---|---|---|---|
-| **Access** | Frontend **memory** (`authStore.access`), sent as `Authorization: Bearer` | 30 min (in **dev** the unit is overridden to *days*) | No |
+| **Access** | Frontend **memory** (`authStore.access`), sent as `Authorization: Bearer` | 30 min (production); in **dev** the unit is overridden to *days*, so it is 30 days | No |
 | **Refresh** | **HttpOnly cookie** (`JWT_COOKIE_NAME`, default `token`) | 30 days | Yes — `tokens` collection |
 | Reset-password / verify-email | — | 10 min | Yes — `tokens` collection |
 
@@ -187,8 +187,10 @@ back to the `STRICT_AUTH` env — `STRICT_AUTH=false` opens all flags,
   mitigation. *(Flagged for follow-up — tightening the real CSP is worth a
   dedicated task.)*
 - **`express-mongo-sanitize`** strips `$`/`.` keys (Mongo operator injection).
-- Body parsers capped at 50 MB; `authLimiter` rate-limits auth routes
-  (20 req / 15 min); central `errorConverter` + `errorHandler`.
+- Body parsers capped at 50 MB; central `errorConverter` + `errorHandler`.
+  > Note: an `authLimiter` (20 req / 15 min) is *defined* in
+  > `middlewares/rateLimiter.js` but is **not currently applied to any route**,
+  > so auth endpoints are effectively unrate-limited (see "Known gaps").
 
 ---
 
@@ -201,6 +203,9 @@ Called out honestly so newcomers don't assume more hardening than exists:
   [plugin-system.md](./plugin-system.md)) — iframe isolation is future work.
 - The **internal-plugin upload** route's admin permission check is currently
   commented out.
+- **Auth routes are not rate-limited** — `authLimiter` is defined in
+  `middlewares/rateLimiter.js` but not applied to any route (§6), so login /
+  register / etc. have no brute-force throttling.
 - Permission constants are duplicated on the frontend (§4).
 
 ---

--- a/docs/architecture/backend.md
+++ b/docs/architecture/backend.md
@@ -14,7 +14,7 @@ Runs on **`:3200`** in development (`yarn dev`, nodemon). See
 ## 1. Bootstrap & global middleware
 
 `src/index.js` connects Mongoose, runs startup scripts
-(`initializeRoles → assignAdmins → seedPredefinedSiteConfigs / seedProjectTemplates`),
+(`convertLogsCap → initializeRoles → assignAdmins → seedPredefinedSiteConfigs / seedProjectTemplates`),
 starts the HTTP server, initializes Socket.IO, and registers global
 `uncaughtException` / `unhandledRejection` handlers.
 

--- a/docs/architecture/frontend.md
+++ b/docs/architecture/frontend.md
@@ -19,8 +19,8 @@ shadcn/Radix-style primitives.
 | Layer | Path | Count | Role | Examples |
 |---|---|---|---|---|
 | **Atoms** | `components/atoms/` | ~44 | Primitives & small wrappers | `button.tsx`, `dialog.tsx`, `DaText.tsx`, `DaInput.tsx`, `DaTabItem.tsx`, `DaStarsRating.tsx`, `JsonEditor.tsx` |
-| **Molecules** | `components/molecules/` | ~63 | Compositions of atoms with light logic | `DaNavUser.tsx`, `PrototypeTabs.tsx`, `DaRuntimeConnector.tsx`, `DynamicSchemaForm.tsx`, + subfolders |
-| **Organisms** | `components/organisms/` | ~65 | Full feature sections | `NavigationBar.tsx`, `HomeHeroSection.tsx`, `PrototypeTabCode.tsx`, `PluginPageRender.tsx`, `UsersManagement.tsx` |
+| **Molecules** | `components/molecules/` | ~95 | Compositions of atoms with light logic | `DaNavUser.tsx`, `PrototypeTabs.tsx`, `DaRuntimeConnector.tsx`, `DynamicSchemaForm.tsx`, + subfolders |
+| **Organisms** | `components/organisms/` | ~63 | Full feature sections | `NavigationBar.tsx`, `HomeHeroSection.tsx`, `PrototypeTabCode.tsx`, `PluginPageRender.tsx`, `UsersManagement.tsx` |
 
 Molecules also group into feature subfolders: `forms/` (e.g. `FormCreateModel`,
 `FormSignIn`), `dashboard/` (`DaDashboard`, `DaDashboardGrid`,

--- a/docs/architecture/request-lifecycle.md
+++ b/docs/architecture/request-lifecycle.md
@@ -50,9 +50,10 @@ What each layer contributes:
    refresh cookie (`withCredentials`).
 4. **Backend pipeline** — `auth({ optional: PUBLIC_VIEWING }) → validate →
    controller → service → Mongoose`. Public models are readable without a token;
-   private ones 401/403.
-5. **Serialization** — the `toJSON` plugin renames `_id → id` and strips private
-   fields.
+   private ones 401/403. (`optional` may be a boolean or a function of `req`,
+   e.g. `(req) => req.authConfig.PUBLIC_VIEWING`.)
+5. **Serialization** — the `toJSON` plugin renames `_id → id`, strips private
+   fields, and remaps timestamps (`createdAt → created_at`, drops `updatedAt`).
 6. **Client state bridge** — `ModelDetailLayout` copies the query result into
    `modelStore`, which derives the supported API sets from the CVI so the rest of
    the workspace shares one source of truth.


### PR DESCRIPTION
## Summary

A code-verification pass over **`docs/architecture/`** — every concrete claim (paths, ports, counts, function names, behaviors) was cross-checked against the actual backend/frontend code.

**Overall: the architecture docs are highly accurate (~95%)** — the "code-verified" claim largely holds. This PR corrects the small set of factual inaccuracies found. **No code changed — documentation only.**

## Fixes

- **`frontend.md`** — molecule component count `~63` → **`~95`** (actual, including the 9 feature subfolders); organisms `~65` → `~63`. (Atoms `~44` was correct.)
- **`auth-security.md`** — access-token lifetime is **30 min in production, 30 days in dev** (the dev override flips the unit to *days* but keeps the value 30) — the old "30 min (in dev … days)" read as 30 minutes.
- **`auth-security.md`** — `authLimiter` (20 req / 15 min) is **defined in `middlewares/rateLimiter.js` but not applied to any route**. The doc previously claimed auth routes are rate-limited; it now states the limiter is unused (see *Noted for follow-up*).
- **`backend.md`** — added `convertLogsCap` to the documented startup sequence (it runs before `initializeRoles` on every boot).
- **`request-lifecycle.md`** — the `toJSON` plugin also **remaps timestamps** (`createdAt → created_at`, drops `updatedAt`); and `auth({ optional })` may take a **function of `req`** (e.g. `(req) => req.authConfig.PUBLIC_VIEWING`), not just a boolean.

## Noted for follow-up (code, not changed here)

- **`middlewares/rateLimiter.js`** — `authLimiter` is dead code; **auth endpoints are effectively unrate-limited** (minor security hardening gap). Wiring it onto `/v2/auth/*` is a small code change, kept out of this docs PR.
- **`backend/src/scripts/convertLogsCap.js`** — logs a non-fatal `ECONNRESET` while capping the `changelogs` collection on boot.
- **`backend/src/index.js`** — a comment says `PORT` "defaults to 8080", but `config.js` defaults it to **3200**.
- **`backend/src/models/discussion.model.js`** — `Discussion.ref` is a `String`, not an ObjectId `ref` (unlike `Feedback.ref`); the `data-model.md` ER diagram treats it as a relationship, which is fine conceptually but glosses the type.

## Verification

- Counts taken with `find frontend/src/components/<layer> -type f \( -name '*.tsx' -o -name '*.ts' \) | wc -l` → atoms 44, molecules 95, organisms 63.
- `grep -rn authLimiter backend/src` → defined + exported in `rateLimiter.js`, **zero** usages in routes.
- `config.js`: `if (config.env === 'development') config.jwt.accessExpirationUnit = 'days';` with value 30.
- `index.js` boot order and `discussion.model.js` `ref: { type: String }` confirmed by reading the files.

## Notes

- Commits signed off (`Tri Hua <tri2510@gmail.com>`).
- Deliberately scoped to the architecture docs; the `authLimiter` wiring and other code items are left for separate PRs.
