### PR TITLE
Add syncWithCode functionality to dashboard widgets

### DIFF
--- a/frontend/src/components/molecules/dashboard/DaDashboard.tsx
+++ b/frontend/src/components/molecules/dashboard/DaDashboard.tsx
@@ -49,6 +49,23 @@ import {
 } from '@/components/atoms/dropdown-menu'
 import DaDialog from '@/components/molecules/DaDialog'
 import { useSiteConfig } from '@/utils/siteConfig'
+import { getUsedVehicleApiNames, applySyncWithCodeToOptions } from '@/hooks/useUsedVehicleApisFromCode'
+
+const processWidgetItems = (widgetItems: any[], usedApiNames: string[]) => {
+  if (!widgetItems) return
+  widgetItems.forEach((widget) => {
+    if (!widget?.url) {
+      if (widget.options?.url) {
+        widget.url = widget.options.url
+      } else if (widget.path) {
+        widget.url = widget.path
+      }
+    }
+    if (widget.options) {
+      applySyncWithCodeToOptions(widget.options, usedApiNames)
+    }
+  })
+}
 
 const DaDashboard = () => {
   const { data: model } = useCurrentModel()
@@ -59,11 +76,13 @@ const DaDashboard = () => {
     setActivePrototype,
     prototypeHasUnsavedChanges,
     setPrototypeHasUnsavedChanges,
+    activeModelApis,
   ] = useModelStore((state) => [
     state.prototype as Prototype,
     state.setActivePrototype,
     state.prototypeHasUnsavedChanges,
     state.setPrototypeHasUnsavedChanges,
+    state.activeModelApis,
   ])
   const [widgetItems, setWidgetItems] = useState<any>([])
   const [mode, setMode] = useState<string>(MODE_RUN)
@@ -235,28 +254,14 @@ const DaDashboard = () => {
         console.error('Error parsing widget config', err)
       }
     }
-    //
-    processWidgetItems(widgetItems)
-    setWidgetItems(widgetItems)
-  }, [prototype?.widget_config, prototype?.extend?.selected_signals])
+    const usedApiNames = getUsedVehicleApiNames(
+      prototype?.code,
+      activeModelApis,
+    )
 
