### PR TITLE
feat(frontend): add VSS_PLUGINS config-driven tabs to COVESA VSS page

### DIFF
--- a/frontend/src/components/organisms/ViewApiCovesa.tsx
+++ b/frontend/src/components/organisms/ViewApiCovesa.tsx
@@ -21,6 +21,7 @@ import {
   TbList,
   TbDownload,
   TbReplace,
+  TbFileImport,
   TbLoader,
 } from 'react-icons/tb'
 import useCurrentModel from '@/hooks/useCurrentModel'
@@ -34,6 +35,14 @@ import { Button } from '@/components/atoms/button'
 import usePermissionHook from '@/hooks/usePermissionHook'
 import { PERMISSIONS } from '@/data/permission'
 import { Spinner } from '@/components/atoms/spinner'
+import PluginPageRender from '@/components/organisms/PluginPageRender'
+import { getPluginBySlug } from '@/services/plugin.service'
+import { useSiteConfig } from '@/utils/siteConfig'
+
+interface VssPluginConfig {
+  label: string
+  plugin: string
+}
 
 const ViewApiCovesa = () => {
   const { model_id, api: apiParam } = useParams<{ model_id: string; api?: string }>()
@@ -42,6 +51,7 @@ const ViewApiCovesa = () => {
   const [activeTab, setActiveTab] = useState<
     'list' | 'tree' | 'compare' | 'hierarchical'
   >('list')
+  const [openPluginIndex, setOpenPluginIndex] = useState<number | null>(null)
   const [activeModelApis, refreshModel] = useModelStore((state) => [
     state.activeModelApis,
     state.refreshModel,
@@ -56,6 +66,47 @@ const ViewApiCovesa = () => {
   const [loading, setLoading] = useState(false)
   const [url, setUrl] = useState('')
   const [showUpload, setShowUpload] = useState(false)
+
+  const vssPluginsConfig = useSiteConfig('VSS_PLUGINS')
+  const [availablePlugins, setAvailablePlugins] = useState<VssPluginConfig[]>([])
+
+  useEffect(() => {
+    let cancelled = false
+    const configs: VssPluginConfig[] = Array.isArray(vssPluginsConfig)
+      ? vssPluginsConfig
+      : []
+
+    const valid = configs.filter(
+      (entry) =>
+        entry &&
+        typeof entry.label === 'string' &&
+        typeof entry.plugin === 'string' &&
+        entry.label.trim() &&
+        entry.plugin.trim(),
+    )
+
+    if (valid.length === 0) {
+      setAvailablePlugins([])
+      return
+    }
+
+    const uniqueSlugs = [...new Set(valid.map((p) => p.plugin))]
+    Promise.allSettled(
+      uniqueSlugs.map((slug) => getPluginBySlug(slug).then(() => slug)),
+    ).then((results) => {
+      if (cancelled) return
+      const installedSlugs = new Set(
+        results
+          .filter((r): r is PromiseFulfilledResult<string> => r.status === 'fulfilled')
+          .map((r) => r.value),
+      )
+      setAvailablePlugins(valid.filter((p) => installedSlugs.has(p.plugin)))
+    })
+
+    return () => {
+      cancelled = true
+    }
+  }, [JSON.stringify(vssPluginsConfig)])
 
   useEffect(() => {
     // Set selected API from route param or default to first API
@@ -199,6 +250,20 @@ const ViewApiCovesa = () => {
               Replace Vehicle API
             </DaTabItem>
           )}
+          {availablePlugins.map((p, i) => (
+            <DaTabItem
+              key={`${p.plugin}-${i}`}
+              active={false}
+              to="#"
+              onClick={(e) => {
+                e.preventDefault()
+                setOpenPluginIndex(i)
+              }}
+            >
+              <TbFileImport className="w-5 h-5 mr-2" />
+              {p.label}
+            </DaTabItem>
+          ))}
         </div>
         <div className="text-sm font-medium text-primary pr-4">
           {model?.api_version && `COVESA VSS ${model.api_version}`}
@@ -237,6 +302,31 @@ const ViewApiCovesa = () => {
         <div className="flex w-full grow overflow-auto justify-center">
           <VssComparator />
         </div>
+      )}
+
+      {openPluginIndex !== null && availablePlugins[openPluginIndex] && (
+        <Dialog
+          open={true}
+          onOpenChange={(open) => {
+            if (!open) setOpenPluginIndex(null)
+          }}
+        >
+          <DialogContent className="max-w-4xl max-h-[80vh] overflow-auto flex flex-col">
+            <DialogHeader>
+              <DialogTitle>
+                {availablePlugins[openPluginIndex].label}
+              </DialogTitle>
+            </DialogHeader>
+            <PluginPageRender
+              key={`plugin-${openPluginIndex}`}
+              plugin_id={availablePlugins[openPluginIndex].plugin}
+              data={{
+                model: model || null,
+                prototype: null,
+              }}
+            />
+          </DialogContent>
+        </Dialog>
       )}
 
       {hasWritePermission && (

--- a/frontend/src/pages/SiteConfigManagement.tsx
+++ b/frontend/src/pages/SiteConfigManagement.tsx
@@ -233,6 +233,16 @@ export const PREDEFINED_SITE_CONFIGS: any[] = [
       'When enabled, hides Custom API Schema / API Set management and all model/prototype UI for custom API sets.',
     category: 'model_prototype',
   },
+  {
+    key: 'VSS_PLUGINS',
+    scope: 'site',
+    value: [{ label: 'A2L Importer', plugin: 'a2l-importer' }],
+    secret: false,
+    valueType: 'array',
+    description:
+      'Plugin tabs to show on the Vehicle API (COVESA VSS) page. Each entry needs a "label" (tab display name) and "plugin" (plugin slug). Example: [{"label":"A2L Importer","plugin":"a2l-importer"}]. Only plugins that are installed will appear.',
+    category: 'model_prototype',
+  },
 ]
 
 export const PREDEFINED_GENAI_CONFIG_KEYS: string[] = PREDEFINED_SITE_CONFIGS.filter(

--- a/frontend/src/utils/siteConfig.ts
+++ b/frontend/src/utils/siteConfig.ts
@@ -6,12 +6,45 @@
 //
 // SPDX-License-Identifier: MIT
 
+import { useState, useEffect } from 'react'
 import { configManagementService } from '../services/configManagement.service'
 
 // Cache for site configs to avoid repeated API calls
 let configCache = new Map<string, any>()
 let cacheExpiry: number | null = null
 const CACHE_DURATION = 5 * 60 * 1000 // 5 minutes
+
+const parseConfigValue = (raw: any, defaultVal: any): any => {
+  if (raw === null || raw === undefined || raw === '') {
+    return defaultVal
+  }
+  if (Array.isArray(defaultVal)) {
+    if (Array.isArray(raw)) return raw
+    if (typeof raw === 'string') {
+      try {
+        const parsed = JSON.parse(raw)
+        if (Array.isArray(parsed)) return parsed
+      } catch {
+        // not valid JSON, fall through
+      }
+    }
+    return defaultVal
+  }
+  if (typeof defaultVal === 'boolean') {
+    if (raw === true || raw === false) {
+      return raw
+    }
+    if (typeof raw === 'string') {
+      const normalized = raw.trim().toLowerCase()
+      if (normalized === 'true' || normalized === '1') return true
+      if (normalized === 'false' || normalized === '0') return false
+    }
+    if (typeof raw === 'number') {
+      return raw === 1
+    }
+  }
+  return raw
+}
 
 // Default fallback values for site configs
 const DEFAULT_SITE_CONFIGS: Record<string, any> = {
@@ -25,6 +58,7 @@ const DEFAULT_SITE_CONFIGS: Record<string, any> = {
   DISABLE_CUSTOM_API_SETS: false,
   GENAI_SDV_APP_ENDPOINT:
     'https://workflow.digital.auto/webhook/c0ba14bc-c6a3-4319-ad0a-ad89b1460b36',
+  VSS_PLUGINS: [{ label: 'A2L Importer', plugin: 'a2l-importer' }],
 }
 
 /**
@@ -247,48 +281,27 @@ export const useSiteConfig = (
   scope: string = 'site',
   target_id?: string,
 ) => {
-  const [value, setValue] = useState<any>(fallback ?? DEFAULT_SITE_CONFIGS[key])
+  const defaultVal = fallback ?? DEFAULT_SITE_CONFIGS[key]
+  const [value, setValue] = useState<any>(() =>
+    parseConfigValue(getConfigSync(key, defaultVal), defaultVal),
+  )
 
   useEffect(() => {
     const loadConfig = async () => {
       try {
-        const result = await getConfig(
-          key,
-          scope,
-          target_id,
-          fallback ?? DEFAULT_SITE_CONFIGS[key],
-        )
-        // Treat null/undefined/empty string as missing -> use fallback/default
-        const raw =
-          result !== null && result !== undefined && result !== ''
-            ? result
-            : (fallback ?? DEFAULT_SITE_CONFIGS[key])
-
-        // Coerce booleans when the consumer expects a boolean fallback.
-        // The config API may return string values like "true"/"false".
-        let next = raw
-        if (typeof (fallback ?? DEFAULT_SITE_CONFIGS[key]) === 'boolean') {
-          if (raw === true || raw === false) {
-            next = raw
-          } else if (typeof raw === 'string') {
-            const normalized = raw.trim().toLowerCase()
-            if (normalized === 'true') next = true
-            else if (normalized === 'false') next = false
-            else if (normalized === '1') next = true
-            else if (normalized === '0') next = false
-          } else if (typeof raw === 'number') {
-            next = raw === 1
-          }
-        }
-        setValue(next)
+        const result = await getConfig(key, scope, target_id, defaultVal)
+        const next = parseConfigValue(result, defaultVal)
+        setValue((prev: any) => (Object.is(prev, next) ? prev : next))
       } catch {
-        setValue(fallback ?? DEFAULT_SITE_CONFIGS[key])
+        setValue((prev: any) =>
+          Object.is(prev, defaultVal) ? prev : defaultVal,
+        )
       }
     }
 
     loadConfig()
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [key, scope, target_id]) // Removed 'fallback' from deps - it's just a default value, not a fetch trigger
+  }, [key, scope, target_id])
 
   return value
 }
@@ -301,6 +314,3 @@ export const useDefaultPrototypeImage = () =>
     'DEFAULT_PROTOTYPE_IMAGE',
     DEFAULT_SITE_CONFIGS.DEFAULT_PROTOTYPE_IMAGE,
   )
-
-// Import React hooks (you might need to adjust the import based on your React version)
-import { useState, useEffect } from 'react'


### PR DESCRIPTION
Expose configurable plugin tabs on ViewApiCovesa via the VSS_PLUGINS site config, validating installed plugin slugs and rendering them in a dialog with PluginPageRender. Add array parsing support in useSiteConfig and an admin config entry for Site Config management.