### PR TITLE
Enhance ADMIN_EMAILS parsing to support semicolon

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -106,7 +106,7 @@ The API is available under the `/v2` prefix. Key endpoints include:
 | `EMAIL_ENDPOINT_URL`                    | Endpoint URL for the email service (default: Brevo)                                       | No       | None                                  | `email_api_endpoint_url`                      |
 | `GITHUB_CLIENT_ID`                      | Client ID for GitHub OAuth authentication                                                 | No       | None                                  | `github_client_id`                            |
 | `GITHUB_CLIENT_SECRET`                  | Client secret for GitHub OAuth authentication                                             | No       | None                                  | `github_client_secret`                        |
-| `ADMIN_EMAILS`                          | Comma-separated list of admin email addresses. Use for auto provisioning admin users.     | No       | None                                  | `admin1@example.com,admin2@example.com`       |
+| `ADMIN_EMAILS`                          | Comma- or semicolon-separated list of admin emails. Use for auto provisioning admin users. | No       | None                                  | `admin1@example.com;admin2@example.com`       |
 | `ADMIN_PASSWORD`                        | Password for admin access                                                                 | No       | None                                  | `admin_password`                              |
 | `LOGS_MAX_SIZE`                         | Maximum size of change logs in megabytes                                                  | No       | `100`                                 | `100`                                         |
 

--- a/backend/src/config/config.js
+++ b/backend/src/config/config.js
@@ -192,7 +192,10 @@ const config = {
   sso: {
     msGraphMeEndpoint: 'https://graph.microsoft.com/v1.0/me',
   },
-  adminEmails: envVars.ADMIN_EMAILS?.split(',') || [],
+  adminEmails:
+    envVars.ADMIN_EMAILS?.split(/[;,]/)
+      .map((email) => email.trim())
+      .filter(Boolean) || [],
   adminPassword: envVars.ADMIN_PASSWORD,
   logsMaxSize: envVars.LOGS_MAX_SIZE,
   fileUpload: {

--- a/backend/src/docs/environment-variables.md
+++ b/backend/src/docs/environment-variables.md
@@ -29,7 +29,7 @@ The `CORS_ORIGINS` variable accepts comma-separated regex patterns. The system a
 | `JWT_REFRESH_EXPIRATION_DAYS`   | Refresh token expiration (days)         | `30`    |
 | `JWT_COOKIE_NAME`               | JWT cookie name                         | `token` |
 | `JWT_COOKIE_DOMAIN`             | JWT cookie domain (production only)     | -       |
-| `ADMIN_EMAILS`                  | Admin email addresses (comma-separated) | -       |
+| `ADMIN_EMAILS`                  | Admin emails (comma- or semicolon-separated) | -       |
 | `ADMIN_PASSWORD`                | Auto-provisioned admin password         | -       |
 | `GITHUB_CLIENT_ID`              | GitHub OAuth client ID                  | -       |
 | `GITHUB_CLIENT_SECRET`          | GitHub OAuth client secret              | -       |


### PR DESCRIPTION
This pull request updates how the `ADMIN_EMAILS` environment variable is handled and documented. The main improvement is expanding support for both comma- and semicolon-separated admin email lists, ensuring more flexible configuration and clearer documentation.