-  const processWidgetItems = (widgetItems: any[]) => {
-    if (!widgetItems) return
-    const selectedSignals = prototype?.extend?.selected_signals as string[] | undefined
-    widgetItems.forEach((widget) => {
-      if (!widget?.url) {
-        if (widget.options?.url) {
-          widget.url = widget.options.url
-        } else if (widget.path) {
-          widget.url = widget.path
-        }
-      }
-      if (selectedSignals?.length && (!widget.options?.apis || widget.options.apis.length === 0)) {
-        if (!widget.options) widget.options = {}
-        widget.options.apis = [...selectedSignals]
-      }
-    })
-  }
+    processWidgetItems(widgetItems, usedApiNames)
+    setWidgetItems(widgetItems)
+  }, [prototype?.widget_config, prototype?.code, activeModelApis])
 
   const handleEnterEditMode = () => {
     originalWidgetConfigRef.current = prototype?.widget_config || ''

--- a/frontend/src/components/molecules/dashboard/DaDashboardEditor.tsx
+++ b/frontend/src/components/molecules/dashboard/DaDashboardEditor.tsx
@@ -49,6 +49,7 @@ import DaWidgetList from '@/components/molecules/widgets/DaWidgetList'
 import useListMarketplaceWidgets from '@/hooks/useListMarketplaceWidgets'
 import { Input } from '@/components/atoms/input'
 import ModelApiList from '@/components/organisms/ModelApiList'
+import { getUsedVehicleApiNames, getUsedVehicleApis, applySyncWithCodeToOptions } from '@/hooks/useUsedVehicleApisFromCode'
 
 // Parse CVI once at module level — used as fallback API list when no model is loaded (e.g. template manager)
 let _defaultApis: VehicleApi[] | null = null
@@ -176,13 +177,14 @@ const DaDashboardWidgetEditor = ({
         delete options.iconURL
         delete options.url
       } catch (e) { }
-      const selectedSignals = prototype?.extend?.selected_signals as string[] | undefined
-      if (selectedSignals?.length && (!options.apis || options.apis.length === 0)) {
-        options.apis = [...selectedSignals]
-      }
+      const usedApiNames = getUsedVehicleApiNames(
+        localPrototype.code,
+        activeModelApis,
+      )
+      applySyncWithCodeToOptions(options, usedApiNames)
       setOptionStr(JSON.stringify(options, null, 4))
     }
-  }, [selectedWidget])
+  }, [selectedWidget, localPrototype.code, activeModelApis])
 
   useEffect(() => {
     if (isWizard) {
@@ -198,15 +200,10 @@ const DaDashboardWidgetEditor = ({
       !activeModelApis ||
       activeModelApis.length === 0
     ) {
+      setUsedAPIs([])
       return
     }
-    let newUsedAPIsList = [] as string[]
-    activeModelApis.forEach((item) => {
-      if (localPrototype.code && localPrototype.code.includes(item.shortName)) {
-        newUsedAPIsList.push(item)
-      }
-    })
-    setUsedAPIs(newUsedAPIsList)
+    setUsedAPIs(getUsedVehicleApis(localPrototype.code, activeModelApis))
   }, [localPrototype.code, activeModelApis])
 
   const copyAllSignals = () => {
@@ -398,8 +395,8 @@ const DaWidgetLibrary: FC<DaWidgetLibraryProp> = ({
   popupState,
   targetSelectionCells,
 }) => {
-  const [prototype] = useModelStore(
-    (state: any) => [state.prototype as Prototype],
+  const [prototype, activeModelApis] = useModelStore(
+    (state: any) => [state.prototype as Prototype, state.activeModelApis],
     shallow,
   )
   const { data: user } = useSelfProfileQuery()
@@ -454,10 +451,14 @@ const DaWidgetLibrary: FC<DaWidgetLibraryProp> = ({
         options = activeWidget.options ? JSON.parse(JSON.stringify(activeWidget.options)) : {}
       }
 
-      const selectedSignals = prototype?.extend?.selected_signals as string[] | undefined
-      if (selectedSignals?.length && (!options.apis || options.apis.length === 0)) {
-        options.apis = [...selectedSignals]
+      const usedApiNames = getUsedVehicleApiNames(
+        prototype?.code,
+        activeModelApis,
+      )
+      if (activeWidget.plugin === 'Builtin') {
+        options.syncWithCode = true
       }
+      applySyncWithCodeToOptions(options, usedApiNames)
 
       if (activeTab === 'market') {
         options['iconURL'] = activeWidget.icon

--- a/frontend/src/components/molecules/dashboard/DaRuntimeControl.tsx
+++ b/frontend/src/components/molecules/dashboard/DaRuntimeControl.tsx
@@ -39,6 +39,7 @@ import DaMockManager from './DaMockManager'
 import PrototypeVarsWatch from './PrototypeVarsWatch'
 import DaRemoteCompileRust from '../remote-compiler/DaRemoteCompileRust'
 import { useSystemUI } from '@/hooks/useSystemUI'
+import { getUsedVehicleApiNames } from '@/hooks/useUsedVehicleApisFromCode'
 
 const AlwaysScrollToBottom = () => {
   const elementRef = useRef<HTMLDivElement>(null)
@@ -150,18 +151,20 @@ const DaRuntimeControl: FC = () => {
       return
     }
     let dashboardCfg = prototype?.widget_config || ''
-    let apis: any[] = []
+    const apis = new Set<string>(
+      getUsedVehicleApiNames(code, activeModelApis),
+    )
     activeModelApis.forEach((item: any) => {
       if (item.shortName) {
         if (
           code.includes(item.shortName) ||
           dashboardCfg.includes(item.shortName)
         ) {
-          apis.push(item.name)
+          apis.add(item.name)
         }
       }
     })
-    setUsedApis(apis)
+    setUsedApis(Array.from(apis))
   }, [code, activeModelApis, prototype?.widget_config])
 
   const handleRun = () => {

--- a/frontend/src/components/molecules/widgets/DaWidgetList.tsx
+++ b/frontend/src/components/molecules/widgets/DaWidgetList.tsx
@@ -16,6 +16,7 @@ import { searchWidget, loadWidgetReviews } from '@/services/widget.service'
 import { DaImage } from '@/components/atoms/DaImage'
 import useModelStore from '@/stores/modelStore'
 import { Prototype } from '@/types/model.type'
+import { getUsedVehicleApiNames, applySyncWithCodeToOptions } from '@/hooks/useUsedVehicleApisFromCode'
 
 interface DaWidgetListProps {
   renderWidgets: any[]
@@ -29,6 +30,7 @@ const DaWidgetList: FC<DaWidgetListProps> = ({
   activeTab,
 }) => {
   const prototype = useModelStore((state) => state.prototype as Prototype)
+  const activeModelApis = useModelStore((state) => state.activeModelApis)
   const [searchText, setSearchText] = useState<string>('')
   const [optionsStr, setOptionStr] = useState<string>('')
   const [widgetReviews, setWidgetReviews] = useState<any[]>([])
@@ -75,15 +77,16 @@ const DaWidgetList: FC<DaWidgetListProps> = ({
     if (activeWidget && activeWidget.options) {
       let options = JSON.parse(JSON.stringify(activeWidget.options))
       delete options.url
-      const selectedSignals = prototype?.extend?.selected_signals as string[] | undefined
-      if (selectedSignals?.length && (!options.apis || options.apis.length === 0)) {
-        options.apis = [...selectedSignals]
-      }
+      const usedApiNames = getUsedVehicleApiNames(
+        prototype?.code,
+        activeModelApis,
+      )
+      applySyncWithCodeToOptions(options, usedApiNames)
       setOptionStr(JSON.stringify(options, null, 4))
     } else {
       setOptionStr('{}')
     }
-  }, [activeWidget, prototype?.extend?.selected_signals])
+  }, [activeWidget, prototype?.code, activeModelApis])
 
   return (
     <div className="flex w-full h-full space-x-2">

--- a/frontend/src/data/builtinWidgets.ts
+++ b/frontend/src/data/builtinWidgets.ts
@@ -32,10 +32,8 @@ const BUILT_IN_WIDGETS = [
     path: '/builtin-widgets/chart-signals/index.html',
     desc: 'Visualize multiple signals in one chart',
     options: {
-      apis: [
-        'Vehicle.Cabin.HVAC.Station.Row1.Driver.FanSpeed',
-        'Vehicle.Cabin.HVAC.Station.Row1.Passenger.FanSpeed',
-      ],
+      syncWithCode: true,
+      apis: [],
       dataUpdateInterval: 1000,
       maxDataPoints: 60,
       iconURL: '/builtin-widgets/chart-signals/chart-signals.png',
@@ -50,10 +48,8 @@ const BUILT_IN_WIDGETS = [
     path: '/builtin-widgets/signal-list-settable/index.html',
     desc: 'Display and modify multiple vehicle signals',
     options: {
-      apis: [
-        'Vehicle.Cabin.HVAC.Station.Row1.Driver.FanSpeed',
-        'Vehicle.Cabin.HVAC.Station.Row1.Passenger.FanSpeed',
-      ],
+      syncWithCode: true,
+      apis: [],
       iconURL: '/builtin-widgets/signal-list-settable/signal-list-settable.png',
     },
   },

--- a/frontend/src/hooks/useUsedVehicleApisFromCode.ts
+++ b/frontend/src/hooks/useUsedVehicleApisFromCode.ts
@@ -1,0 +1,57 @@
+// Copyright (c) 2025 Eclipse Foundation.
+//
+// This program and the accompanying materials are made available under the
+// terms of the MIT License which is available at
+// https://opensource.org/licenses/MIT.
+//
+// SPDX-License-Identifier: MIT
+
+import { filterAndCompareVehicleApis } from '@/lib/vehicleApiUtils'
+
+export const getUsedVehicleApiNames = (
+  code: string | undefined,
+  activeModelApis?: any[],
+): string[] => {
+  if (!code || !activeModelApis || activeModelApis.length === 0) {
+    return []
+  }
+
+  const { apisInModel } = filterAndCompareVehicleApis(code, activeModelApis)
+  return apisInModel
+}
+
+export const getUsedVehicleApis = (
+  code: string | undefined,
+  activeModelApis?: any[],
+): any[] => {
+  if (!activeModelApis || activeModelApis.length === 0) {
+    return []
+  }
+
+  const apiNames = new Set(getUsedVehicleApiNames(code, activeModelApis))
+  return activeModelApis.filter((item: any) => apiNames.has(item.name))
+}
+
+export const applySyncWithCodeToOptions = (
+  options: Record<string, any>,
+  usedApiNames: string[],
+): void => {
+  if (!options?.syncWithCode || usedApiNames.length === 0) return
+
+  if ('apis' in options) {
+    options.apis = [...usedApiNames]
+  }
+
+  if ('api' in options) {
+    options.api = usedApiNames[0]
+  }
+
+  const signalKeys = Object.keys(options).filter((key) => key.endsWith('Signal'))
+  if (signalKeys.length > 0 && !('apis' in options) && !('api' in options)) {
+    signalKeys.forEach((key, index) => {
+      if (usedApiNames[index]) {
+        options[key] = usedApiNames[index]
+      }
+    })
+  }
+}


### PR DESCRIPTION
This pull request refactors how vehicle APIs are detected and synchronized with widgets across the dashboard and widget editor components. The main change is the introduction of new utility functions—`getUsedVehicleApiNames`, `getUsedVehicleApis`, and `applySyncWithCodeToOptions`—which centralize and standardize the logic for extracting and applying used vehicle APIs from code. This improves maintainability, reduces duplication, and ensures consistent behavior in widget configuration.
