### PR TITLE
Refactor prototype import and export

### DIFF
--- a/frontend/src/components/molecules/forms/FormImportPrototype.tsx
+++ b/frontend/src/components/molecules/forms/FormImportPrototype.tsx
@@ -6,219 +6,280 @@
 //
 // SPDX-License-Identifier: MIT
 
+import { useMemo, useState } from 'react'
+import { TbCircleCheckFilled, TbFileImport } from 'react-icons/tb'
 import { Button } from '@/components/atoms/button'
 import { Input } from '@/components/atoms/input'
-import { Label } from '@/components/atoms/label'
-import { FormEvent, useEffect, useState } from 'react'
-import { TbLoader, TbCircleCheckFilled } from 'react-icons/tb'
-import { createPrototypeService } from '@/services/prototype.service'
-import { addLog } from '@/services/log.service'
-import useSelfProfileQuery from '@/hooks/useSelfProfile'
-import { useNavigate, useLocation } from 'react-router-dom'
-import useListModelContribution from '@/hooks/useListModelContribution'
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/atoms/select'
-import { zipToPrototype } from '@/lib/zipUtils'
-import { Prototype } from '@/types/model.type'
-import { ModelLite } from '@/types/model.type'
-import DaImportFile from '@/components/atoms/DaImportFile'
 import { Spinner } from '@/components/atoms/spinner'
-import { CVI } from '@/data/CVI'
-import { ModelCreate } from '@/types/model.type'
-import { createModelService } from '@/services/model.service'
+import DaImportFile from '@/components/atoms/DaImportFile'
+import DaDuplicateNameHint from '@/components/atoms/DaDuplicateNameHint'
+import CustomDialog from '@/components/molecules/CustomDialog'
 import { useToast } from '../toaster/use-toast'
