### PR TITLE
feat(dashboard): send app-running-state to built-in widgets

### DIFF
--- a/backend/static/builtin-widgets/syncer.js
+++ b/backend/static/builtin-widgets/syncer.js
@@ -210,6 +210,11 @@ window.addEventListener("message", function (e) {
           appendLog(payload.log)
         }
         break;
+      case "app-running-state":
+        if (onAppRunningStateChanged != undefined) {
+          onAppRunningStateChanged(!!payload.isRunning)
+        }
+        break;
       default:
         break;
     }

--- a/frontend/src/components/molecules/DaRuntimeConnector.tsx
+++ b/frontend/src/components/molecules/DaRuntimeConnector.tsx
@@ -133,8 +133,8 @@ const DaRuntimeConnector = forwardRef<any, KitConnectProps>(
       }
     })
 
-    const [apisValue, setActiveApis, setTraceVars, setAppLog] = useRuntimeStore(
-      (state) => [state.apisValue, state.setActiveApis, state.setTraceVars, state.setAppLog],
+    const [apisValue, setActiveApis, setTraceVars, setAppLog, setIsAppRunning] = useRuntimeStore(
+      (state) => [state.apisValue, state.setActiveApis, state.setTraceVars, state.setAppLog, state.setIsAppRunning],
       shallow,
     )
 
@@ -556,6 +556,7 @@ const DaRuntimeConnector = forwardRef<any, KitConnectProps>(
           if (onNewLog) {
             onNewLog(`Exit code ${payload.code}\r\n`)
           }
+          setIsAppRunning(false)
           if (onAppRunningStateChanged) {
             onAppRunningStateChanged(false)
           }
@@ -701,6 +702,7 @@ const DaRuntimeConnector = forwardRef<any, KitConnectProps>(
         }
       }
 
+      setIsAppRunning(newRunningState)
       if (onAppRunningStateChanged) {
         onAppRunningStateChanged(newRunningState)
       }

--- a/frontend/src/components/molecules/dashboard/DaDashboardGrid.tsx
+++ b/frontend/src/components/molecules/dashboard/DaDashboardGrid.tsx
@@ -23,6 +23,7 @@ interface PropsWidgetItem {
   apisValue: any
   appLog?: string
   vssTree?: any
+  isAppRunning?: boolean
 }
 
 const WidgetItem: FC<PropsWidgetItem> = ({
@@ -30,6 +31,7 @@ const WidgetItem: FC<PropsWidgetItem> = ({
   apisValue,
   appLog,
   vssTree,
+  isAppRunning,
 }) => {
   const [rSpan, setRSpan] = useState<number>(0)
   const [cSpan, setCSpan] = useState<number>(0)
@@ -108,6 +110,18 @@ const WidgetItem: FC<PropsWidgetItem> = ({
     sendVssTreeToWidget(vssTree)
   }, [vssTree, iframeLoaded])
 
+  // Send app running state to widget whenever it changes
+  useEffect(() => {
+    if (!iframeLoaded) return
+    frameElement?.current?.contentWindow?.postMessage(
+      JSON.stringify({
+        cmd: 'app-running-state',
+        isRunning: !!isAppRunning,
+      }),
+      '*',
+    )
+  }, [isAppRunning, iframeLoaded])
+
   if (!widgetConfig)
     return (
       <div
@@ -157,10 +171,11 @@ const DaDashboardGrid: FC<DaDashboardGridProps> = ({ widgetItems }) => {
   // Memoize VSS tree to prevent unnecessary re-renders with large data
   const memoizedVssTree = useMemo(() => cvi, [cvi])
 
-  const [apisValue, traceVars, appLog] = useRuntimeStore((state) => [
+  const [apisValue, traceVars, appLog, isAppRunning] = useRuntimeStore((state) => [
     state.apisValue,
     state.traceVars,
     state.appLog,
+    state.isAppRunning,
   ])
 
   const [allVars, setAllVars] = useState<any>({})
@@ -246,6 +261,7 @@ const DaDashboardGrid: FC<DaDashboardGridProps> = ({ widgetItems }) => {
                   apisValue={allVars}
                   appLog={appLog}
                   vssTree={memoizedVssTree}
+                  isAppRunning={isAppRunning}
                 />
               )
             } else if (widgetIndex === -1) {

--- a/frontend/src/stores/runtimeStore.ts
+++ b/frontend/src/stores/runtimeStore.ts
@@ -14,18 +14,21 @@ type RuntimeState = {
   apisValue?: {}
   traceVars?: {}
   appLog?: string
+  isAppRunning: boolean
 }
 
 type Actions = {
   setActiveApis: (_: any) => void
   setAppLog: (log: string) => void
   setTraceVars: (_: any) => void
+  setIsAppRunning: (isRunning: boolean) => void
 }
 
 const useRuntimeStore = createWithEqualityFn<RuntimeState & Actions>()(
   immer((set) => ({
     apisValue: [],
     appLog: "",
+    isAppRunning: false,
     setAppLog: (log) => {
       set((state) => {
         state.appLog = log
@@ -38,7 +41,11 @@ const useRuntimeStore = createWithEqualityFn<RuntimeState & Actions>()(
     setTraceVars: (values) =>
       set((state) => {
         state.traceVars = values
-      })
+      }),
+    setIsAppRunning: (isRunning) =>
+      set((state) => {
+        state.isAppRunning = isRunning
+      }),
   }))
 )
 


### PR DESCRIPTION
Wire runtime app running state through the store and postMessage so widgets can react via onAppRunningStateChanged in syncer.js