### PR TITLE
Update socket message read_file to read-file, write_file to write-file And remove toLowerCase in kitId

### DIFF
--- a/docs/architecture/realtime-signals.md
+++ b/docs/architecture/realtime-signals.md
@@ -59,7 +59,7 @@ flowchart LR
 | C→S | `subscribe_apis` / `unsubscribe_apis` | subscribe only to the APIs a prototype uses (`usedAPIs`) |
 | C→S | `run_python_app` / `run_rust_app` / `run_cpp_app`, `stop_python_app`, `deploy_request` | run / stop / deploy prototype code |
 | C→S | `write_signals_value`, `set_vars_value` | write a signal/variable value to the kit |
-| C→S | `generate_vehicle_model`, `list_mock_signal`, `read_file`, `write_file` | manage the kit's VSS vehicle model, mocks, files |
+| C→S | `generate_vehicle_model`, `list_mock_signal`, `read-file`, `write-file` | manage the kit's VSS vehicle model, mocks, files |
 | S→C | `list-all-kits-result` | the kit list (filtered by `targetPrefix`, default `runtime-`) |
 | S→C | `messageToKit-kitReply` → `apis-value` | **the live signal stream** |
 | S→C | `messageToKit-kitReply` → `trace_vars`, run/deploy logs, exit codes | execution feedback |

