### PR TITLE
Disable staging button when prototype code is empty

### DIFF
--- a/frontend/src/components/molecules/PrototypeRightActionButtons.tsx
+++ b/frontend/src/components/molecules/PrototypeRightActionButtons.tsx
@@ -15,17 +15,21 @@ const DEFAULT_STAGING_TAB: TabConfig = {
 export interface PrototypeRightActionButtonProps {
   tabs?: TabConfig[]
   onClick?: (tabConfig: TabConfig) => void
+  stagingDisabled?: boolean
+  stagingDisabledTitle?: string
 }
 
 export const PrototypeRightActionButton = ({
   config,
   disabled,
+  title,
   onClick,
 }: {
   config: TabConfig & {
     iconElement?: React.ReactNode
   }
   disabled?: boolean
+  title?: string
   onClick?: () => void
 }) => {
   const icon = !config.hideIcon
@@ -48,6 +52,7 @@ export const PrototypeRightActionButton = ({
           corners: config.corners,
         }}
         disabled={disabled}
+        title={title}
         onClick={onClick}
       />
     )
@@ -86,6 +91,8 @@ export const PrototypeRightActionButton = ({
 const PrototypeRightActionButtons = ({
   tabs,
   onClick,
+  stagingDisabled,
+  stagingDisabledTitle,
 }: PrototypeRightActionButtonProps) => {
   const { model_id, prototype_id } = useParams()
   const navigate = useNavigate()
@@ -101,13 +108,18 @@ const PrototypeRightActionButtons = ({
   return (
     <div className="flex items-center gap-2">
       {displayTabs.map((tabConfig) => {
+        const isStaging = tabConfig.builtin === 'staging'
         return (
           <PrototypeRightActionButton
             key={`right-actions-btn-${JSON.stringify(tabConfig)}`}
             config={tabConfig}
+            disabled={isStaging ? stagingDisabled : undefined}
+            title={isStaging ? stagingDisabledTitle : undefined}
             onClick={
               tabConfig.openMode === 'dialog'
-                ? () => onClick?.(tabConfig)
+                ? stagingDisabled && isStaging
+                  ? undefined
+                  : () => onClick?.(tabConfig)
                 : tabConfig.type === 'builtin' || tabConfig.builtin
                   ? undefined
                   : () =>

--- a/frontend/src/components/organisms/PrototypeTabCode.tsx
+++ b/frontend/src/components/organisms/PrototypeTabCode.tsx
@@ -213,11 +213,10 @@ const PrototypeTabCode: FC = () => {
     let dataToSave: string | undefined
     if (codeToSave !== undefined) {
       // Explicit save from editor (Save All or Ctrl+S) — always persist, do not skip
-      if (!codeToSave) return
       dataToSave = codeToSave
     } else {
       // Periodic auto-save — skip if unchanged
-      if (!code || code === savedCode) return
+      if (code === undefined || code === savedCode) return
       dataToSave = code
     }
 

--- a/frontend/src/components/organisms/StagingTabButton.tsx
+++ b/frontend/src/components/organisms/StagingTabButton.tsx
@@ -18,6 +18,7 @@ const StagingTabButton = ({
   onClick,
   disabled = false,
   active = false,
+  title,
 }: StagingTabButtonProps) => {
   const { model_id, prototype_id, tab } = useParams()
 
@@ -38,46 +39,67 @@ const StagingTabButton = ({
   const stagingTo = isRoutingBased
     ? `/model/${model_id}/library/prototype/${prototype_id}/staging`
     : '#'
-  if (stagingVariant === 'tab')
+
+  const buttonConfig = {
+    label: stagingLabel,
+    iconSvg: stagingConfig.iconSvg,
+    variant: stagingVariant,
+    corners: stagingConfig.corners,
+    hideIcon: stagingConfig.hideIcon,
+    iconElement: stagingIcon,
+    type: 'custom' as const,
+  }
+
+  if (stagingVariant === 'tab') {
+    if (disabled) {
+      return (
+        <span
+          title={title}
+          className="inline-flex h-full opacity-50 cursor-not-allowed"
+        >
+          <DaTabItem active={isActive} dataId="tab-staging">
+            {stagingIcon}
+            {stagingLabel}
+          </DaTabItem>
+        </span>
+      )
+    }
     return (
       <DaTabItem active={isActive} to={stagingTo} dataId="tab-staging">
         {stagingIcon}
         {stagingLabel}
       </DaTabItem>
     )
+  }
 
   if (isRoutingBased) {
+    if (disabled) {
+      return (
+        <span title={title} className="flex items-center self-center">
+          <PrototypeRightActionButton
+            config={buttonConfig}
+            disabled={disabled}
+            title={title}
+          />
+        </span>
+      )
+    }
     return (
       <Link to={stagingTo} className="flex items-center self-center">
-        <PrototypeRightActionButton
-          config={{
-            label: stagingLabel,
-            iconSvg: stagingConfig.iconSvg,
-            variant: stagingVariant,
-            corners: stagingConfig.corners,
-            iconElement: stagingIcon,
-            hideIcon: stagingConfig.hideIcon,
-            type: 'custom',
-          }}
-        />
+        <PrototypeRightActionButton config={buttonConfig} />
       </Link>
     )
   }
 
   return (
-    <PrototypeRightActionButton
-      disabled={disabled}
-      onClick={onClick}
-      config={{
-        label: stagingLabel,
-        iconSvg: stagingConfig.iconSvg,
-        variant: stagingVariant,
-        corners: stagingConfig.corners,
-        hideIcon: stagingConfig.hideIcon,
-        iconElement: stagingIcon,
-        type: 'custom',
-      }}
-    />
+    <span title={title} className="flex items-center self-center">
+      <PrototypeRightActionButton
+        disabled={disabled}
+        title={title}
+        onClick={onClick}
+        config={buttonConfig}
+      />
+    </span>
   )
 }
 

--- a/frontend/src/lib/prototypeCodeUtils.ts
+++ b/frontend/src/lib/prototypeCodeUtils.ts
@@ -1,0 +1,10 @@
+export function hasPrototypeCode(code?: string | null): boolean {
+  if (!code?.trim()) return false
+  try {
+    const parsed = JSON.parse(code)
+    if (Array.isArray(parsed)) return parsed.length > 0
+  } catch {
+    /* plain source */
+  }
+  return true
+}

--- a/frontend/src/pages/PagePrototypeDetail.tsx
+++ b/frontend/src/pages/PagePrototypeDetail.tsx
@@ -19,7 +19,6 @@ import { Spinner } from '@/components/atoms/spinner'
 import AddonSelect from '@/components/molecules/AddonSelect'
 import DaDialog from '@/components/molecules/DaDialog'
 import DaRuntimeControl from '@/components/molecules/dashboard/DaRuntimeControl'
-import PrototypeRightActionButtons from '@/components/molecules/PrototypeRightActionButtons'
 import PrototypeTabs, {
   getTabConfig,
 } from '@/components/molecules/PrototypeTabs'
@@ -42,6 +41,7 @@ import useCurrentPrototype from '@/hooks/useCurrentPrototype'
 import usePermissionHook from '@/hooks/usePermissionHook'
 import usePluginPreloader from '@/hooks/usePluginPreloader'
 import useSelfProfileQuery from '@/hooks/useSelfProfile'
+import { hasPrototypeCode } from '@/lib/prototypeCodeUtils'
 import PagePrototypePlugin from '@/pages/PagePrototypePlugin'
 import PrototypeRightAction from '@/pages/PrototypeRightAction'
 import { configManagementService } from '@/services/configManagement.service'
@@ -219,6 +219,22 @@ const PagePrototypeDetail: FC<ViewPrototypeProps> = ({}) => {
       }
     }
   }, [tab, prototypeTabs, model_id, prototype_id, navigate])
+
+  useEffect(() => {
+    if (
+      tab === 'staging' &&
+      model_id &&
+      prototype_id &&
+      !isPrototypeLoading &&
+      prototype &&
+      !hasPrototypeCode(prototype.code)
+    ) {
+      navigate(
+        `/model/${model_id}/library/prototype/${prototype_id}/code`,
+        { replace: true },
+      )
+    }
+  }, [tab, model_id, prototype_id, prototype, isPrototypeLoading, navigate])
 
   useEffect(() => {
     if (user && prototype && tab) {
@@ -474,7 +490,9 @@ const PagePrototypeDetail: FC<ViewPrototypeProps> = ({}) => {
             {tab == 'code' && <PrototypeTabCode />}
             {tab == 'dashboard' && <PrototypeTabDashboard />}
             {tab == 'feedback' && <PrototypeTabFeedback />}
-            {tab == 'staging' && <PrototypeTabStaging prototype={prototype} />}
+            {tab == 'staging' && hasPrototypeCode(prototype?.code) && (
+              <PrototypeTabStaging prototype={prototype} />
+            )}
 
             {/* Render ALL plugin components unconditionally - they stay mounted and cached */}
             {/* Only show the one that matches current tab and pluginId */}

--- a/frontend/src/pages/PrototypeRightAction.tsx
+++ b/frontend/src/pages/PrototypeRightAction.tsx
@@ -2,6 +2,7 @@ import DaDialog from '@/components/molecules/DaDialog'
 import PrototypeRightActionButtons from '@/components/molecules/PrototypeRightActionButtons'
 import { TabConfig } from '@/components/organisms/CustomTabEditor'
 import PrototypeTabStaging from '@/components/organisms/PrototypeTabStaging'
+import { hasPrototypeCode } from '@/lib/prototypeCodeUtils'
 import PagePrototypePlugin from '@/pages/PagePrototypePlugin'
 import { Prototype } from '@/types/model.type'
 import { useState } from 'react'
@@ -16,6 +17,10 @@ const PrototypeRightAction = ({
   actions,
 }: PrototypeRightActionProps) => {
   const [openDialog, setOpenDialog] = useState('')
+  const stagingDisabled = !hasPrototypeCode(prototype?.code)
+  const stagingDisabledTitle = stagingDisabled
+    ? 'Generate code first to enable staging'
+    : undefined
   return (
     <>
       {actions?.map((action) => {
@@ -47,6 +52,8 @@ const PrototypeRightAction = ({
       <PrototypeRightActionButtons
         tabs={actions}
         onClick={(action) => setOpenDialog(JSON.stringify(action))}
+        stagingDisabled={stagingDisabled}
+        stagingDisabledTitle={stagingDisabledTitle}
       />
     </>
   )


### PR DESCRIPTION
This pull request enhances the user experience and code safety around the "staging" feature in the prototype UI. It ensures that the staging tab and related actions are only enabled when valid prototype code exists, provides user feedback when staging is unavailable, and refactors logic for maintainability.
