### PR TITLE
feat(home): add all-prototypes carousel with view-based sorting

### DIFF
--- a/frontend/src/components/atoms/DaFilter.tsx
+++ b/frontend/src/components/atoms/DaFilter.tsx
@@ -20,6 +20,7 @@ interface DaFilterProps {
   singleSelect?: boolean
   defaultValue?: string[]
   label?: string
+  disabled?: boolean
 }
 
 const DaFilter = ({
@@ -30,6 +31,7 @@ const DaFilter = ({
   singleSelect = false,
   defaultValue,
   label,
+  disabled = false,
 }: DaFilterProps) => {
   const [selectedOptions, setSelectedOptions] = useState<string[]>(() => {
     const allOptions = Object.values(categories).flat()
@@ -103,6 +105,7 @@ const DaFilter = ({
         className={cn('mr-2 shadow-xs', className)}
         variant="outline"
         onClick={toggleDropdownVisibility}
+        disabled={disabled}
       >
         <TbSortDescending className="size-4" /> {label || 'Filter'}
       </Button>

--- a/frontend/src/components/molecules/DaDialog.tsx
+++ b/frontend/src/components/molecules/DaDialog.tsx
@@ -7,6 +7,7 @@
 // SPDX-License-Identifier: MIT
 
 import React, { useState, useEffect, useRef } from 'react'
+import { DismissableLayerBranch } from '@radix-ui/react-dismissable-layer'
 import {
   Dialog,
   DialogContent,
@@ -68,6 +69,37 @@ const DaDialog = ({
 
   const canClose = showCloseButton
 
+  const isSelectOpen = () =>
+    !!document.querySelector('[data-radix-select-content][data-state="open"]')
+
+  const dismissOpenSelects = () => {
+    if (!isSelectOpen()) return
+    document.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }),
+    )
+  }
+
+  const closeDialog = () => {
+    dismissOpenSelects()
+    handleOpenChange(false)
+  }
+
+  const closeButtonClassName =
+    'pointer-events-auto text-muted-foreground hover:text-foreground transition-colors focus:outline-none focus-visible:outline-none'
+
+  const renderCloseButton = (className: string) => (
+    <DismissableLayerBranch>
+      <button
+        className={cn(closeButtonClassName, className)}
+        onClick={closeDialog}
+        aria-label="Close"
+        type="button"
+      >
+        <TbX className="w-5 h-5" />
+      </button>
+    </DismissableLayerBranch>
+  )
+
   return (
     <Dialog open={isOpen} onOpenChange={handleOpenChange}>
       {trigger && (
@@ -96,6 +128,7 @@ const DaDialog = ({
           if (preventOutsideClose) e.preventDefault()
         }}
         onEscapeKeyDown={(e) => {
+          if (isSelectOpen()) return
           if (preventOutsideClose) e.preventDefault()
         }}
         aria-describedby={undefined}
@@ -111,30 +144,14 @@ const DaDialog = ({
                 <p className="text-sm text-muted-foreground leading-snug">{description}</p>
               )}
             </div>
-            {canClose && (
-              <button
-                className="shrink-0 text-muted-foreground hover:text-foreground transition-colors focus:outline-none focus-visible:outline-none"
-                onClick={() => handleOpenChange(false)}
-                aria-label="Close"
-                type="button"
-              >
-                <TbX className="w-5 h-5" />
-              </button>
-            )}
+            {canClose &&
+              renderCloseButton('relative z-[60] shrink-0')}
           </div>
         ) : (
           // Untitled dialog (e.g. self-titled forms): float the close button in the
           // corner with no header bar so it doesn't add an empty title row.
-          canClose && (
-            <button
-              className="absolute right-4 top-4 z-10 text-muted-foreground hover:text-foreground transition-colors focus:outline-none focus-visible:outline-none"
-              onClick={() => handleOpenChange(false)}
-              aria-label="Close"
-              type="button"
-            >
-              <TbX className="w-5 h-5" />
-            </button>
-          )
+          canClose &&
+          renderCloseButton('absolute right-4 top-4 z-[60]')
         )}
 
         <div

--- a/frontend/src/components/molecules/DaPrototypeCard.tsx
+++ b/frontend/src/components/molecules/DaPrototypeCard.tsx
@@ -45,6 +45,7 @@ import {
   DropdownMenuTrigger,
 } from '../atoms/dropdown-menu'
 import { updatePrototypeService, deletePrototypeService } from '@/services/prototype.service'
+import { invalidatePrototypeListQueries } from '@/hooks/usePrototypeQueries'
 import { uploadFileService } from '@/services/upload.service'
 import { downloadPrototypeZip } from '@/lib/zipUtils'
 import DaImportFile from '../atoms/DaImportFile'
@@ -82,9 +83,7 @@ export const DaPrototypeCard = ({
   const queryClient = useQueryClient()
   const deletePrototype = useMutation({
     mutationFn: (id: string) => deletePrototypeService(id),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['listModelPrototypes'] })
-    },
+    onSuccess: () => invalidatePrototypeListQueries(queryClient),
   })
   const navigate = useNavigate()
   const { toast } = useToast()

--- a/frontend/src/components/molecules/forms/FormCreatePrototype.tsx
+++ b/frontend/src/components/molecules/forms/FormCreatePrototype.tsx
@@ -13,7 +13,10 @@ import { FormEvent, useEffect, useMemo, useState } from 'react'
 import { TbCircleCheckFilled, TbLoader } from 'react-icons/tb'
 import { createPrototypeService } from '@/services/prototype.service'
 import { useToast } from '../toaster/use-toast'
-import { useListModelPrototypes } from '@/hooks/usePrototypeQueries'
+import {
+  invalidatePrototypeListQueries,
+  useListModelPrototypes,
+} from '@/hooks/usePrototypeQueries'
 import useCurrentModel from '@/hooks/useCurrentModel'
 import { isAxiosError } from 'axios'
 import { addLog } from '@/services/log.service'
@@ -30,7 +33,7 @@ import {
   SelectValue,
 } from '@/components/atoms/select'
 import { Model, ModelLite, ModelCreate } from '@/types/model.type'
-import { useQuery } from '@tanstack/react-query'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { Spinner } from '@/components/atoms/spinner'
 import { CVI } from '@/data/CVI'
 import { createModelService, listModelsLite } from '@/services/model.service'
@@ -86,10 +89,11 @@ const FormCreatePrototype = ({
   const { data: contributionModels, isLoading: isFetchingModelContribution } =
     useListModelContribution()
   const [localModel, setLocalModel] = useState<ModelLite>()
-  const { refetch, data: existingPrototypes } = useListModelPrototypes(
+  const { data: existingPrototypes } = useListModelPrototypes(
     localModel?.id || '',
   )
   const navigate = useNavigate()
+  const queryClient = useQueryClient()
   const { toast } = useToast()
 
   const { data: currentUser } = useSelfProfileQuery()
@@ -258,8 +262,7 @@ const FormCreatePrototype = ({
       // Reset form data
       setData(initialState)
 
-      // Refetch data
-      await refetch()
+      await invalidatePrototypeListQueries(queryClient)
     } catch (error) {
       if (isAxiosError(error)) {
         setError(error.response?.data?.message || 'Something went wrong')

--- a/frontend/src/components/molecules/forms/FormCreatePrototype.tsx
+++ b/frontend/src/components/molecules/forms/FormCreatePrototype.tsx
@@ -416,7 +416,7 @@ const FormCreatePrototype = ({
 
       {(isLoadingTemplates || templateOptions.length > 0) && (
         <div className="flex flex-col mt-4">
-          <Label className="mb-2">Project Template *</Label>
+          <Label className="mb-2">Prototype Template *</Label>
           {isLoadingTemplates ? (
             <p className="flex items-center text-sm text-muted-foreground h-9">
               <Spinner className="mr-1 h-4 w-4" />

--- a/frontend/src/components/molecules/forms/FormImportPrototype.tsx
+++ b/frontend/src/components/molecules/forms/FormImportPrototype.tsx
@@ -16,7 +16,10 @@ import DaDuplicateNameHint from '@/components/atoms/DaDuplicateNameHint'
 import CustomDialog from '@/components/molecules/CustomDialog'
 import { useToast } from '../toaster/use-toast'
 import useCurrentModel from '@/hooks/useCurrentModel'
-import { useListModelPrototypes } from '@/hooks/usePrototypeQueries'
+import {
+  invalidatePrototypeListQueries,
+  useListModelPrototypes,
+} from '@/hooks/usePrototypeQueries'
 import useDuplicateNameCheck from '@/hooks/useDuplicateNameCheck'
 import useSelfProfileQuery from '@/hooks/useSelfProfile'
 import { buildPrototypeImportPayload, zipToPrototype } from '@/lib/zipUtils'
@@ -24,14 +27,16 @@ import { addLog } from '@/services/log.service'
 import { createPrototypeService } from '@/services/prototype.service'
 import { Prototype } from '@/types/model.type'
 import { useNavigate } from 'react-router-dom'
+import { useQueryClient } from '@tanstack/react-query'
 
 const FormImportPrototype = () => {
   const { data: model } = useCurrentModel()
-  const { data: modelPrototypes, refetch } = useListModelPrototypes(
+  const { data: modelPrototypes } = useListModelPrototypes(
     model ? model.id : '',
   )
   const { data: currentUser } = useSelfProfileQuery()
   const navigate = useNavigate()
+  const queryClient = useQueryClient()
   const { toast } = useToast()
 
   const [isOpenImportDialog, setIsOpenImportDialog] = useState(false)
@@ -165,7 +170,7 @@ const FormImportPrototype = () => {
       setExtractedPrototype(null)
       setPrototypeName('')
 
-      await refetch()
+      await invalidatePrototypeListQueries(queryClient)
     } catch (error: any) {
       if (error.response?.data?.message) {
         setImportError(error.response.data.message)

--- a/frontend/src/components/molecules/forms/FormNewPrototype.tsx
+++ b/frontend/src/components/molecules/forms/FormNewPrototype.tsx
@@ -13,7 +13,6 @@ import { DaInput } from '@/components/atoms/DaInput'
 import { DaSelect, DaSelectItem } from '@/components/atoms/DaSelect'
 import { DaText } from '@/components/atoms/DaText'
 import { Label } from '@/components/atoms/label'
-import { Spinner } from '@/components/atoms/spinner'
 import {
     Select,
     SelectContent,
@@ -24,7 +23,7 @@ import {
 import { useToast } from '@/components/molecules/toaster/use-toast'
 import default_journey from '@/data/default_journey'
 import { listProjectTemplates } from '@/services/projectTemplate.service'
-import { useListModelPrototypes } from '@/hooks/usePrototypeQueries'
+import { useListModelPrototypes, invalidatePrototypeListQueries } from '@/hooks/usePrototypeQueries'
 import useCurrentModel from '@/hooks/useCurrentModel'
 import {
     getDefaultDashboardCfg,
@@ -39,7 +38,7 @@ import { createModelService, listModelsLite } from '@/services/model.service'
 import { listModelTemplates } from '@/services/modelTemplate.service'
 import { createPrototypeService } from '@/services/prototype.service'
 import { ModelLite, Prototype } from '@/types/model.type'
-import { useQuery } from '@tanstack/react-query'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { isAxiosError } from 'axios'
 import { FormEvent, useEffect, useMemo, useRef, useState } from 'react'
 import { TbLoader } from 'react-icons/tb'
@@ -74,6 +73,7 @@ const FormNewPrototype = ({
     onSuccess,
 }: FormNewPrototypeProps) => {
     const navigate = useNavigate()
+    const queryClient = useQueryClient()
     const [searchParams] = useSearchParams()
     const { toast } = useToast()
     const { data: currentUser, isLoading: isCurrentUserLoading } = useSelfProfileQuery()
@@ -319,6 +319,8 @@ const FormNewPrototype = ({
                 duration: 3000,
             })
 
+            await invalidatePrototypeListQueries(queryClient)
+
             if (onSuccess) {
                 onSuccess(modelId, response.id, prototypeName.trim())
             } else {
@@ -548,6 +550,7 @@ const FormNewPrototype = ({
                 label="Prototype Name"
                 className="mt-4"
                 data-id="prototype-name-input"
+                labelClassName="font-medium"
             />
             {isDuplicatePrototypeName && (
                 <DaDuplicateNameHint
@@ -560,33 +563,31 @@ const FormNewPrototype = ({
                 />
             )}
 
-            {(isLoadingTemplates || templateOptions.length > 0) && (
-                <div className="flex flex-col mt-4">
-                    <Label className="mb-2">Project Template *</Label>
-                    {isLoadingTemplates ? (
-                        <p className="flex items-center text-sm text-muted-foreground h-9">
-                            <Spinner className="mr-1 h-4 w-4" />
-                            Loading templates...
-                        </p>
-                    ) : (
-                        <Select
-                            value={selectedTemplateId}
-                            onValueChange={setSelectedTemplateId}
-                        >
-                            <SelectTrigger data-id="project-template-select" className="w-full">
-                                <SelectValue placeholder="Select a template" />
-                            </SelectTrigger>
-                            <SelectContent>
-                                {templateOptions.map((t) => (
-                                    <SelectItem key={t.id} value={t.id}>
-                                        {t.name}
-                                    </SelectItem>
-                                ))}
-                            </SelectContent>
-                        </Select>
-                    )}
-                </div>
-            )}
+            {(isLoadingTemplates || templateOptions.length > 0) &&
+                (isLoadingTemplates ? (
+                    <div className="mt-4">
+                        <DaText variant="regular-medium">Project Template *</DaText>
+                        <div className="flex h-10 border px-2 rounded-md shadow-sm mt-2 items-center">
+                            <TbLoader className="size-4 animate-spin mr-2" /> Loading
+                            templates...
+                        </div>
+                    </div>
+                ) : (
+                    <DaSelect
+                        value={selectedTemplateId}
+                        onValueChange={setSelectedTemplateId}
+                        label="Project Template *"
+                        wrapperClassName="mt-4"
+                        dataId="project-template-select"
+                        className="w-full"
+                    >
+                        {templateOptions.map((t) => (
+                            <DaSelectItem key={t.id} value={t.id}>
+                                {t.name}
+                            </DaSelectItem>
+                        ))}
+                    </DaSelect>
+                ))}
 
             <div className="mt-4 select-none">
                 <DaCheckbox

--- a/frontend/src/components/molecules/forms/FormNewPrototype.tsx
+++ b/frontend/src/components/molecules/forms/FormNewPrototype.tsx
@@ -566,7 +566,7 @@ const FormNewPrototype = ({
             {(isLoadingTemplates || templateOptions.length > 0) &&
                 (isLoadingTemplates ? (
                     <div className="mt-4">
-                        <DaText variant="regular-medium">Project Template *</DaText>
+                        <DaText variant="regular-medium">Prototype Template *</DaText>
                         <div className="flex h-10 border px-2 rounded-md shadow-sm mt-2 items-center">
                             <TbLoader className="size-4 animate-spin mr-2" /> Loading
                             templates...
@@ -576,7 +576,7 @@ const FormNewPrototype = ({
                     <DaSelect
                         value={selectedTemplateId}
                         onValueChange={setSelectedTemplateId}
-                        label="Project Template *"
+                        label="Prototype Template *"
                         wrapperClassName="mt-4"
                         dataId="project-template-select"
                         className="w-full"

--- a/frontend/src/components/molecules/project/ProjectTemplateEditor.tsx
+++ b/frontend/src/components/molecules/project/ProjectTemplateEditor.tsx
@@ -147,7 +147,7 @@ export default function ProjectTemplateEditor({
       }}
       className="w-[95vw] sm:w-[90vw] max-w-[1200px] h-[90vh] max-h-[calc(100dvh-2rem)]"
       contentContainerClassName="min-h-0"
-      dialogTitle={isEdit ? 'Edit Project Template' : 'Create Project Template'}
+      dialogTitle={isEdit ? 'Edit Prototype Template' : 'Create Prototype Template'}
       footer={
         <>
           <Button variant="outline" onClick={resetAndClose}>

--- a/frontend/src/components/organisms/HomeConfigSection.tsx
+++ b/frontend/src/components/organisms/HomeConfigSection.tsx
@@ -488,7 +488,7 @@ const HomeConfigSection: React.FC = () => {
                             const Component = getHomeComponent(element?.type)
                             if (!Component) return null
                             const blockId = `block-${index}-${element?.type ?? 'unknown'}`
-                            const isPlaceholderBlock = element?.type === 'recent' || element?.type === 'popular'
+                            const isPlaceholderBlock = element?.type === 'recent' || element?.type === 'popular' || element?.type === 'prototype-list'
                             return (
                               <Draggable key={blockId} draggableId={blockId} index={index}>
                                 {(provided, snapshot) => (

--- a/frontend/src/components/organisms/HomePrototypeList.tsx
+++ b/frontend/src/components/organisms/HomePrototypeList.tsx
@@ -1,0 +1,587 @@
+// Copyright (c) 2025 Eclipse Foundation.
+//
+// This program and the accompanying materials are made available under the
+// terms of the MIT License which is available at
+// https://opensource.org/licenses/MIT.
+//
+// SPDX-License-Identifier: MIT
+
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { useQueries, useQuery } from '@tanstack/react-query'
+import { Prototype } from '@/types/model.type'
+import {
+  listPrototypesPaged,
+  listAllPrototypesFiltered,
+  PROTOTYPE_LIST_CARD_FIELDS,
+} from '@/services/prototype.service'
+import useSelfProfileQuery from '@/hooks/useSelfProfile'
+import { useUrlQueryParam } from '@/hooks/useUrlQueryParam'
+import {
+  TbChevronLeft,
+  TbChevronRight,
+  TbInfoCircle,
+} from 'react-icons/tb'
+import { HiPlus } from 'react-icons/hi'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '../atoms/tooltip'
+import { Button } from '../atoms/button'
+import DaFilter from '../atoms/DaFilter'
+import DaDialog from '../molecules/DaDialog'
+import useAuthStore from '@/stores/authStore'
+import { DaPrototypeCard, DaPrototypeCardSkeleton } from '../molecules/DaPrototypeCard'
+import { useAuthConfigs } from '@/hooks/useAuthConfigs'
+import { cn } from '@/lib/utils'
+import { sortPrototypesByViewed } from '@/utils/prototypeSort'
+import { prototypeQueryKeys } from '@/hooks/usePrototypeQueries'
+
+type HomePrototypeListProps = {
+  requiredLogin?: boolean
+  title?: string
+}
+
+type PrototypeSortOption =
+  | 'newest'
+  | 'oldest'
+  | 'name-az'
+  | 'name-za'
+  | 'last-viewed'
+  | 'first-viewed'
+
+type PrototypeCategory = 'all' | 'mine'
+
+const PROTOTYPE_CATEGORIES: readonly PrototypeCategory[] = ['all', 'mine']
+const PROTOTYPE_SORT_OPTIONS: readonly PrototypeSortOption[] = [
+  'newest',
+  'oldest',
+  'name-az',
+  'name-za',
+  'last-viewed',
+  'first-viewed',
+]
+
+const SORT_LABELS: Record<PrototypeSortOption, string> = {
+  newest: 'Newest',
+  oldest: 'Oldest',
+  'name-az': 'Name A-Z',
+  'name-za': 'Name Z-A',
+  'last-viewed': 'Last Viewed',
+  'first-viewed': 'First Viewed',
+}
+
+const SORT_LABEL_TO_OPTION = Object.fromEntries(
+  Object.entries(SORT_LABELS).map(([key, label]) => [label, key]),
+) as Record<string, PrototypeSortOption>
+
+const SORT_FILTER_OPTIONS = [
+  'Last Viewed',
+  'First Viewed',
+  'Newest',
+  'Oldest',
+  'Name A-Z',
+  'Name Z-A',
+]
+
+const SORT_BY_PARAM: Record<PrototypeSortOption, string> = {
+  newest: 'createdAt:desc',
+  oldest: 'createdAt:asc',
+  'name-az': 'name:asc',
+  'name-za': 'name:desc',
+  'last-viewed': 'createdAt:desc',
+  'first-viewed': 'createdAt:desc',
+}
+
+const SWIPE_THRESHOLD = 40
+const SWIPE_LOCK_THRESHOLD = 8
+
+function useItemsPerPage(): number {
+  const getCount = () => {
+    const w = window.innerWidth
+    if (w >= 1280) return 5
+    if (w >= 1024) return 3
+    if (w >= 768) return 2
+    return 1
+  }
+  const [count, setCount] = useState(getCount)
+  useEffect(() => {
+    const onResize = () => setCount(getCount())
+    window.addEventListener('resize', onResize)
+    return () => window.removeEventListener('resize', onResize)
+  }, [])
+  return count
+}
+
+const HomePrototypeList = ({
+  requiredLogin,
+  title,
+}: HomePrototypeListProps) => {
+  const { data: user, isLoading: userLoading } = useSelfProfileQuery()
+  const { authConfigs } = useAuthConfigs()
+  const navigate = useNavigate()
+  const itemsPerView = useItemsPerPage()
+  // Advance a full page on every Next/Prev click so all items shown are new,
+  // matching the behaviour of HomePrototypePopular.
+  const pageStep = itemsPerView
+  const [activeCategory, setActiveCategory] = useUrlQueryParam(
+    'prototype-category',
+    PROTOTYPE_CATEGORIES,
+    'all',
+  )
+  const [sortBy, setSortBy] = useUrlQueryParam(
+    'prototype-sort',
+    PROTOTYPE_SORT_OPTIONS,
+    'newest',
+  )
+
+  const [currentItemIndex, setCurrentItemIndex] = useState<number>(0)
+
+  const [openRemindDialog, setOpenRemindDialog] = useState(false)
+  const [selectedPrototype, setSelectedPrototype] = useState<Prototype | null>(
+    null,
+  )
+  const [infoOpen, setInfoOpen] = useState(false)
+  const { setOpenLoginDialog } = useAuthStore()
+
+  useEffect(() => {
+    if (!userLoading && !user && activeCategory === 'mine') {
+      setActiveCategory('all')
+    }
+  }, [userLoading, user, activeCategory, setActiveCategory])
+
+  useEffect(() => {
+    setCurrentItemIndex(0)
+  }, [itemsPerView, sortBy, activeCategory])
+
+  const isClientViewSort =
+    sortBy === 'last-viewed' || sortBy === 'first-viewed'
+
+  const viewSortFilterParams = useMemo(
+    () => ({
+      category: activeCategory,
+      fields: PROTOTYPE_LIST_CARD_FIELDS,
+      ...(activeCategory === 'mine' && user ? { created_by: user.id } : {}),
+    }),
+    [activeCategory, user],
+  )
+
+  const allForViewSortQuery = useQuery({
+    queryKey: prototypeQueryKeys.allForViewSort(viewSortFilterParams),
+    queryFn: () =>
+      listAllPrototypesFiltered({
+        fields: PROTOTYPE_LIST_CARD_FIELDS,
+        ...(activeCategory === 'mine' && user
+          ? { created_by: user.id }
+          : {}),
+      }),
+    enabled: !userLoading && isClientViewSort,
+  })
+
+  const sortedItems = useMemo(() => {
+    if (!isClientViewSort || !allForViewSortQuery.data) return []
+    if (sortBy !== 'last-viewed' && sortBy !== 'first-viewed') return []
+    return sortPrototypesByViewed(allForViewSortQuery.data, sortBy)
+  }, [isClientViewSort, allForViewSortQuery.data, sortBy])
+
+  const baseParams = useMemo(
+    () => ({
+      limit: itemsPerView,
+      sortBy: SORT_BY_PARAM[sortBy],
+      fields: PROTOTYPE_LIST_CARD_FIELDS,
+      ...(activeCategory === 'mine' && user ? { created_by: user.id } : {}),
+    }),
+    [itemsPerView, sortBy, activeCategory, user],
+  )
+
+  const pagedQueryKeyParams = useMemo(
+    () => ({ ...baseParams, category: activeCategory }),
+    [baseParams, activeCategory],
+  )
+
+  const page0Query = useQuery({
+    queryKey: prototypeQueryKeys.paged({ ...pagedQueryKeyParams, page: 1 }),
+    queryFn: () => listPrototypesPaged({ ...baseParams, page: 1 }),
+    enabled: !userLoading && !isClientViewSort,
+  })
+
+  const pagedTotalResults = page0Query.data?.totalResults
+  const totalResults = isClientViewSort
+    ? allForViewSortQuery.data?.length
+    : pagedTotalResults
+
+  const additionalPageIndices = useMemo(() => {
+    if (
+      isClientViewSort ||
+      userLoading ||
+      pagedTotalResults === undefined ||
+      pagedTotalResults === 0
+    ) {
+      return []
+    }
+    const start = Math.max(0, currentItemIndex - pageStep)
+    const end = Math.min(
+      pagedTotalResults,
+      currentItemIndex + itemsPerView + pageStep,
+    )
+    const minPage = Math.floor(start / itemsPerView)
+    const maxPage = Math.floor((end - 1) / itemsPerView)
+    const indices: number[] = []
+    for (let p = minPage; p <= maxPage; p++) {
+      if (p !== 0) indices.push(p)
+    }
+    return indices
+  }, [
+    isClientViewSort,
+    userLoading,
+    pagedTotalResults,
+    currentItemIndex,
+    pageStep,
+    itemsPerView,
+  ])
+
+  const additionalPageQueries = useQueries({
+    queries: additionalPageIndices.map((pageIndex) => ({
+      queryKey: prototypeQueryKeys.paged({
+        ...pagedQueryKeyParams,
+        page: pageIndex + 1,
+      }),
+      queryFn: () =>
+        listPrototypesPaged({
+          ...baseParams,
+          page: pageIndex + 1,
+        }),
+      enabled:
+        !isClientViewSort &&
+        !userLoading &&
+        pagedTotalResults !== undefined &&
+        pageIndex * itemsPerView < pagedTotalResults,
+    })),
+  })
+
+  const pagesCache = useMemo(() => {
+    const cache: Record<number, Prototype[]> = {}
+    if (page0Query.data) cache[0] = page0Query.data.results
+    additionalPageIndices.forEach((pageIndex, i) => {
+      const data = additionalPageQueries[i]?.data
+      if (data) cache[pageIndex] = data.results
+    })
+    return cache
+  }, [page0Query.data, additionalPageIndices, additionalPageQueries])
+
+  const maxItemIndex =
+    totalResults !== undefined ? Math.max(0, totalResults - itemsPerView) : 0
+  const canGoLeft = currentItemIndex > 0
+  const canGoRight =
+    totalResults !== undefined && currentItemIndex < maxItemIndex
+
+  const clampIndex = (n: number) => Math.max(0, Math.min(maxItemIndex, n))
+
+  const goLeft = () => {
+    if (canGoLeft) setCurrentItemIndex((i) => clampIndex(i - pageStep))
+  }
+  const goRight = () => {
+    if (canGoRight) setCurrentItemIndex((i) => clampIndex(i + pageStep))
+  }
+
+  // Touch-swipe navigation for the carousel: live track drag + snap-to-page on release
+  const trackWrapperRef = useRef<HTMLDivElement>(null)
+  const touchStartXRef = useRef<number | null>(null)
+  const touchStartYRef = useRef<number | null>(null)
+  const touchSwipingRef = useRef<boolean>(false)
+  const [dragDeltaPx, setDragDeltaPx] = useState(0)
+  const [isDragging, setIsDragging] = useState(false)
+
+  const handleTouchStart = (e: React.TouchEvent<HTMLDivElement>) => {
+    const t = e.touches[0]
+    if (!t) return
+    touchStartXRef.current = t.clientX
+    touchStartYRef.current = t.clientY
+    touchSwipingRef.current = false
+    setDragDeltaPx(0)
+  }
+
+  const handleTouchMove = (e: React.TouchEvent<HTMLDivElement>) => {
+    const t = e.touches[0]
+    if (
+      !t ||
+      touchStartXRef.current === null ||
+      touchStartYRef.current === null
+    )
+      return
+    const dx = t.clientX - touchStartXRef.current
+    const dy = t.clientY - touchStartYRef.current
+    if (!touchSwipingRef.current) {
+      if (Math.abs(dx) > Math.abs(dy) && Math.abs(dx) > SWIPE_LOCK_THRESHOLD) {
+        touchSwipingRef.current = true
+        setIsDragging(true)
+      } else {
+        return
+      }
+    }
+    // Resist over-drag at edges so user gets visual feedback that there's nothing beyond
+    let effectiveDx = dx
+    if (!canGoLeft && dx > 0) effectiveDx = dx * 0.3
+    if (!canGoRight && dx < 0) effectiveDx = dx * 0.3
+    setDragDeltaPx(effectiveDx)
+  }
+
+  const handleTouchEnd = (e: React.TouchEvent<HTMLDivElement>) => {
+    if (touchStartXRef.current !== null && touchSwipingRef.current) {
+      const t = e.changedTouches[0]
+      const wrapperWidth = trackWrapperRef.current?.clientWidth ?? 0
+      const slotWidthPx = wrapperWidth > 0 ? wrapperWidth / itemsPerView : 0
+      const dx = t ? t.clientX - touchStartXRef.current : 0
+      // Snap if dragged at least the smaller of 40px and 40% of one slot.
+      const dynamicThreshold = Math.min(
+        SWIPE_THRESHOLD,
+        slotWidthPx > 0 ? slotWidthPx * 0.4 : SWIPE_THRESHOLD,
+      )
+      if (dx <= -dynamicThreshold && canGoRight) {
+        setCurrentItemIndex((i) => clampIndex(i + pageStep))
+      } else if (dx >= dynamicThreshold && canGoLeft) {
+        setCurrentItemIndex((i) => clampIndex(i - pageStep))
+      }
+    }
+    touchStartXRef.current = null
+    touchStartYRef.current = null
+    touchSwipingRef.current = false
+    setDragDeltaPx(0)
+    setIsDragging(false)
+  }
+
+  if (requiredLogin && !user) {
+    return null
+  }
+
+  const isEmpty = totalResults === 0
+
+  const handleSortFilterChange = (selected: string[]) => {
+    const label = selected[0]
+    if (!label) return
+    const option = SORT_LABEL_TO_OPTION[label]
+    if (option) setSortBy(option)
+  }
+
+  const handlePrototypeClick = (prototype: Prototype) => {
+    if (authConfigs.PUBLIC_VIEWING || user) {
+      navigate(
+        `/model/${prototype.model_id}/library/prototype/${prototype.id}/view`,
+      )
+    } else {
+      setSelectedPrototype(prototype)
+      setOpenRemindDialog(true)
+    }
+  }
+
+  const categoryButtons: { label: string; value: PrototypeCategory }[] = user
+    ? [
+        { label: 'All', value: 'all' },
+        { label: 'My Prototypes', value: 'mine' },
+      ]
+    : []
+
+  const isInitialLoading = isClientViewSort
+    ? allForViewSortQuery.isLoading
+    : page0Query.isLoading
+
+  // Number of item slots to render in the flex strip. Before the first response (initial
+  // loading) render `itemsPerView` placeholder slots so the carousel reserves the right
+  // visual footprint immediately.
+  const stripCount =
+    totalResults !== undefined && totalResults > 0 ? totalResults : itemsPerView
+
+  // Inline skeleton mirrors DaPrototypeCard layout pixel-for-pixel.
+  const renderSkeletonCard = (key: React.Key) => (
+    <DaPrototypeCardSkeleton key={key} />
+  )
+
+  return (
+    <div className="flex flex-col w-full container">
+      <div className="flex flex-wrap items-center justify-between gap-y-2">
+        <div className="flex flex-wrap items-center gap-3">
+          <h2 className="flex items-center gap-1.5 text-lg font-semibold text-primary">
+            {title || 'All Prototypes'}
+            <TooltipProvider>
+              <Tooltip open={infoOpen} onOpenChange={setInfoOpen}>
+                <TooltipTrigger asChild>
+                  <span
+                    className="inline-flex"
+                    onPointerDown={(e) => {
+                      e.preventDefault()
+                    }}
+                    onClick={(e) => {
+                      e.preventDefault()
+                      e.stopPropagation()
+                      setInfoOpen(!infoOpen)
+                    }}
+                  >
+                    <TbInfoCircle className="size-5 shrink-0 cursor-pointer text-muted-foreground" />
+                  </span>
+                </TooltipTrigger>
+                <TooltipContent className="max-w-sm text-xs">
+                  Browse all prototypes available on the platform. Navigate
+                  using the arrows to load more.
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
+          </h2>
+          {categoryButtons.length > 0 && (
+            <div className="flex flex-wrap items-center gap-2">
+              {categoryButtons.map((cat) => (
+                <Button
+                  key={cat.value}
+                  variant="ghost"
+                  disabled={isEmpty}
+                  className={cn(
+                    activeCategory === cat.value
+                      ? 'border-[#7B838B]'
+                      : 'border-transparent hover:border-[#7B838B]',
+                    'border hover:border text-base bg-transparent!',
+                  )}
+                  size="sm"
+                  onClick={() => setActiveCategory(cat.value)}
+                >
+                  {cat.label}
+                </Button>
+              ))}
+            </div>
+          )}
+        </div>
+        <div className="flex flex-wrap items-center gap-2">
+          <DaFilter
+            key={sortBy}
+            categories={{ 'Sort By': SORT_FILTER_OPTIONS }}
+            onChange={handleSortFilterChange}
+            singleSelect
+            showCategory={false}
+            defaultValue={[SORT_LABELS[sortBy]]}
+            label={SORT_LABELS[sortBy]}
+            disabled={isEmpty}
+            className="mr-0 h-8 shadow-none border-transparent bg-transparent px-2 text-base font-normal hover:bg-accent"
+          />
+
+          {/* Add prototype button */}
+          <Button
+            variant="outline"
+            size="sm"
+            className="border-primary bg-transparent text-primary max-[1080px]:px-[7px]!"
+            onClick={() => navigate('/new-prototype')}
+          >
+            <HiPlus className="text-base" />
+            <span className="inline max-[1080px]:hidden">Add Prototype</span>
+          </Button>
+        </div>
+      </div>
+
+      <div className="relative mt-2">
+        <button
+          type="button"
+          onClick={goLeft}
+          disabled={!canGoLeft}
+          className="absolute -left-4 min-[1440px]:-left-12 top-1/2 -translate-y-1/2 z-10 flex items-center justify-center size-9 rounded-full bg-primary text-white hover:bg-primary/90 shadow-md transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:bg-primary"
+        >
+          <TbChevronLeft className="size-5" />
+        </button>
+        <div
+          ref={trackWrapperRef}
+          className="overflow-hidden mx-12 min-[1440px]:mx-0 touch-pan-y"
+          onTouchStart={handleTouchStart}
+          onTouchMove={handleTouchMove}
+          onTouchEnd={handleTouchEnd}
+        >
+          {!isInitialLoading && totalResults === 0 ? (
+            <div className="flex items-center justify-center min-h-[168px] text-sm text-muted-foreground">
+              No prototypes found
+            </div>
+          ) : (
+            <div
+              className={cn(
+                'flex gap-2.5',
+                !isDragging && 'transition-transform duration-300 ease-out',
+              )}
+              style={{
+                // Each slot pitch = slotWidth + gap = (100% + 0.625rem) / itemsPerView,
+                // since slotWidth = (100% - (N-1) * 0.625rem) / N.
+                transform: `translate3d(calc((100% + 0.625rem) * ${-currentItemIndex} / ${itemsPerView} + ${dragDeltaPx}px), 0, 0)`,
+              }}
+            >
+              {Array.from({ length: stripCount }).map((_, i) => {
+                const page = Math.floor(i / itemsPerView)
+                const offset = i % itemsPerView
+                const pageItems = pagesCache[page]
+                const prototype = isClientViewSort
+                  ? sortedItems[i]
+                  : pageItems?.[offset]
+                const itemWidth = `calc((100% - ${itemsPerView - 1} * 0.625rem) / ${itemsPerView})`
+                return (
+                  <div
+                    key={i}
+                    className="flex-none"
+                    style={{
+                      width: itemWidth,
+                    }}
+                  >
+                    {prototype ? (
+                      <div
+                        onClick={() => handlePrototypeClick(prototype)}
+                        className="cursor-pointer"
+                      >
+                        <DaPrototypeCard
+                          prototype={prototype}
+                          variant="home"
+                        />
+                      </div>
+                    ) : (
+                      renderSkeletonCard(`sk-${i}`)
+                    )}
+                  </div>
+                )
+              })}
+            </div>
+          )}
+        </div>
+        <button
+          type="button"
+          onClick={goRight}
+          disabled={!canGoRight}
+          className="absolute -right-4 min-[1440px]:-right-12 top-1/2 -translate-y-1/2 z-10 flex items-center justify-center size-9 rounded-full bg-primary text-white hover:bg-primary/90 shadow-md transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:bg-primary"
+        >
+          <TbChevronRight className="size-5" />
+        </button>
+      </div>
+
+      {/* Popup Dialog */}
+      <DaDialog open={openRemindDialog} onOpenChange={setOpenRemindDialog}>
+        <div className="flex flex-col max-w-xl">
+          <h3 className="text-lg font-semibold text-primary">
+            Sign In Required
+          </h3>
+          <p className="mt-4 text-base text-muted-foreground">
+            You must first sign in to explore SDV idea about
+            <span className="text-primary px-1 font-semibold">
+              {selectedPrototype?.name}
+            </span>
+          </p>
+          <div className="flex justify-end mt-6">
+            <Button
+              variant="default"
+              size="sm"
+              onClick={() => {
+                setOpenRemindDialog(false)
+                setOpenLoginDialog(true)
+              }}
+              className="w-20"
+            >
+              Sign In
+            </Button>
+          </div>
+        </div>
+      </DaDialog>
+    </div>
+  )
+}
+
+export default HomePrototypeList

--- a/frontend/src/components/organisms/PrototypeLibraryList.tsx
+++ b/frontend/src/components/organisms/PrototypeLibraryList.tsx
@@ -14,7 +14,7 @@ import { useParams, useNavigate } from 'react-router-dom'
 import { DaPrototypeCard } from '../molecules/DaPrototypeCard'
 import DaErrorDisplay from '../molecules/DaErrorDisplay'
 import DaSkeletonGrid from '../molecules/DaSkeletonGrid'
-import { getPrototypeLastViewed } from '@/utils/prototypeLastViewed'
+import { sortPrototypesByViewed } from '@/utils/prototypeSort'
 
 interface PrototypeLibraryListProps {
   selectedFilters?: string[]
@@ -55,52 +55,42 @@ const PrototypeLibraryList = ({
 
   useEffect(() => {
     if (!fetchedPrototypes) return
-    const lastViewed = getPrototypeLastViewed()
+
+    const filtered = fetchedPrototypes.filter((prototype) => {
+      if (!searchInput) return true
+      return prototype.name.toLowerCase().includes(searchInput.toLowerCase())
+    })
+
+    if (selectedFilters?.includes('Last view')) {
+      setFilteredPrototypes(sortPrototypesByViewed(filtered, 'last-viewed'))
+      return
+    }
+    if (selectedFilters?.includes('First view')) {
+      setFilteredPrototypes(sortPrototypesByViewed(filtered, 'first-viewed'))
+      return
+    }
+
     const compareNames = (a: Prototype, b: Prototype) =>
       a.name.localeCompare(b.name)
 
     setFilteredPrototypes(
-      fetchedPrototypes
-        .filter((prototype) => {
-          if (!searchInput) return true
-          return prototype.name
-            .toLowerCase()
-            .includes(searchInput.toLowerCase())
-        })
-        .sort((a: Prototype, b: Prototype) => {
-          const dateA = a.createdAt ? new Date(a.createdAt).getTime() : 0
-          const dateB = b.createdAt ? new Date(b.createdAt).getTime() : 0
+      [...filtered].sort((a: Prototype, b: Prototype) => {
+        const dateA = a.createdAt ? new Date(a.createdAt).getTime() : 0
+        const dateB = b.createdAt ? new Date(b.createdAt).getTime() : 0
 
-          if (selectedFilters?.includes('Newest')) {
-            return dateB - dateA
-          } else if (selectedFilters?.includes('Oldest')) {
-            return dateA - dateB
-          } else if (
-            selectedFilters?.includes('Last view') ||
-            selectedFilters?.includes('First view')
-          ) {
-            const lastViewedA = lastViewed[a.id]
-            const lastViewedB = lastViewed[b.id]
-            const hasViewedA = lastViewedA !== undefined
-            const hasViewedB = lastViewedB !== undefined
-
-            if (!hasViewedA && !hasViewedB) return compareNames(a, b)
-            if (!hasViewedA) return 1
-            if (!hasViewedB) return -1
-
-            const timestampDifference = selectedFilters.includes('Last view')
-              ? lastViewedB - lastViewedA
-              : lastViewedA - lastViewedB
-            return timestampDifference || compareNames(a, b)
-          } else if (selectedFilters?.includes('Name A-Z')) {
-            return compareNames(a, b)
-          } else if (selectedFilters?.includes('Name Z-A')) {
-            return compareNames(b, a)
-          } else if (selectedFilters?.includes('Rating')) {
-            return (b.avg_score ?? 0) - (a.avg_score ?? 0)
-          }
-          return 0
-        }),
+        if (selectedFilters?.includes('Newest')) {
+          return dateB - dateA
+        } else if (selectedFilters?.includes('Oldest')) {
+          return dateA - dateB
+        } else if (selectedFilters?.includes('Name A-Z')) {
+          return compareNames(a, b)
+        } else if (selectedFilters?.includes('Name Z-A')) {
+          return compareNames(b, a)
+        } else if (selectedFilters?.includes('Rating')) {
+          return (b.avg_score ?? 0) - (a.avg_score ?? 0)
+        }
+        return 0
+      }),
     )
   }, [searchInput, selectedFilters, fetchedPrototypes])
 

--- a/frontend/src/components/organisms/PrototypeTabInfo.tsx
+++ b/frontend/src/components/organisms/PrototypeTabInfo.tsx
@@ -7,6 +7,7 @@
 // SPDX-License-Identifier: MIT
 
 import React, { useState, useEffect, useMemo } from 'react'
+import { useQueryClient } from '@tanstack/react-query'
 import { Prototype } from '../../types/model.type'
 import { DaImage } from '../atoms/DaImage'
 import { Button } from '../atoms/button'
@@ -36,7 +37,10 @@ import { updatePrototypeService, deletePrototypeService } from '@/services/proto
 import { uploadFileService } from '@/services/upload.service'
 import useCurrentModel from '@/hooks/useCurrentModel'
 import { useNavigate } from 'react-router-dom'
-import { useListModelPrototypes } from '@/hooks/usePrototypeQueries'
+import {
+  invalidatePrototypeListQueries,
+  useListModelPrototypes,
+} from '@/hooks/usePrototypeQueries'
 import useCurrentPrototype from '@/hooks/useCurrentPrototype'
 import usePermissionHook from '@/hooks/usePermissionHook'
 import { PERMISSIONS } from '@/data/permission'
@@ -63,6 +67,7 @@ const PrototypeTabInfo: React.FC<PrototypeTabInfoProps> = ({
   const [isEditing, setIsEditing] = useState(false)
   const [localPrototype, setLocalPrototype] = useState(prototype)
   const defaultPrototypeImage = useDefaultPrototypeImage()
+  const queryClient = useQueryClient()
   const { data: model } = useCurrentModel()
   const { data: modelPrototypes, refetch: refetchModelPrototypes } = useListModelPrototypes(
     model?.id || '',
@@ -201,7 +206,7 @@ const PrototypeTabInfo: React.FC<PrototypeTabInfoProps> = ({
     try {
       setIsDeleting(true)
       await deletePrototypeService(prototype.id)
-      await refetchModelPrototypes()
+      await invalidatePrototypeListQueries(queryClient)
       navigate(`/model/${model?.id}/library`)
     } catch (error) {
       console.error('Failed to delete prototype:', error)

--- a/frontend/src/hooks/usePrototypeQueries.ts
+++ b/frontend/src/hooks/usePrototypeQueries.ts
@@ -6,7 +6,7 @@
 //
 // SPDX-License-Identifier: MIT
 
-import { useQuery } from '@tanstack/react-query'
+import { QueryClient, useQuery } from '@tanstack/react-query'
 import {
   listPopularPrototypes,
   listRecentPrototypes,
@@ -17,10 +17,18 @@ export const prototypeQueryKeys = {
   all: ['prototypes'] as const,
   paged: (params: Record<string, unknown>) =>
     ['prototypes', 'paged', params] as const,
+  allForViewSort: (params: Record<string, unknown>) =>
+    ['prototypes', 'all-for-view-sort', params] as const,
   model: (modelId: string) => ['listModelPrototypes', modelId] as const,
   recent: () => ['prototypes', 'recent'] as const,
   popular: () => ['prototypes', 'popular'] as const,
 }
+
+export const invalidatePrototypeListQueries = (queryClient: QueryClient) =>
+  Promise.all([
+    queryClient.invalidateQueries({ queryKey: prototypeQueryKeys.all }),
+    queryClient.invalidateQueries({ queryKey: ['listModelPrototypes'] }),
+  ])
 
 export const usePopularPrototypes = (enabled = true) =>
   useQuery({

--- a/frontend/src/hooks/useUrlQueryParam.ts
+++ b/frontend/src/hooks/useUrlQueryParam.ts
@@ -1,0 +1,45 @@
+// Copyright (c) 2025 Eclipse Foundation.
+//
+// This program and the accompanying materials are made available under the
+// terms of the MIT License which is available at
+// https://opensource.org/licenses/MIT.
+//
+// SPDX-License-Identifier: MIT
+
+import { useCallback, useMemo } from 'react'
+import { useSearchParams } from 'react-router-dom'
+
+export function useUrlQueryParam<T extends string>(
+  key: string,
+  validValues: readonly T[],
+  defaultValue: T,
+): [T, (value: T) => void] {
+  const [searchParams, setSearchParams] = useSearchParams()
+
+  const value = useMemo(() => {
+    const raw = searchParams.get(key)
+    return raw && (validValues as readonly string[]).includes(raw)
+      ? (raw as T)
+      : defaultValue
+  }, [searchParams, key, validValues, defaultValue])
+
+  const setValue = useCallback(
+    (next: T) => {
+      setSearchParams(
+        (prev) => {
+          const params = new URLSearchParams(prev)
+          if (next === defaultValue) {
+            params.delete(key)
+          } else {
+            params.set(key, next)
+          }
+          return params
+        },
+        { replace: true },
+      )
+    },
+    [key, defaultValue, setSearchParams],
+  )
+
+  return [value, setValue]
+}

--- a/frontend/src/pages/PageModelList.tsx
+++ b/frontend/src/pages/PageModelList.tsx
@@ -36,6 +36,7 @@ import { useAuthConfigs } from '@/hooks/useAuthConfigs'
 import useDuplicateNameCheck from '@/hooks/useDuplicateNameCheck'
 import DaDuplicateNameHint from '@/components/atoms/DaDuplicateNameHint'
 import { isAxiosError } from 'axios'
+import { invalidatePrototypeListQueries } from '@/hooks/usePrototypeQueries'
 
 type ModelTab = 'myModel' | 'myContribution' | 'public'
 
@@ -265,6 +266,7 @@ const PageModelList = () => {
               return createPrototypeService(newPrototype)
             }),
           )
+          await invalidatePrototypeListQueries(queryClient)
         }
 
         await refetch()

--- a/frontend/src/pages/PagePrototypeDetail.tsx
+++ b/frontend/src/pages/PagePrototypeDetail.tsx
@@ -277,7 +277,7 @@ const PagePrototypeDetail: FC<ViewPrototypeProps> = ({}) => {
         data,
       })
       invalidateProjectTemplateQueries(queryClient)
-      toast.success('Project template saved')
+      toast.success('Prototype template saved')
       setOpenSaveProjectTemplate(false)
       setProjectTemplateName('')
       setProjectTemplateDescription('')

--- a/frontend/src/pages/ProjectTemplateManager.tsx
+++ b/frontend/src/pages/ProjectTemplateManager.tsx
@@ -65,7 +65,7 @@ export default function ProjectTemplateManager() {
   return (
     <div className="p-6">
       <div className="mb-4 flex items-center justify-between">
-        <h1 className="text-xl font-semibold">Project Templates</h1>
+        <h1 className="text-xl font-semibold">Prototype Templates</h1>
         <Button
           onClick={() => {
             setEditId(undefined)
@@ -154,7 +154,7 @@ export default function ProjectTemplateManager() {
           <div className="col-span-full text-center py-12">
             <TbFileCode className="size-12 mx-auto text-muted-foreground mb-2" />
             <p className="text-sm text-muted-foreground">
-              No project templates yet
+              No prototype templates yet
             </p>
           </div>
         )}
@@ -171,8 +171,8 @@ export default function ProjectTemplateManager() {
       />
 
       <DaConfirmPopup
-        title="Delete Project Template"
-        label="This will permanently delete the project template. This action cannot be undone."
+        title="Delete Prototype Template"
+        label="This will permanently delete the prototype template. This action cannot be undone."
         state={[openConfirm, setOpenConfirm]}
         onConfirm={() => {
           if (deleteId) del.mutate(deleteId)

--- a/frontend/src/services/prototype.service.ts
+++ b/frontend/src/services/prototype.service.ts
@@ -10,6 +10,32 @@ import { List } from '@/types/common.type'
 import { serverAxios, cacheAxios } from './base'
 import { Prototype } from '@/types/model.type'
 
+export const PROTOTYPE_LIST_CARD_FIELDS = [
+  'model_id',
+  'name',
+  'visibility',
+  'image_file',
+  'id',
+  'created_at',
+  'created_by',
+  'tags',
+  'state',
+  'code',
+  'executed_turns',
+].join(',')
+
+const PROTOTYPE_LIST_DEFAULT_FIELDS = [
+  'model_id',
+  'name',
+  'visibility',
+  'image_file',
+  'id',
+  'created_at',
+  'created_by',
+  'tags',
+  'state',
+].join(',')
+
 export const listPopularPrototypes = async (): Promise<Prototype[]> => {
   const response = await serverAxios.get('/prototypes/popular')
   return response.data
@@ -20,35 +46,51 @@ export const listRecentPrototypes = async (): Promise<Prototype[]> => {
   return response.data
 }
 
-export const listAllPrototypes = async (): Promise<List<Prototype>> => {
+export const listPrototypesPaged = async (params: {
+  page: number
+  limit: number
+  sortBy?: string
+  created_by?: string
+  fields?: string
+}): Promise<List<Prototype>> => {
+  const requestParams = {
+    fields: params.fields ?? PROTOTYPE_LIST_DEFAULT_FIELDS,
+    ...params,
+  }
+
+  try {
+    const response = await serverAxios.get<List<Prototype>>('/prototypes', {
+      params: requestParams,
+    })
+    return response.data
+  } catch (error) {
+    console.error(`[listPrototypesPaged] Request failed:`, error)
+    throw error
+  }
+}
+
+export const listAllPrototypesFiltered = async (params?: {
+  created_by?: string
+  fields?: string
+}): Promise<Prototype[]> => {
   let page = 1
-  const limit = 12
-  let allResults: Prototype[] = []
+  const limit = 50
+  const allResults: Prototype[] = []
   let totalPages = 1
-  const addedIds = new Set<string>() // To track added prototype IDs, BE have duplicate data
+  const addedIds = new Set<string>()
 
   do {
     const response = await serverAxios.get<List<Prototype>>('/prototypes', {
       params: {
-        fields: [
-          'model_id',
-          'name',
-          'visibility',
-          'image_file',
-          'id',
-          'created_at',
-          'created_by',
-          'tags',
-          'state',
-        ].join(','),
+        fields: params?.fields ?? PROTOTYPE_LIST_DEFAULT_FIELDS,
+        ...(params?.created_by ? { created_by: params.created_by } : {}),
         page,
         limit,
       },
     })
 
     response.data.results.forEach((prototype) => {
-      if (addedIds.has(prototype.id)) {
-      } else {
+      if (!addedIds.has(prototype.id)) {
         addedIds.add(prototype.id)
         allResults.push(prototype)
       }
@@ -57,6 +99,12 @@ export const listAllPrototypes = async (): Promise<List<Prototype>> => {
     totalPages = response.data.totalPages
     page++
   } while (page <= totalPages)
+
+  return allResults
+}
+
+export const listAllPrototypes = async (): Promise<List<Prototype>> => {
+  const allResults = await listAllPrototypesFiltered()
 
   return {
     results: allResults,

--- a/frontend/src/utils/homeComponentMap.ts
+++ b/frontend/src/utils/homeComponentMap.ts
@@ -12,6 +12,7 @@ import HomeFeatureList from '@/components/organisms/HomeFeatureList'
 import HomeButtonList from '@/components/organisms/HomeButtonList'
 import HomePrototypeRecent from '@/components/organisms/HomePrototypeRecent'
 import HomePrototypePopular from '@/components/organisms/HomePrototypePopular'
+import HomePrototypeList from '@/components/organisms/HomePrototypeList'
 import HomeNews from '@/components/organisms/HomeNews'
 import HomeFooterSection from '@/components/organisms/HomeFooterSection'
 
@@ -22,6 +23,7 @@ const homeComponentMap: Record<string, React.ComponentType<any>> = {
   'news': HomeNews,
   'recent': HomePrototypeRecent,
   'popular': HomePrototypePopular,
+  'prototype-list': HomePrototypeList,
   'partner-list': HomePartners,
   'home-footer': HomeFooterSection,
 }
@@ -40,6 +42,7 @@ export const getBlockTypeLabel = (type: string): string => {
     'news': 'News',
     'recent': 'Recent prototypes',
     'popular': 'Popular prototypes',
+    'prototype-list': 'All prototypes',
     'partner-list': 'Partners',
     'home-footer': 'Footer',
   }

--- a/frontend/src/utils/projectTemplate.ts
+++ b/frontend/src/utils/projectTemplate.ts
@@ -217,7 +217,7 @@ export const EMPTY_PROJECT_TEMPLATE_FORM: ProjectTemplateFormState = {
 }
 
 export const DUPLICATE_TEMPLATE_NAME_MESSAGE =
-  'A project template with this name already exists'
+  'A prototype template with this name already exists'
 
 export function getProjectTemplateErrorMessage(
   error: unknown,

--- a/frontend/src/utils/prototypeSort.ts
+++ b/frontend/src/utils/prototypeSort.ts
@@ -1,0 +1,41 @@
+// Copyright (c) 2025 Eclipse Foundation.
+//
+// This program and the accompanying materials are made available under the
+// terms of the MIT License which is available at
+// https://opensource.org/licenses/MIT.
+//
+// SPDX-License-Identifier: MIT
+
+import { Prototype } from '@/types/model.type'
+import {
+  getPrototypeLastViewed,
+  PrototypeLastViewed,
+} from '@/utils/prototypeLastViewed'
+
+export type PrototypeViewSort = 'last-viewed' | 'first-viewed'
+
+const compareNames = (a: Prototype, b: Prototype) =>
+  a.name.localeCompare(b.name)
+
+export function sortPrototypesByViewed(
+  prototypes: Prototype[],
+  mode: PrototypeViewSort,
+  lastViewed: PrototypeLastViewed = getPrototypeLastViewed(),
+): Prototype[] {
+  return [...prototypes].sort((a, b) => {
+    const lastViewedA = lastViewed[a.id]
+    const lastViewedB = lastViewed[b.id]
+    const hasViewedA = lastViewedA !== undefined
+    const hasViewedB = lastViewedB !== undefined
+
+    if (!hasViewedA && !hasViewedB) return compareNames(a, b)
+    if (!hasViewedA) return 1
+    if (!hasViewedB) return -1
+
+    const timestampDifference =
+      mode === 'last-viewed'
+        ? lastViewedB - lastViewedA
+        : lastViewedA - lastViewedB
+    return timestampDifference || compareNames(a, b)
+  })
+}


### PR DESCRIPTION
Add HomePrototypeList as a configurable home block with category/sort filters, URL-persisted state, and a carousel UI. Last/First Viewed sorts fetch all prototypes and sort client-side via shared sortPrototypesByViewed. Invalidate prototype list queries on delete so home and library views refresh.