### PR TITLE
Add sort by name to prototype service

### DIFF
--- a/backend/src/services/prototype.service.js
+++ b/backend/src/services/prototype.service.js
@@ -132,12 +132,31 @@ const bulkCreatePrototypes = async (userId, prototypes) => {
  * @returns {Promise<QueryResult>}
  */
 const queryPrototypes = async (filter, options) => {
+  const defaultSort = 'editors_choice:desc,createdAt:asc';
+  const requestedSort = options?.sortBy;
+  const requestedParts = requestedSort
+    ? requestedSort
+        .split(',')
+        .map((part) => part.trim())
+        .filter(Boolean)
+    : [];
+  const nameSort = requestedParts.find((part) => part.startsWith('name:'));
+
+  const resolvedSort = nameSort
+    ? [
+        nameSort,
+        ...defaultSort.split(','),
+        ...requestedParts.filter((part) => part !== nameSort),
+      ].join(',')
+    : requestedSort
+      ? [defaultSort, requestedSort].join(',')
+      : defaultSort;
+
   const prototypes = await Prototype.paginate(filter, {
     ...options,
-    // Default sort by editors_choice and createdAt
-    sortBy: options?.sortBy
-      ? ['editors_choice:desc,createdAt:asc', options.sortBy].join(',')
-      : 'editors_choice:desc,createdAt:asc',
+    // Default sort by editors_choice and createdAt, except name sort is promoted
+    // to primary to support correct alphabetical paging.
+    sortBy: resolvedSort,
   });
   return prototypes;
 };


### PR DESCRIPTION
When clients request name:asc or name:desc, promote that sort to primary so alphabetical paging works correctly across paginated results.