-
-const initialState = {
-  modelName: '',
-  cvi: JSON.stringify(CVI),
-  mainApi: 'Vehicle',
-}
+import useCurrentModel from '@/hooks/useCurrentModel'
+import { useListModelPrototypes } from '@/hooks/usePrototypeQueries'
+import useDuplicateNameCheck from '@/hooks/useDuplicateNameCheck'
+import useSelfProfileQuery from '@/hooks/useSelfProfile'
+import { buildPrototypeImportPayload, zipToPrototype } from '@/lib/zipUtils'
+import { addLog } from '@/services/log.service'
+import { createPrototypeService } from '@/services/prototype.service'
+import { Prototype } from '@/types/model.type'
+import { useNavigate } from 'react-router-dom'
 
 const FormImportPrototype = () => {
-  const [isLoading, setIsLoading] = useState(false)
-  const [data, setData] = useState(initialState)
-  const navigate = useNavigate()
-  const [error, setError] = useState<string>('')
-  const {
-    data: contributionModels,
-    isLoading: isFetchingModelContribution,
-    refetch,
-  } = useListModelContribution()
+  const { data: model } = useCurrentModel()
+  const { data: modelPrototypes, refetch } = useListModelPrototypes(
+    model ? model.id : '',
+  )
   const { data: currentUser } = useSelfProfileQuery()
-  const [localModel, setLocalModel] = useState<ModelLite>()
+  const navigate = useNavigate()
   const { toast } = useToast()
 
-  const handleChange = (name: keyof typeof data, value: string | number) => {
-    setData((prev) => ({ ...prev, [name]: value }))
-  }
+  const [isOpenImportDialog, setIsOpenImportDialog] = useState(false)
+  const [selectedFile, setSelectedFile] = useState<File | null>(null)
+  const [prototypeName, setPrototypeName] = useState<string>('')
+  const [extractedPrototype, setExtractedPrototype] =
+    useState<Partial<Prototype> | null>(null)
+  const [importError, setImportError] = useState<string | null>(null)
+  const [isImporting, setIsImporting] = useState(false)
+  const [isParsingImport, setIsParsingImport] = useState(false)
 
-  const handleImportPrototypeZip = async (file: File) => {
-    if (!file) return
-    if (!data.modelName) return
+  const existingPrototypeNames = useMemo(
+    () => modelPrototypes?.map((p) => p.name) ?? [],
+    [modelPrototypes],
+  )
 
-    let modelId: string
+  const {
+    isDuplicate: isDuplicatePrototypeName,
+    suggestedName: suggestedPrototypeName,
+  } = useDuplicateNameCheck(prototypeName, existingPrototypeNames)
 
+  const isDuplicateImportError = Boolean(
+    importError?.includes('already in use for model'),
+  )
+
+  const apiSuggestedPrototypeName = useMemo(() => {
+    if (!importError) return null
+    const match = importError.match(/like:\s*([^.,]+)/)
+    return match?.[1]?.trim() ?? null
+  }, [importError])
+
+  const handleFileChange = async (file: File) => {
+    setSelectedFile(file)
+    setImportError(null)
     try {
-      // Determine the model ID based on whether a local model exists or a new one needs to be created
-      if (localModel) {
-        // Scenario 1: `localModel` exists, use its ID
-        modelId = localModel.id
-      } else if (data.modelName) {
-        // Scenario 2: `localModel` does not exist, create a new model
-        const modelBody: ModelCreate = {
-          cvi: data.cvi,
-          main_api: data.mainApi,
-          name: data.modelName,
-          api_version: 'v4.1',
-        }
-
-        const newModelId = await createModelService(modelBody)
-        modelId = newModelId
+      const prototype = await zipToPrototype(model?.id || '', file)
+      if (prototype && prototype.name) {
+        setExtractedPrototype(prototype)
+        setPrototypeName(prototype.name)
       } else {
-        throw new Error('Model data is missing')
-      }
-
-      setIsLoading(true)
-
-      // Import the prototype from the ZIP file
-      const prototype = await zipToPrototype(modelId, file)
-
-      if (prototype) {
-        const prototypePayload: Partial<Prototype> = {
-          state: prototype.state || 'development',
-          apis: {
-            VSS: [],
-            VSC: [],
-          },
-          code: prototype.code || '',
-          widget_config: prototype.widget_config || '{}',
-          description: prototype.description,
-          tags: prototype.tags || [],
-          image_file: prototype.image_file,
-          model_id: modelId,
-          name: prototype.name,
-          complexity_level: prototype.complexity_level || '3',
-          customer_journey: prototype.customer_journey || '{}',
-          portfolio: prototype.portfolio || {},
-        }
-
-        const response = await createPrototypeService(prototypePayload)
-
-        // Log the prototype creation
-        await addLog({
-          name: `New prototype '${response.name}' under model '${localModel?.name || data.modelName}'`,
-          description: `Prototype '${response.name}' was created by ${currentUser?.email || currentUser?.name || currentUser?.id}`,
-          type: 'new-prototype',
-          create_by: currentUser?.id!,
-          ref_id: response.id,
-          ref_type: 'prototype',
-          parent_id: modelId,
-        })
-
-        toast({
-          title: ``,
-          description: (
-            <p className="flex items-center text-sm">
-              <TbCircleCheckFilled className="text-green-500 w-4 h-4 mr-2" />
-              Import prototype successfully
-            </p>
-          ),
-          duration: 3000,
-        })
-
-        // Refetch data and navigate to the new prototype's page
-        await refetch()
-        navigate(`/model/${modelId}/library/list/${response.id}`)
-      } else {
-        throw new Error('Failed to extract prototype from the ZIP file')
+        setImportError('Invalid zip file. Could not extract prototype data.')
+        setExtractedPrototype(null)
+        setPrototypeName('')
       }
     } catch (error) {
-      setError('Failed to import prototype')
-      console.error('Failed to import prototype:', error)
-    } finally {
-      setIsLoading(false)
+      setImportError('Error processing the zip file.')
+      setExtractedPrototype(null)
+      setPrototypeName('')
     }
   }
 
-  useEffect(() => {
-    if (
-      contributionModels &&
-      !isFetchingModelContribution &&
-      contributionModels.results.length > 0
-    ) {
-      setLocalModel(contributionModels.results[0])
+  const handleImportFileSelected = async (file: File) => {
+    setImportError(null)
+    setSelectedFile(null)
+    setExtractedPrototype(null)
+    setPrototypeName('')
+
+    const maxFileSize = 10 * 1024 * 1024
+    if (!file.name.endsWith('.zip')) {
+      setImportError('Only .zip files are allowed.')
+      setIsOpenImportDialog(true)
+      return
     }
-  }, [contributionModels, isFetchingModelContribution])
+    if (file.size > maxFileSize) {
+      setImportError('File size must be less than 10 MB.')
+      setIsOpenImportDialog(true)
+      return
+    }
+
+    setIsParsingImport(true)
+    try {
+      await handleFileChange(file)
+    } finally {
+      setIsParsingImport(false)
+    }
+    setIsOpenImportDialog(true)
+  }
+
+  const handleConfirmImport = async () => {
+    if (
+      !selectedFile ||
+      !model ||
+      !prototypeName.trim() ||
+      !extractedPrototype
+    ) {
+      setImportError('Please select a valid file and provide a prototype name.')
+      return
+    }
+
+    if (isDuplicatePrototypeName) {
+      return
+    }
+
+    setIsImporting(true)
+    setImportError(null)
+
+    try {
+      const prototypePayload = buildPrototypeImportPayload(
+        extractedPrototype,
+        model.id,
+        prototypeName,
+      )
+
+      const response = await createPrototypeService(prototypePayload)
+
+      await addLog({
+        name: `New prototype '${prototypeName}' under model '${model.name}'`,
+        description: `Prototype '${prototypeName}' was created by ${currentUser?.email || currentUser?.name || currentUser?.id}`,
+        type: 'new-prototype',
+        create_by: currentUser?.id!,
+        ref_id: response.id,
+        ref_type: 'prototype',
+        parent_id: model.id,
+      })
+
+      toast({
+        title: ``,
+        description: (
+          <p className="flex items-center text-sm">
+            <TbCircleCheckFilled className="mr-2 h-4 w-4 text-green-500" />
+            Prototype "{prototypeName}" imported successfully
+          </p>
+        ),
+        duration: 3000,
+      })
+
+      await navigate(`/model/${model.id}/library/prototype/${response.id}`)
+
+      setIsOpenImportDialog(false)
+      setSelectedFile(null)
+      setExtractedPrototype(null)
+      setPrototypeName('')
+
+      await refetch()
+    } catch (error: any) {
+      if (error.response?.data?.message) {
+        setImportError(error.response.data.message)
+      } else {
+        setImportError('Failed to import prototype')
+      }
+      console.error('Import error:', error)
+    } finally {
+      setIsImporting(false)
+    }
+  }
+
+  const handleDialogOpenChange = (open: boolean) => {
+    setIsOpenImportDialog(open)
+    if (!open) {
+      setSelectedFile(null)
+      setExtractedPrototype(null)
+      setPrototypeName('')
+      setImportError(null)
+    }
+  }
 
   return (
-    <div className="flex flex-col bg-background">
-      <h2 className="text-lg font-semibold text-primary">Import Prototype</h2>
-
-      {contributionModels && !isFetchingModelContribution && localModel ? (
-        <div className="flex flex-col mt-4">
-          <Label className="mb-2">Model name *</Label>
-          <Select
-            defaultValue={localModel.id}
-            onValueChange={(e: string) => {
-              const selectedModel = contributionModels.results.find(
-                (model: ModelLite) => model.id === e,
-              )
-              selectedModel && setLocalModel(selectedModel)
-            }}
-          >
-            <SelectTrigger>
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-              {contributionModels.results.map(
-                (model: ModelLite, index: number) => (
-                  <SelectItem key={index} value={model.id}>
-                    {model.name}
-                  </SelectItem>
-                ),
-              )}
-            </SelectContent>
-          </Select>
-        </div>
-      ) : isFetchingModelContribution ? (
-        <p className="mt-4 flex items-center text-base text-muted-foreground">
-          <Spinner className="w-4 h-4 mr-1" />
-          Loading vehicle model...
-        </p>
-      ) : (
-        <div className="flex flex-col mt-4">
-          <Label className="mb-2">Model Name *</Label>
-          <Input
-            name="name"
-            value={data.modelName}
-            onChange={(e) => handleChange('modelName', e.target.value)}
-            placeholder="Model name"
-          />
-        </div>
-      )}
-
-      {error && <p className="mt-4 text-sm text-destructive">{error}</p>}
-
+    <>
       <DaImportFile
         accept=".zip"
-        onFileChange={handleImportPrototypeZip}
-        className="flex w-full"
+        disabled={isParsingImport || isImporting}
+        onFileChange={(file) => void handleImportFileSelected(file)}
       >
         <Button
-          disabled={isLoading || (!localModel && !data.modelName)}
-          type="submit"
-          className="w-full mt-8"
+          variant="outline"
+          size="sm"
+          className="flex"
+          disabled={isParsingImport || isImporting}
         >
-          {isLoading && <TbLoader className="animate-spin text-lg mr-2" />}
-          Select file and import
+          {isParsingImport ? (
+            <Spinner className="w-5 h-5" />
+          ) : (
+            <TbFileImport className="w-5 h-5" />
+          )}
+          Import Prototype
         </Button>
       </DaImportFile>
-    </div>
+
+      <CustomDialog
+        open={isOpenImportDialog}
+        onOpenChange={handleDialogOpenChange}
+        dialogTitle="Import Prototype"
+        description="Confirm the prototype name before importing."
+        className="h-fit xl:h-fit overflow-hidden"
+      >
+        <div className="flex flex-col space-y-4">
+          {selectedFile && (
+            <p className="text-sm text-muted-foreground">{selectedFile.name}</p>
+          )}
+          {extractedPrototype && (
+            <div className="flex flex-col">
+              <Input
+                value={prototypeName}
+                onChange={(e) => {
+                  setPrototypeName(e.target.value)
+                  setImportError(null)
+                }}
+                placeholder={
+                  extractedPrototype ? extractedPrototype.name : 'Prototype Name'
+                }
+                className="w-full"
+              />
+              {(isDuplicatePrototypeName || isDuplicateImportError) && (
+                <DaDuplicateNameHint
+                  message={
+                    isDuplicatePrototypeName
+                      ? `The prototype name '${prototypeName}' is already in use for model '${model?.name}'`
+                      : importError || 'This prototype name is already in use'
+                  }
+                  suggestedName={
+                    suggestedPrototypeName ?? apiSuggestedPrototypeName
+                  }
+                  onApplySuggestion={(name) => {
+                    setPrototypeName(name)
+                    setImportError(null)
+                  }}
+                  className="mt-2"
+                />
+              )}
+            </div>
+          )}
+          {importError && !isDuplicatePrototypeName && !isDuplicateImportError && (
+            <div className="text-red-500 text-sm">{importError}</div>
+          )}
+          <Button
+            variant="default"
+            size="sm"
+            disabled={
+              !selectedFile ||
+              !prototypeName.trim() ||
+              isImporting ||
+              !extractedPrototype ||
+              isDuplicatePrototypeName
+            }
+            onClick={handleConfirmImport}
+          >
+            {isImporting ? (
+              <div className="flex items-center">
+                <Spinner className="mr-2 size-4" />
+                Importing...
+              </div>
+            ) : (
+              'Import'
+            )}
+          </Button>
+        </div>
+      </CustomDialog>
+    </>
   )
 }
 

--- a/frontend/src/lib/zipUtils.tsx
+++ b/frontend/src/lib/zipUtils.tsx
@@ -19,11 +19,47 @@ import {
 } from '@/services/extendedApis.service'
 
 import { convertCode } from '@/services/convert_code.service'
+import { uploadFileService } from '@/services/upload.service'
 import { FileSystemItem } from '@/components/molecules/project_editor/types'
 import { base64ToArrayBuffer } from '@/lib/utils'
 
 const removeSpecialCharacters = (str: string) => {
   return str.replace(/[^a-zA-Z0-9 ]/g, '')
+}
+
+const readImageFileFromZip = async (
+  zipFile: JSZip,
+  path: string,
+): Promise<File | undefined> => {
+  const entry = zipFile.file(path)
+  if (!entry) return undefined
+  const blob = await entry.async('blob')
+  const filename = path.split('/').pop() || 'image_file.png'
+  return new File([blob], filename, { type: blob.type || 'image/png' })
+}
+
+const resolvePrototypeImageUrl = async (
+  zipFile: JSZip,
+  imagePath: string,
+  metadataUrl?: string,
+): Promise<string | undefined> => {
+  try {
+    const imageFile = await readImageFileFromZip(zipFile, imagePath)
+    if (imageFile) {
+      const { url } = await uploadFileService(imageFile)
+      return url
+    }
+  } catch (err) {
+    console.error('Failed to upload prototype image from zip:', err)
+  }
+  if (
+    typeof metadataUrl === 'string' &&
+    metadataUrl.trim() &&
+    !metadataUrl.startsWith('/ref/')
+  ) {
+    return metadataUrl
+  }
+  return undefined
 }
 
 const getImgFile = (zip: JSZip, imageUrl: string, filename: string) => {
@@ -133,6 +169,8 @@ const downloadAllPrototypeInModel = async (model: Model, zip: JSZip) => {
           // analysis_image_file: prototype.analysis_image_file,
           customer_journey: prototype.customer_journey,
           // partner_logo: prototype.partner_logo,
+          ...(prototype.extend != null && { extend: prototype.extend }),
+          ...(prototype.portfolio != null && { portfolio: prototype.portfolio }),
         })),
         null,
         4,
@@ -159,6 +197,8 @@ const downloadAllPrototypeInModel = async (model: Model, zip: JSZip) => {
             // analysis_image_file: prototype.analysis_image_file,
             customer_journey: prototype.customer_journey,
             // partner_logo: prototype.partner_logo,
+            ...(prototype.extend != null && { extend: prototype.extend }),
+            ...(prototype.portfolio != null && { portfolio: prototype.portfolio }),
           },
           null,
           4,
@@ -200,6 +240,9 @@ export const downloadModelZip = async (model: Model) => {
           typeof model.api_version === 'string' && model.api_version.trim()
             ? model.api_version.trim()
             : null,
+        ...(model.custom_template != null && {
+          custom_template: model.custom_template,
+        }),
       },
       null,
       4,
@@ -281,6 +324,14 @@ export const zipToModel = async (file: File) => {
         (await zipFile
           .file(`prototypes/${prototype.name}/dashboard.json`)
           ?.async('string')) || '[]'
+      const imageUrl = await resolvePrototypeImageUrl(
+        zipFile,
+        `prototypes/${prototype.name}/image_file.png`,
+        prototype.image_file,
+      )
+      if (imageUrl) {
+        prototype.image_file = imageUrl
+      }
     }
 
     const pluginsStr =
@@ -332,6 +383,8 @@ export const downloadPrototypeZip = async (prototype: Prototype) => {
           // analysis_image_file: prototype.analysis_image_file,
           customer_journey: prototype.customer_journey,
           // partner_logo: prototype.partner_logo,
+          ...(prototype.extend != null && { extend: prototype.extend }),
+          ...(prototype.portfolio != null && { portfolio: prototype.portfolio }),
         },
         null,
         4,
@@ -345,6 +398,26 @@ export const downloadPrototypeZip = async (prototype: Prototype) => {
     saveAs(content, zipFilename)
   } catch (err) { }
 }
+
+export const buildPrototypeImportPayload = (
+  proto: Partial<Prototype>,
+  modelId: string,
+  name?: string,
+): Partial<Prototype> => ({
+  state: proto.state || 'development',
+  apis: proto.apis ?? { VSS: [], VSC: [] },
+  code: proto.code || '',
+  widget_config: proto.widget_config || '{}',
+  description: proto.description,
+  tags: proto.tags || [],
+  image_file: proto.image_file,
+  model_id: modelId,
+  name: name ?? proto.name,
+  complexity_level: proto.complexity_level || '3',
+  customer_journey: proto.customer_journey || '{}',
+  portfolio: proto.portfolio || {},
+  ...(proto.extend != null && { extend: proto.extend }),
+})
 
 export const zipToPrototype = async (
   model_id: string,
@@ -425,6 +498,15 @@ export const zipToPrototype = async (
     let newDashboard = { widgets: newWidgets }
 
     Object.assign(prototype, metadata, { code, widget_config: JSON.stringify(newDashboard) })
+
+    const imageUrl = await resolvePrototypeImageUrl(
+      zipFile,
+      'image_file.png',
+      metadata.image_file,
+    )
+    if (imageUrl) {
+      prototype.image_file = imageUrl
+    }
 
     // Ensure the model_id is correctly set to the new model_id
     prototype.model_id = model_id

--- a/frontend/src/pages/PageModelList.tsx
+++ b/frontend/src/pages/PageModelList.tsx
@@ -14,7 +14,7 @@ import { TbLoader, TbPackageExport, TbRefresh, TbSearch } from 'react-icons/tb'
 import DaDialog from '@/components/molecules/DaDialog'
 import FormCreateModel from '@/components/molecules/forms/FormCreateModel'
 import DaImportFile from '@/components/atoms/DaImportFile'
-import { zipToModel } from '@/lib/zipUtils'
+import { buildPrototypeImportPayload, zipToModel } from '@/lib/zipUtils'
 import { createModelService } from '@/services/model.service'
 import { createPrototypeService } from '@/services/prototype.service'
 import { uploadFileService } from '@/services/upload.service'
@@ -211,6 +211,9 @@ const PageModelList = () => {
           model_files: importedModel.model.model_files || {},
           name: modelName,
           visibility: 'private',
+          ...(importedModel.model.custom_template != null && {
+            custom_template: importedModel.model.custom_template,
+          }),
         }
 
         if (apiVersion == null) {
@@ -255,20 +258,10 @@ const PageModelList = () => {
         if (importedModel.prototypes?.length > 0) {
           await Promise.all(
             importedModel.prototypes.map(async (proto: Partial<Prototype>) => {
-              const newPrototype: Partial<Prototype> = {
-                state: proto.state || 'development',
-                apis: { VSS: [], VSC: [] },
-                code: proto.code || '',
-                widget_config: proto.widget_config || '{}',
-                description: proto.description,
-                tags: proto.tags || [],
-                image_file: proto.image_file,
-                model_id: createdModelId,
-                name: proto.name,
-                complexity_level: proto.complexity_level || '3',
-                customer_journey: proto.customer_journey || '{}',
-                portfolio: proto.portfolio || {},
-              }
+              const newPrototype = buildPrototypeImportPayload(
+                proto,
+                createdModelId,
+              )
               return createPrototypeService(newPrototype)
             }),
           )

--- a/frontend/src/pages/PagePrototypeLibrary.tsx
+++ b/frontend/src/pages/PagePrototypeLibrary.tsx
@@ -13,36 +13,26 @@ import { useParams } from 'react-router-dom'
 import {
   TbChartScatter,
   TbListDetails,
-  TbFileImport,
   TbPlus,
   TbSearch,
 } from 'react-icons/tb'
 import { Button } from '@/components/atoms/button'
-import { Spinner } from '@/components/atoms/spinner'
 import usePermissionHook from '@/hooks/usePermissionHook'
 import { PERMISSIONS } from '@/data/permission'
-import useCurrentModel from '@/hooks/useCurrentModel'
-import { useListModelPrototypes } from '@/hooks/usePrototypeQueries'
-import { createPrototypeService } from '@/services/prototype.service'
 import useSelfProfileQuery from '@/hooks/useSelfProfile'
-import { zipToPrototype } from '@/lib/zipUtils'
-import { Prototype } from '@/types/model.type'
 import DaDialog from '@/components/molecules/DaDialog'
 import { useNavigate } from 'react-router-dom'
 import DaFilter from '@/components/atoms/DaFilter'
 import { Input } from '@/components/atoms/input'
 import { Skeleton } from '@/components/atoms/skeleton'
 import { cn } from '@/lib/utils'
-import CustomDialog from '@/components/molecules/CustomDialog'
-import DaFileUpload from '@/components/atoms/DaFileUpload'
 import FormCreatePrototype from '@/components/molecules/forms/FormCreatePrototype'
+import FormImportPrototype from '@/components/molecules/forms/FormImportPrototype'
 import { useSiteConfig } from '@/utils/siteConfig'
 
 const PagePrototypeLibrary = () => {
   const [activeTab, setActiveTab] = useState<'list' | 'portfolio'>('list')
-  const { data: model } = useCurrentModel()
   const { model_id, tab } = useParams<{ model_id: string; tab?: string }>()
-  const { refetch } = useListModelPrototypes(model ? model.id : '')
   const { data: user } = useSelfProfileQuery()
   // Prototype "create/import" requires write permission on the parent model
   const [isAuthorized] = usePermissionHook([PERMISSIONS.WRITE_MODEL, model_id])
@@ -55,14 +45,6 @@ const PagePrototypeLibrary = () => {
     ),
   )
   const [searchInput, setSearchInput] = useState('')
-  const [isOpenImportDialog, setIsOpenImportDialog] = useState(false)
-
-  const [selectedFile, setSelectedFile] = useState<File | null>(null)
-  const [prototypeName, setPrototypeName] = useState<string>('')
-  const [extractedPrototype, setExtractedPrototype] =
-    useState<Partial<Prototype> | null>(null)
-  const [importError, setImportError] = useState<string | null>(null)
-  const [isImporting, setIsImporting] = useState(false)
 
   useEffect(() => {
     if (tab) {
@@ -85,81 +67,6 @@ const PagePrototypeLibrary = () => {
       'prototypeLibrary-selectedFilter',
       JSON.stringify(option),
     )
-  }
-
-  const handleFileChange = async (file: File) => {
-    setSelectedFile(file)
-    setImportError(null)
-    try {
-      const prototype = await zipToPrototype(model?.id || '', file)
-      if (prototype && prototype.name) {
-        setExtractedPrototype(prototype)
-        setPrototypeName(prototype.name)
-      } else {
-        setImportError('Invalid zip file. Could not extract prototype data.')
-        setExtractedPrototype(null)
-        setPrototypeName('')
-      }
-    } catch (error) {
-      setImportError('Error processing the zip file.')
-      setExtractedPrototype(null)
-      setPrototypeName('')
-    }
-  }
-
-  const handleClearFile = () => {
-    setSelectedFile(null)
-    setExtractedPrototype(null)
-    setPrototypeName('')
-    setImportError(null)
-  }
-
-  const handleConfirmImport = async () => {
-    if (
-      !selectedFile ||
-      !model ||
-      !prototypeName.trim() ||
-      !extractedPrototype
-    ) {
-      setImportError('Please select a valid file and provide a prototype name.')
-      return
-    }
-
-    setIsImporting(true)
-    setImportError(null)
-
-    try {
-      const prototypePayload: Partial<Prototype> = {
-        state: extractedPrototype.state || 'development',
-        apis: { VSS: [], VSC: [] },
-        code: extractedPrototype.code || '',
-        widget_config: extractedPrototype.widget_config || '{}',
-        description: extractedPrototype.description,
-        tags: extractedPrototype.tags || [],
-        image_file: extractedPrototype.image_file,
-        model_id: model.id,
-        name: prototypeName,
-        complexity_level: extractedPrototype.complexity_level || '3',
-        customer_journey: extractedPrototype.customer_journey || '{}',
-        portfolio: extractedPrototype.portfolio || {},
-      }
-
-      await createPrototypeService(prototypePayload)
-      await refetch()
-      setIsOpenImportDialog(false)
-      setSelectedFile(null)
-      setExtractedPrototype(null)
-      setPrototypeName('')
-    } catch (error: any) {
-      if (error.response?.data?.message) {
-        setImportError(error.response.data.message)
-      } else {
-        setImportError('Failed to import prototype')
-      }
-      console.error('Import error:', error)
-    } finally {
-      setIsImporting(false)
-    }
   }
 
   return (
@@ -227,15 +134,7 @@ const PagePrototypeLibrary = () => {
                     isAuthorized && 'opacity-100 pointer-events-auto',
                   )}
                 >
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    className="flex"
-                    onClick={() => setIsOpenImportDialog(true)}
-                  >
-                    <TbFileImport className="w-5 h-5" />
-                    Import Prototype
-                  </Button>
+                  <FormImportPrototype />
                   {enableNewPrototypePage ? (
                     <Button
                       data-id="btn-create-new-prototype"
@@ -291,79 +190,6 @@ const PagePrototypeLibrary = () => {
           {activeTab === 'portfolio' && <PrototypeLibraryPortfolio />}
         </div>
       </div>
-
-      <CustomDialog
-        open={isOpenImportDialog}
-        onOpenChange={(open) => {
-          setIsOpenImportDialog(open)
-          if (!open) {
-            setSelectedFile(null)
-            setExtractedPrototype(null)
-            setPrototypeName('')
-            setImportError(null)
-          }
-        }}
-        dialogTitle="Import Prototype"
-        description="Upload a zip file containing the prototype."
-        className="h-fit xl:h-fit overflow-hidden"
-      >
-        <div className="flex flex-col space-y-4">
-          <DaFileUpload
-            accept=".zip"
-            label="Select or Drop Zip File"
-            isImage={false}
-            validate={async (file) => {
-              const maxFileSize = 10 * 1024 * 1024
-              if (!file.name.endsWith('.zip')) {
-                return 'Only .zip files are allowed.'
-              }
-              if (file.size > maxFileSize) {
-                return 'File size must be less than 10 MB.'
-              }
-              await handleFileChange(file)
-              return null
-            }}
-            onFileUpload={(url) => {
-              if (url === '') {
-                handleClearFile()
-              }
-            }}
-          />
-          {extractedPrototype && (
-            <Input
-              value={prototypeName}
-              onChange={(e) => setPrototypeName(e.target.value)}
-              placeholder={
-                extractedPrototype ? extractedPrototype.name : 'Prototype Name'
-              }
-              className="w-full"
-            />
-          )}
-          {importError && (
-            <div className="text-red-500 text-sm">{importError}</div>
-          )}
-          <Button
-            variant="default"
-            size="sm"
-            disabled={
-              !selectedFile ||
-              !prototypeName.trim() ||
-              isImporting ||
-              !extractedPrototype
-            }
-            onClick={handleConfirmImport}
-          >
-            {isImporting ? (
-              <div className="flex items-center">
-                <Spinner className="mr-2 size-4" />
-                Importing...
-              </div>
-            ) : (
-              'Import'
-            )}
-          </Button>
-        </div>
-      </CustomDialog>
     </div>
   )
 }

--- a/frontend/src/types/model.type.ts
+++ b/frontend/src/types/model.type.ts
@@ -168,6 +168,7 @@ export type ModelCreate = {
   extended_apis?: any[]
   api_data_url?: string
   model_template_id?: string | null
+  custom_template?: any
 }
 
 export type VehicleApi = {


### PR DESCRIPTION
Consolidate prototype ZIP import into FormImportPrototype (used by the prototype library), replacing inline logic in PagePrototypeLibrary. Add duplicate-name validation with DaDuplicateNameHint, a confirm-name dialog, and navigation to the new prototype detail page after import.

Introduce buildPrototypeImportPayload in zipUtils for consistent import payloads across single-prototype and full-model ZIP flows, including extend metadata. Round-trip custom_template on model export/import and add custom_template to ModelCreate.