--- a/frontend/src/components/molecules/DaRuntimeConnector.tsx
+++ b/frontend/src/components/molecules/DaRuntimeConnector.tsx
@@ -324,7 +324,7 @@ const DaRuntimeConnector = forwardRef<any, KitConnectProps>(
 
     const readFile = (filePath: string) => {
       socketio?.emit('messageToKit', {
-        cmd: 'read_file',
+        cmd: 'read-file',
         to_kit_id: activeRtId,
         data: filePath,
       })
@@ -332,7 +332,7 @@ const DaRuntimeConnector = forwardRef<any, KitConnectProps>(
 
     const writeFile = (filePath: string, fileContent: string) => {
       socketio?.emit('messageToKit', {
-        cmd: 'write_file',
+        cmd: 'write-file',
         to_kit_id: activeRtId,
         data: { path: filePath, content: fileContent },
       })
@@ -615,7 +615,7 @@ const DaRuntimeConnector = forwardRef<any, KitConnectProps>(
         onRuntimeStateResponse(payload)
       }
 
-      if (payload.cmd === 'read_file' && onReadFileResponse) {
+      if (payload.cmd === 'read-file' && onReadFileResponse) {
         onReadFileResponse(payload.data?.path || '', payload.data?.content || '')
       }
     }

--- a/frontend/src/components/organisms/PluginPageRender.tsx
+++ b/frontend/src/components/organisms/PluginPageRender.tsx
@@ -359,7 +359,7 @@ const PluginPageRender: React.FC<PluginPageRenderProps> = ({ plugin_id, data, on
   const handleFetchSignalMapping = useCallback((kitName: string): Promise<string> => {
     return new Promise((resolve, reject) => {
       const socket = io(KIT_SERVER_URL)
-      const kitId = kitName.toLowerCase()
+      const kitId = kitName
       let settled = false
 
       const finish = (fn: () => void) => {
@@ -395,7 +395,7 @@ const PluginPageRender: React.FC<PluginPageRenderProps> = ({ plugin_id, data, on
   const handleFetchVss = useCallback((kitName: string): Promise<string> => {
     return new Promise((resolve, reject) => {
       const socket = io(KIT_SERVER_URL)
-      const kitId = kitName.toLowerCase()
+      const kitId = kitName
       let settled = false
 
       const finish = (fn: () => void) => {
@@ -431,7 +431,7 @@ const PluginPageRender: React.FC<PluginPageRenderProps> = ({ plugin_id, data, on
   const handleReplaceVss = useCallback((kitName: string, vssContent: string): Promise<void> => {
     return new Promise((resolve, reject) => {
       const socket = io(KIT_SERVER_URL)
-      const kitId = kitName.toLowerCase()
+      const kitId = kitName
       let settled = false
 
       const finish = (fn: () => void) => {
@@ -469,7 +469,7 @@ const PluginPageRender: React.FC<PluginPageRenderProps> = ({ plugin_id, data, on
 
     return new Promise((resolve, reject) => {
       const socket = io(KIT_SERVER_URL)
-      const kitId = kitName.toLowerCase()
+      const kitId = kitName
       let settled = false
 
       const finish = (fn: () => void) => {

--- a/frontend/src/components/organisms/PluginPageRender.tsx
+++ b/frontend/src/components/organisms/PluginPageRender.tsx
@@ -375,11 +375,11 @@ const PluginPageRender: React.FC<PluginPageRenderProps> = ({ plugin_id, data, on
 
       socket.on('connect', () => {
         socket.emit('register_client', { username: 'plugin', user_id: 'plugin', domain: 'domain' })
-        socket.emit('messageToKit', { cmd: 'read_file', to_kit_id: kitId, data: SIGNAL_CONFIG_PATH })
+        socket.emit('messageToKit', { cmd: 'read-file', to_kit_id: kitId, data: SIGNAL_CONFIG_PATH })
       })
 
       socket.on('messageToKit-kitReply', (payload: any) => {
-        if (payload?.cmd === 'read_file') {
+        if (payload?.cmd === 'read-file') {
           clearTimeout(timeout)
           finish(() => resolve(payload.data?.content || ''))
         }
@@ -411,11 +411,11 @@ const PluginPageRender: React.FC<PluginPageRenderProps> = ({ plugin_id, data, on
 
       socket.on('connect', () => {
         socket.emit('register_client', { username: 'plugin', user_id: 'plugin', domain: 'domain' })
-        socket.emit('messageToKit', { cmd: 'read_file', to_kit_id: kitId, data: VSS_PATH })
+        socket.emit('messageToKit', { cmd: 'read-file', to_kit_id: kitId, data: VSS_PATH })
       })
 
       socket.on('messageToKit-kitReply', (payload: any) => {
-        if (payload?.cmd === 'read_file') {
+        if (payload?.cmd === 'read-file') {
           clearTimeout(timeout)
           finish(() => resolve(payload.data?.content || ''))
         }
@@ -444,7 +444,7 @@ const PluginPageRender: React.FC<PluginPageRenderProps> = ({ plugin_id, data, on
       socket.on('connect', () => {
         socket.emit('register_client', { username: 'plugin', user_id: 'plugin', domain: 'domain' })
         socket.emit('messageToKit', {
-          cmd: 'write_file',
+          cmd: 'write-file',
           to_kit_id: kitId,
           data: { path: VSS_PATH, content: vssContent },
         })
@@ -485,7 +485,7 @@ const PluginPageRender: React.FC<PluginPageRenderProps> = ({ plugin_id, data, on
 
           // 1. Write signal mapping
           socket.emit('messageToKit', {
-            cmd: 'write_file',
+            cmd: 'write-file',
             to_kit_id: kitId,
             data: { path: SIGNAL_CONFIG_PATH, content: fileContent },
           })
@@ -495,7 +495,7 @@ const PluginPageRender: React.FC<PluginPageRenderProps> = ({ plugin_id, data, on
           const vssJson = JSON.stringify(vssData)
 
           socket.emit('messageToKit', {
-            cmd: 'write_file',
+            cmd: 'write-file',
             to_kit_id: kitId,
             data: { path: VSS_PATH, content: vssJson },
           })


### PR DESCRIPTION
This pull request standardizes the command naming convention for file operations in both the frontend and documentation, changing `read_file` and `write_file` to `read-file` and `write-file`. It also updates the way kit IDs are handled in several functions, removing the automatic `.toLowerCase()` transformation to preserve the original casing. These changes improve consistency and prevent potential issues with kit ID mismatches.
