### PR TITLE
Enhance prototype filtering with last viewed options

### DIFF
--- a/frontend/src/components/organisms/PrototypeLibraryList.tsx
+++ b/frontend/src/components/organisms/PrototypeLibraryList.tsx
@@ -14,6 +14,7 @@ import { useParams, useNavigate } from 'react-router-dom'
 import { DaPrototypeItem } from '../molecules/DaPrototypeItem'
 import DaErrorDisplay from '../molecules/DaErrorDisplay'
 import DaSkeletonGrid from '../molecules/DaSkeletonGrid'
+import { getPrototypeLastViewed } from '@/utils/prototypeLastViewed'
 
 interface PrototypeLibraryListProps {
   selectedFilters?: string[]
@@ -54,6 +55,10 @@ const PrototypeLibraryList = ({
 
   useEffect(() => {
     if (!fetchedPrototypes) return
+    const lastViewed = getPrototypeLastViewed()
+    const compareNames = (a: Prototype, b: Prototype) =>
+      a.name.localeCompare(b.name)
+
     setFilteredPrototypes(
       fetchedPrototypes
         .filter((prototype) => {
@@ -63,15 +68,34 @@ const PrototypeLibraryList = ({
             .includes(searchInput.toLowerCase())
         })
         .sort((a: Prototype, b: Prototype) => {
-          const dateA = (a.createdAt) ? new Date(a.createdAt).getTime() : 0
-          const dateB = (b.createdAt) ? new Date(b.createdAt).getTime() : 0
+          const dateA = a.createdAt ? new Date(a.createdAt).getTime() : 0
+          const dateB = b.createdAt ? new Date(b.createdAt).getTime() : 0
 
           if (selectedFilters?.includes('Newest')) {
             return dateB - dateA
           } else if (selectedFilters?.includes('Oldest')) {
             return dateA - dateB
+          } else if (
+            selectedFilters?.includes('Last view') ||
+            selectedFilters?.includes('First view')
+          ) {
+            const lastViewedA = lastViewed[a.id]
+            const lastViewedB = lastViewed[b.id]
+            const hasViewedA = lastViewedA !== undefined
+            const hasViewedB = lastViewedB !== undefined
+
+            if (!hasViewedA && !hasViewedB) return compareNames(a, b)
+            if (!hasViewedA) return 1
+            if (!hasViewedB) return -1
+
+            const timestampDifference = selectedFilters.includes('Last view')
+              ? lastViewedB - lastViewedA
+              : lastViewedA - lastViewedB
+            return timestampDifference || compareNames(a, b)
           } else if (selectedFilters?.includes('Name A-Z')) {
-            return a.name.localeCompare(b.name)
+            return compareNames(a, b)
+          } else if (selectedFilters?.includes('Name Z-A')) {
+            return compareNames(b, a)
           } else if (selectedFilters?.includes('Rating')) {
             return (b.avg_score ?? 0) - (a.avg_score ?? 0)
           }

--- a/frontend/src/pages/PagePrototypeDetail.tsx
+++ b/frontend/src/pages/PagePrototypeDetail.tsx
@@ -52,6 +52,7 @@ import { saveRecentPrototype } from '@/services/prototype.service'
 import useModelStore from '@/stores/modelStore'
 import { Prototype } from '@/types/model.type'
 import { useSiteConfig } from '@/utils/siteConfig'
+import { recordPrototypeLastViewed } from '@/utils/prototypeLastViewed'
 import { useQueryClient } from '@tanstack/react-query'
 import { FC, useCallback, useEffect, useState } from 'react'
 import {
@@ -174,6 +175,12 @@ const PagePrototypeDetail: FC<ViewPrototypeProps> = ({}) => {
       setActivePrototype(fetchedPrototype)
     }
   }, [fetchedPrototype, setActivePrototype])
+
+  useEffect(() => {
+    if (fetchedPrototype?.id) {
+      recordPrototypeLastViewed(fetchedPrototype.id)
+    }
+  }, [fetchedPrototype?.id])
 
   useEffect(() => {
     if (!tab || tab === 'view') {

--- a/frontend/src/pages/PagePrototypeLibrary.tsx
+++ b/frontend/src/pages/PagePrototypeLibrary.tsx
@@ -202,12 +202,22 @@ const PagePrototypeLibrary = () => {
                   )}
                 </Button>
                 <DaFilter
-                  categories={{ 'Sort By': ['Newest', 'Oldest', 'Name A-Z', 'Rating'] }}
+                  categories={{
+                    'Sort By': [
+                      'Last view',
+                      'First view',
+                      'Newest',
+                      'Oldest',
+                      'Name A-Z',
+                      'Name Z-A',
+                      'Rating',
+                    ],
+                  }}
                   onChange={handleFilterChange}
                   className="w-fit mr-0 h-8 shadow px-2 text-sm"
                   singleSelect={true}
                   defaultValue={selectedFilters}
-                  label="Sort By"
+                  label={selectedFilters.length > 0 ? selectedFilters[0] : 'Newest'}
                 />
                 <div
                   className={cn(

--- a/frontend/src/utils/prototypeLastViewed.ts
+++ b/frontend/src/utils/prototypeLastViewed.ts
@@ -1,0 +1,42 @@
+const PROTOTYPE_LAST_VIEWED_KEY = 'prototype_last_viewed'
+
+export type PrototypeLastViewed = Record<string, number>
+
+export const getPrototypeLastViewed = (): PrototypeLastViewed => {
+  try {
+    const rawValue = localStorage.getItem(PROTOTYPE_LAST_VIEWED_KEY)
+    if (!rawValue) return {}
+
+    const parsedValue: unknown = JSON.parse(rawValue)
+    if (
+      !parsedValue ||
+      typeof parsedValue !== 'object' ||
+      Array.isArray(parsedValue)
+    ) {
+      return {}
+    }
+
+    return Object.fromEntries(
+      Object.entries(parsedValue).filter(
+        ([prototypeId, timestamp]) =>
+          prototypeId.length > 0 &&
+          typeof timestamp === 'number' &&
+          Number.isFinite(timestamp),
+      ),
+    )
+  } catch {
+    return {}
+  }
+}
+
+export const recordPrototypeLastViewed = (prototypeId: string) => {
+  if (!prototypeId) return
+
+  try {
+    const lastViewed = getPrototypeLastViewed()
+    lastViewed[prototypeId] = Date.now()
+    localStorage.setItem(PROTOTYPE_LAST_VIEWED_KEY, JSON.stringify(lastViewed))
+  } catch {
+    // Ignore unavailable storage and quota errors.
+  }
+}


### PR DESCRIPTION
This pull request adds the ability to sort prototypes by when they were last or first viewed, using local storage to track view history. It introduces utility functions for recording and retrieving the last viewed timestamps, updates the sorting logic in the prototype list, and enhances the filter options in the library UI.