### PR TITLE
Add useCanEditPrototype hook for managing edit permissions

### DIFF
--- a/frontend/src/components/organisms/PluginPageRender.tsx
+++ b/frontend/src/components/organisms/PluginPageRender.tsx
@@ -29,6 +29,7 @@ import {
 import useRuntimeStore from '@/stores/runtimeStore'
 import { configManagementService } from '@/services/configManagement.service'
 import usePermissionHook from '@/hooks/usePermissionHook'
+import useCanEditPrototype from '@/hooks/useCanEditPrototype'
 import { PERMISSIONS } from '@/data/permission'
 import type { PluginAPI } from '@/types/plugin.types'
 import type { Model, Prototype } from '@/types/model.type'
@@ -73,6 +74,7 @@ const PluginPageRender: React.FC<PluginPageRenderProps> = ({ plugin_id, data, on
   const prototype_id = data?.prototype?.id
 
   const [isAuthorized] = usePermissionHook([PERMISSIONS.WRITE_MODEL, model_id])
+  const canEditPrototype = useCanEditPrototype(data?.prototype)
 
   // Access runtime store for API values
   const { apisValue, setActiveApis } = useRuntimeStore()
@@ -1038,7 +1040,7 @@ const PluginPageRender: React.FC<PluginPageRenderProps> = ({ plugin_id, data, on
         <div key={`plugin-${plugin_id}-${loadedPluginName}`} className="w-full h-full">
           <PluginComponent
             data={data}
-            editable={isAuthorized}
+            editable={canEditPrototype}
             config={pluginConfig}
             api={pluginAPI}
           />

--- a/frontend/src/hooks/useCanEditPrototype.ts
+++ b/frontend/src/hooks/useCanEditPrototype.ts
@@ -1,0 +1,25 @@
+// Copyright (c) 2025 Eclipse Foundation.
+//
+// This program and the accompanying materials are made available under the
+// terms of the MIT License which is available at
+// https://opensource.org/licenses/MIT.
+//
+// SPDX-License-Identifier: MIT
+
+import useSelfProfileQuery from '@/hooks/useSelfProfile'
+import usePermissionHook from '@/hooks/usePermissionHook'
+import { PERMISSIONS } from '@/data/permission'
+import type { Prototype } from '@/types/model.type'
+
+/**
+ * Returns true iff the current user is the creator of the given prototype
+ * or an admin (MANAGE_USERS permission).
+ */
+const useCanEditPrototype = (prototype?: Prototype | null): boolean => {
+  const { data: user } = useSelfProfileQuery()
+  const [isAdmin] = usePermissionHook([PERMISSIONS.MANAGE_USERS])
+  if (!user || !prototype?.created_by?.id) return false
+  return user.id === prototype.created_by.id || isAdmin
+}
+
+export default useCanEditPrototype


### PR DESCRIPTION
This pull request introduces a new permission hook to determine edit access to prototypes and updates the `PluginPageRender` component to use this logic. The main goal is to ensure that only prototype creators or admins can edit prototypes, improving security and permission handling.
