### PR TITLE
Remove duplicate Config Runtime Server UI

### DIFF
--- a/docs/architecture/realtime-signals.md
+++ b/docs/architecture/realtime-signals.md
@@ -44,8 +44,7 @@ flowchart LR
 
 - **Server URL** — the `kitServerUrl` prop, resolved by callers from the
   `RUNTIME_SERVER_URL` site config → `config.runtime.url`
-  (`https://kit.digitalauto.tech`), overridable by a user's `customKitServer`
-  (localStorage). Extra options come from `RUNTIME_SERVER_CONFIG`.
+  (`https://kit.digitalauto.tech`). Extra options come from `RUNTIME_SERVER_CONFIG`.
 - **Connect / register** — on connect it emits `register_client` `{ username,
   user_id, domain }` (and `unregister_client` on cleanup), then
   `messageToKit { cmd: 'list-all-kits' }` to discover kits.
@@ -111,7 +110,6 @@ connector(s) and drives execution:
   `stop-app` to widget iframes.
 - Tabs: Terminal (logs), Signals Watch (`DaApisWatch`), Vars Watch, Mock Services
   (`DaMockManager`).
-- A config dialog lets the user point at a custom kit server.
 
 ---
 

--- a/frontend/src/components/molecules/dashboard/DaRuntimeControl.tsx
+++ b/frontend/src/components/molecules/dashboard/DaRuntimeControl.tsx
@@ -9,9 +9,8 @@
 import { FC, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Button } from '@/components/atoms/button'
 import { Input } from '@/components/atoms/input'
-import { TbPlayerPlayFilled, TbPlayerStopFilled, TbSettings } from 'react-icons/tb'
+import { TbPlayerPlayFilled, TbPlayerStopFilled } from 'react-icons/tb'
 import { FaAnglesLeft, FaAnglesRight } from 'react-icons/fa6'
-import { SlOptionsVertical } from 'react-icons/sl'
 import { cn } from '@/lib/utils'
 import useModelStore from '@/stores/modelStore'
 import { Prototype } from '@/types/model.type'
@@ -87,17 +86,8 @@ const DaRuntimeControl: FC<DaRuntimeControlProps> = ({ className }) => {
   const [activeRtId, setActiveRtId] = useState<string | undefined>('')
   const [log, setLog] = useState<string>('')
   const runTimeRef = useRef<any>()
-  const runTimeRef1 = useRef<any>()
 
   const [activeTab, setActiveTab] = useState<string>('output')
-  const [customKitServer, setCustomKitServer] = useState<string>(
-    localStorage.getItem('customKitServer') || '',
-  )
-  const [tmpCustomKitServer, setTmpCustomKitServer] = useState<string>(
-    localStorage.getItem('customKitServer') || '',
-  )
-  const [showConfigDialog, setShowConfigDialog] = useState<boolean>(false)
-  const [runtimeMenuOpen, setRuntimeMenuOpen] = useState(false)
   const [useRuntime, setUseRuntime] = useState<boolean>(true)
   const [mockSignals, setMockSignals] = useState<any[]>([])
   const [curRuntimeInfo, setCurRuntimeInfo] = useState<any>(null)
@@ -115,10 +105,6 @@ const DaRuntimeControl: FC<DaRuntimeControlProps> = ({ className }) => {
   const [isAdvantageMode, setIsAdvantageMode] = useState<number>(-5)
   const rustCompilerRef = useRef<any>()
   
-
-  useEffect(() => {
-    localStorage.setItem('customKitServer', customKitServer.trim())
-  }, [customKitServer])
 
   useEffect(() => {
     setCurRuntimeInfo(null)
@@ -166,12 +152,7 @@ const DaRuntimeControl: FC<DaRuntimeControlProps> = ({ className }) => {
         }
         break
       default:
-        if (runTimeRef.current) {
-          runTimeRef.current?.runApp(code || '', prototype?.name || 'App name')
-        }
-        if (runTimeRef1.current) {
-          runTimeRef1.current?.runApp(code || '', prototype?.name || 'App name')
-        }
+        runTimeRef.current?.runApp(code || '', prototype?.name || 'App name')
     }
 
     notifyWidgetIframes({
@@ -195,12 +176,7 @@ const DaRuntimeControl: FC<DaRuntimeControlProps> = ({ className }) => {
     switch (prototype?.language) {
       case 'rust':
       default:
-        if (runTimeRef.current) {
-          runTimeRef.current?.stopApp()
-        }
-        if (runTimeRef1.current) {
-          runTimeRef1.current?.stopApp()
-        }
+        runTimeRef.current?.stopApp()
         break
     }
     notifyWidgetIframes({
@@ -219,22 +195,12 @@ const DaRuntimeControl: FC<DaRuntimeControlProps> = ({ className }) => {
 
   const writeSignalValue = (obj: any) => {
     if (!obj) return
-    if (runTimeRef.current) {
-      runTimeRef.current?.writeSignalsValue(obj)
-    }
-    if (runTimeRef1.current) {
-      runTimeRef1.current?.writeSignalsValue(obj)
-    }
+    runTimeRef.current?.writeSignalsValue(obj)
   }
 
   const writeVarsValue = (obj: any) => {
     if (!obj) return
-    if (runTimeRef.current) {
-      runTimeRef.current?.writeVarsValue(obj)
-    }
-    if (runTimeRef1.current) {
-      runTimeRef1.current?.writeVarsValue(obj)
-    }
+    runTimeRef.current?.writeVarsValue(obj)
   }
 
   const notifyWidgetIframes = (data: any) => {
@@ -346,54 +312,6 @@ const DaRuntimeControl: FC<DaRuntimeControlProps> = ({ className }) => {
         />
       </DaDialog>
 
-      {/* Runtime Server Config Dialog */}
-      <DaDialog
-        open={showConfigDialog}
-        onOpenChange={setShowConfigDialog}
-        trigger={<span></span>}
-        className="w-[600px] max-w-[90vw]"
-        showCloseButton={false}
-        dialogTitle="Configure Runtime Server"
-        footer={
-          <>
-            <Button
-              variant="outline"
-              onClick={() => {
-                setTmpCustomKitServer(customKitServer)
-                setShowConfigDialog(false)
-              }}
-            >
-              Cancel
-            </Button>
-            <Button
-              onClick={() => {
-                const newServer = tmpCustomKitServer.trim()
-                localStorage.setItem('customKitServer', newServer)
-                setCustomKitServer(newServer)
-                setShowConfigDialog(false)
-                scheduleRuntimeReconnect(100)
-              }}
-            >
-              Save
-            </Button>
-          </>
-        }
-      >
-        <div className="space-y-3">
-          <p className="text-sm text-muted-foreground">
-            Runtime server URL: leave empty to use default server
-          </p>
-          <Input
-            className="w-full text-primary"
-            value={tmpCustomKitServer}
-            onChange={(e) => {
-              setTmpCustomKitServer(e.target.value)
-            }}
-            placeholder="Custom server URL"
-          />
-        </div>
-      </DaDialog>
-
       {/* Runtime Controls Header */}
       <div className={cn('px-1 flex items-center', !isExpand && 'hidden')}>
         {useRuntime && (
@@ -404,43 +322,23 @@ const DaRuntimeControl: FC<DaRuntimeControlProps> = ({ className }) => {
             >
               Runtime:
             </label>
-            {customKitServer && customKitServer.trim().length > 0 ? (
-              <DaRuntimeConnector
-                targetPrefix="runtime-"
-                kitServerUrl={customKitServer}
-                socketIoConfig={runtimeServerConfig}
-                ref={runTimeRef}
-                usedAPIs={usedApis}
-                hideLabel={true}
-                onActiveRtChanged={(rtId: string | undefined) =>
-                  setActiveRtId(rtId)
-                }
-                onLoadedMockSignals={setMockSignals}
-                onNewLog={appendLog}
-                onAppRunningStateChanged={(state: boolean) => {
-                  setIsRunning(state)
-                }}
-                onRuntimeInfoReceived={setCurRuntimeInfo}
-              />
-            ) : (
-              <DaRuntimeConnector
-                targetPrefix="runtime-"
-                kitServerUrl={runtimeServerUrl}
-                socketIoConfig={runtimeServerConfig}
-                ref={runTimeRef1}
-                usedAPIs={usedApis}
-                hideLabel={true}
-                onActiveRtChanged={(rtId: string | undefined) =>
-                  setActiveRtId(rtId)
-                }
-                onLoadedMockSignals={setMockSignals}
-                onNewLog={appendLog}
-                onAppRunningStateChanged={(state: boolean) => {
-                  setIsRunning(state)
-                }}
-                onRuntimeInfoReceived={setCurRuntimeInfo}
-              />
-            )}
+            <DaRuntimeConnector
+              targetPrefix="runtime-"
+              kitServerUrl={runtimeServerUrl}
+              socketIoConfig={runtimeServerConfig}
+              ref={runTimeRef}
+              usedAPIs={usedApis}
+              hideLabel={true}
+              onActiveRtChanged={(rtId: string | undefined) =>
+                setActiveRtId(rtId)
+              }
+              onLoadedMockSignals={setMockSignals}
+              onNewLog={appendLog}
+              onAppRunningStateChanged={(state: boolean) => {
+                setIsRunning(state)
+              }}
+              onRuntimeInfoReceived={setCurRuntimeInfo}
+            />
           </>
         )}
         <div className="pl-2">
@@ -456,31 +354,6 @@ const DaRuntimeControl: FC<DaRuntimeControlProps> = ({ className }) => {
             Add Runtime
           </Button>
         </div>
-        <div className="grow" />
-        <DropdownMenu open={runtimeMenuOpen} onOpenChange={setRuntimeMenuOpen}>
-          <DropdownMenuTrigger asChild>
-            <div
-              className="cursor-pointer hover:bg-slate-500 p-2 rounded"
-              style={{ color: 'hsl(0, 0%, 100%)' }}
-            >
-              <SlOptionsVertical size={20} />
-            </div>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent align="end">
-            <DropdownMenuItem
-              onClick={() => {
-                setRuntimeMenuOpen(false)
-                setTmpCustomKitServer(customKitServer)
-                setShowConfigDialog(true)
-              }}
-            >
-              <div className="flex w-full items-center justify-between gap-2">
-                <TbSettings className="w-5 h-5" />
-                <span>Config Runtime Server</span>
-              </div>
-            </DropdownMenuItem>
-          </DropdownMenuContent>
-        </DropdownMenu>
       </div>
 
       {/* Play/Stop Controls */}
@@ -538,12 +411,7 @@ const DaRuntimeControl: FC<DaRuntimeControlProps> = ({ className }) => {
                 appendLog(log)
                 if (isDone) {
                   if (status === 'compile-done' && appName) {
-                    if (runTimeRef.current) {
-                      runTimeRef.current?.runBinApp(appName)
-                    }
-                    if (runTimeRef1.current) {
-                      runTimeRef1.current?.runBinApp(appName)
-                    }
+                    runTimeRef.current?.runBinApp(appName)
                   }
                 }
               }}
@@ -600,16 +468,7 @@ const DaRuntimeControl: FC<DaRuntimeControlProps> = ({ className }) => {
                           }`}
                         onClick={() => {
                           if (!requestContent.trim()) return
-                          if (runTimeRef.current) {
-                            runTimeRef.current?.requestInstallLib(
-                              requestContent,
-                            )
-                          }
-                          if (runTimeRef1.current) {
-                            runTimeRef1.current?.requestInstallLib(
-                              requestContent,
-                            )
-                          }
+                          runTimeRef.current?.requestInstallLib(requestContent)
                           setRequestMode('')
                           setRequestContent('')
                         }}
@@ -642,12 +501,7 @@ const DaRuntimeControl: FC<DaRuntimeControlProps> = ({ className }) => {
                         <DropdownMenuContent align="end">
                           <DropdownMenuItem
                             onClick={() => {
-                              if (runTimeRef.current) {
-                                runTimeRef.current?.listPythonLibs()
-                              }
-                              if (runTimeRef1.current) {
-                                runTimeRef1.current?.listPythonLibs()
-                              }
+                              runTimeRef.current?.listPythonLibs()
                             }}
                           >
                             <div className="flex w-full items-center">
@@ -670,12 +524,7 @@ const DaRuntimeControl: FC<DaRuntimeControlProps> = ({ className }) => {
                             onClick={async () => {
                               if (!model) return
                               const vssJson = await getComputedAPIs(model.id)
-                              if (runTimeRef.current) {
-                                runTimeRef.current?.builldVehicleModel(vssJson)
-                              }
-                              if (runTimeRef1.current) {
-                                runTimeRef1.current?.builldVehicleModel(vssJson)
-                              }
+                              runTimeRef.current?.builldVehicleModel(vssJson)
                             }}
                           >
                             <div className="flex w-full items-center">
@@ -685,12 +534,7 @@ const DaRuntimeControl: FC<DaRuntimeControlProps> = ({ className }) => {
 
                           <DropdownMenuItem
                             onClick={() => {
-                              if (runTimeRef.current) {
-                                runTimeRef.current?.revertToDefaultVehicleModel()
-                              }
-                              if (runTimeRef1.current) {
-                                runTimeRef1.current?.revertToDefaultVehicleModel()
-                              }
+                              runTimeRef.current?.revertToDefaultVehicleModel()
                             }}
                           >
                             <div className="flex w-full items-center">
@@ -772,20 +616,10 @@ const DaRuntimeControl: FC<DaRuntimeControlProps> = ({ className }) => {
               <DaMockManager
                 mockSignals={mockSignals}
                 loadMockSignalsFromRt={() => {
-                  if (runTimeRef.current) {
-                    runTimeRef.current?.loadMockSignals()
-                  }
-                  if (runTimeRef1.current) {
-                    runTimeRef1.current?.loadMockSignals()
-                  }
+                  runTimeRef.current?.loadMockSignals()
                 }}
                 sendMockSignalsToRt={(signals: any[]) => {
-                  if (runTimeRef.current) {
-                    runTimeRef.current?.setMockSignals(signals)
-                  }
-                  if (runTimeRef1.current) {
-                    runTimeRef1.current?.setMockSignals(signals)
-                  }
+                  runTimeRef.current?.setMockSignals(signals)
                 }}
               />
             )}


### PR DESCRIPTION
Drop the per-browser localStorage override in DaRuntimeControl and rely solely on the site-wide RUNTIME_SERVER_URL site config. Simplifies to a single DaRuntimeConnector and updates realtime-signals docs accordingly.