### PR TITLE
feat: add HIDE_VEHICLE_MODELS_PAGE site config

### DIFF
--- a/backend/src/config/predefinedSiteConfigs.js
+++ b/backend/src/config/predefinedSiteConfigs.js
@@ -220,6 +220,16 @@ const PREDEFINED_SITE_CONFIGS = [
     category: 'model_prototype',
   },
   {
+    key: 'HIDE_VEHICLE_MODELS_PAGE',
+    scope: 'site',
+    value: false,
+    secret: false,
+    valueType: 'boolean',
+    description:
+      'Hide the /model (Vehicle Models) list page. When enabled: visiting /model redirects to Home, the "Vehicle Models" breadcrumb item is removed, and any home buttons whose URL is /model are hidden. Model detail pages (/model/:id) remain accessible.',
+    category: 'model_prototype',
+  },
+  {
     key: 'PUBLIC_VIEWING',
     scope: 'site',
     value: true,

--- a/frontend/src/components/molecules/DaBreadcrumbBar.tsx
+++ b/frontend/src/components/molecules/DaBreadcrumbBar.tsx
@@ -17,6 +17,7 @@ import {
 } from '@/components/atoms/DaBreadcrumb'
 import useCurrentModel from '@/hooks/useCurrentModel'
 import useCurrentPrototype from '@/hooks/useCurrentPrototype'
+import { useSiteConfig } from '@/utils/siteConfig'
 
 const breadcrumbNames: { [key: string]: string } = {
   home: 'Home',
@@ -32,6 +33,7 @@ const DaBreadcrumbBar = () => {
   const { data: model } = useCurrentModel()
   const { data: prototype } = useCurrentPrototype()
   const location = useLocation()
+  const hideVehicleModelsPage = useSiteConfig('HIDE_VEHICLE_MODELS_PAGE', false)
   const [breadcrumbs, setBreadcrumbs] = useState<JSX.Element[]>([])
 
   const generateBreadcrumbItem = (
@@ -70,7 +72,10 @@ const DaBreadcrumbBar = () => {
 
     const isNewPrototypeRoute = pathnames[0] === 'new-prototype'
 
-    if (pathnames[0] === 'model' || isNewPrototypeRoute) {
+    if (
+      (pathnames[0] === 'model' || isNewPrototypeRoute) &&
+      !hideVehicleModelsPage
+    ) {
       paths.push({
         path: '/model',
         name: breadcrumbNames['model'],
@@ -194,7 +199,7 @@ const DaBreadcrumbBar = () => {
       )
     })
     setBreadcrumbs(breadcrumbList)
-  }, [location.pathname, model, prototype])
+  }, [location.pathname, model, prototype, hideVehicleModelsPage])
 
   return (
     <div className="flex h-[52px] w-full justify-between">

--- a/frontend/src/components/organisms/HomeButtonList.tsx
+++ b/frontend/src/components/organisms/HomeButtonList.tsx
@@ -9,6 +9,7 @@
 import useSelfProfileQuery from '@/hooks/useSelfProfile'
 import { useMemo } from 'react'
 import { useNavigate } from 'react-router-dom'
+import { useSiteConfig } from '@/utils/siteConfig'
 import DaDialog from '../molecules/DaDialog'
 import { DaActionCard } from '../molecules/DaActionCard'
 import { FaCar } from 'react-icons/fa'
@@ -31,6 +32,7 @@ type HomeButtonListProps = {
 const HomeButtonList = ({ items, requiredLogin }: HomeButtonListProps) => {
   const navigate = useNavigate()
   const { data: user } = useSelfProfileQuery()
+  const hideVehicleModelsPage = useSiteConfig('HIDE_VEHICLE_MODELS_PAGE', false)
 
   const meetConditions = useMemo(() => {
     let result = true
@@ -42,11 +44,19 @@ const HomeButtonList = ({ items, requiredLogin }: HomeButtonListProps) => {
     return result
   }, [requiredLogin, user])
 
+  const visibleItems = useMemo(
+    () =>
+      items?.filter(
+        (button) => !(hideVehicleModelsPage && button.url === '/model'),
+      ),
+    [items, hideVehicleModelsPage],
+  )
+
   return (
     meetConditions && (
       <div className="container pb-6 flex w-full flex-col justify-center">
         <div className="grid w-full grid-cols-2 grid-rows-2 xl:grid-cols-4 xl:grid-rows-1 gap-1.52">
-          {items?.map((button, index) => {
+          {visibleItems?.map((button, index) => {
             if (button.type === 'new-model')
               return (
                 <DaDialog

--- a/frontend/src/components/organisms/HomeFeatureList.tsx
+++ b/frontend/src/components/organisms/HomeFeatureList.tsx
@@ -8,6 +8,7 @@
 
 import { ReactNode } from 'react'
 import { useNavigate } from 'react-router-dom'
+import { useSiteConfig } from '@/utils/siteConfig'
 import { DaCardIntroBig } from '../molecules/DaCardIntroBigAlt'
 import { Button } from '@/components/atoms/button'
 
@@ -55,6 +56,7 @@ type HomeFeatureListProps = {
 
 const HomeFeatureList = ({ items }: HomeFeatureListProps) => {
   const navigate = useNavigate()
+  const hideVehicleModelsPage = useSiteConfig('HIDE_VEHICLE_MODELS_PAGE', false)
 
   const handleButtonClick = (url: string) => {
     // Check if URL is external (starts with http:// or https://)
@@ -72,16 +74,20 @@ const HomeFeatureList = ({ items }: HomeFeatureListProps) => {
   return (
     <div className="container flex w-full flex-col justify-center">
       <div className="grid w-full grid-cols-1 gap-4 lg:grid-cols-3">
-        {items?.map((card, index) => (
+        {items?.map((card, index) => {
+          const visibleButtons = card.buttons?.filter(
+            (button) => !(hideVehicleModelsPage && button.url === '/model'),
+          )
+          return (
           <div key={index} className="flex w-full items-center justify-center">
             <DaCardIntroBig
               key={index}
               title={card.title || ''}
               content={card.description || ''}
             >
-              {card.buttons && card.buttons.length > 0 && (
+              {visibleButtons && visibleButtons.length > 0 && (
                 <div className="flex flex-wrap gap-4">
-                  {card.buttons.map((button, btnIndex) => (
+                  {visibleButtons.map((button, btnIndex) => (
                     <Button
                       key={btnIndex}
                       variant={button.variant || "default"}
@@ -118,7 +124,8 @@ const HomeFeatureList = ({ items }: HomeFeatureListProps) => {
               {card.children}
             </DaCardIntroBig>
           </div>
-        ))}
+          )
+        })}
       </div>
     </div>
   )

--- a/frontend/src/configs/routes.tsx
+++ b/frontend/src/configs/routes.tsx
@@ -7,9 +7,11 @@
 // SPDX-License-Identifier: MIT
 
 import { lazy } from 'react'
+import { Navigate } from 'react-router-dom'
 import RootLayout from '@/layouts/RootLayout'
 import SuspenseProvider from '@/providers/SuspenseProvider'
 import { RouteConfig } from '@/types/common.type.ts'
+import { useSiteConfig } from '@/utils/siteConfig'
 import PageUserProfile from '@/pages/PageUserProfile.tsx'
 import PageMyAssets from '@/pages/PageMyAssets.tsx'
 import PageHealth from '@/pages/PageHealth.tsx'
@@ -100,6 +102,12 @@ const PageVehicleApi = lazy(() => retry(() => import('@/pages/PageVehicleApi')))
 // const PageInventoryItemList = lazy(() =>
 //   retry(() => import('@/pages/PageInventoryItemList')),
 // )
+
+const PageModelListGuarded = () => {
+  const hidden = useSiteConfig('HIDE_VEHICLE_MODELS_PAGE', false)
+  if (hidden) return <Navigate to="/" replace />
+  return <PageModelList />
+}
 
 const routesConfig: RouteConfig[] = [
   {
@@ -343,7 +351,7 @@ const routesConfig: RouteConfig[] = [
             index: true,
             element: (
               <SuspenseProvider>
-                <PageModelList />
+                <PageModelListGuarded />
               </SuspenseProvider>
             ),
           },

--- a/frontend/src/pages/PageModelDetail.tsx
+++ b/frontend/src/pages/PageModelDetail.tsx
@@ -49,7 +49,7 @@ import { addLog } from '@/services/log.service'
 import useSelfProfileQuery from '@/hooks/useSelfProfile'
 import { listModelsLite } from '@/services/model.service'
 import DaDuplicateNameHint from '@/components/atoms/DaDuplicateNameHint'
-import { useDefaultModelImage } from '@/utils/siteConfig'
+import { useDefaultModelImage, useSiteConfig } from '@/utils/siteConfig'
 import useDuplicateNameCheck from '@/hooks/useDuplicateNameCheck'
 import { useToast } from '@/components/molecules/toaster/use-toast'
 
@@ -173,6 +173,7 @@ const PageModelDetail = () => {
   const queryClient = useQueryClient()
   const [isAuthorized] = usePermissionHook([PERMISSIONS.WRITE_MODEL, model?.id])
   const [confirmPopupOpen, setConfirmPopupOpen] = useState(false)
+  const hideVehicleModelsPage = useSiteConfig('HIDE_VEHICLE_MODELS_PAGE', false)
 
   const { data: currentUser } = useSelfProfileQuery()
 
@@ -241,7 +242,7 @@ const PageModelDetail = () => {
         ref_id: model.id,
         ref_type: 'model',
       })
-      window.location.href = '/model'
+      window.location.href = hideVehicleModelsPage ? '/' : '/model'
     } catch (error) {
       console.error('Failed to delete model:', error)
     } finally {

--- a/frontend/src/pages/SiteConfigManagement.tsx
+++ b/frontend/src/pages/SiteConfigManagement.tsx
@@ -233,6 +233,16 @@ export const PREDEFINED_SITE_CONFIGS: any[] = [
       'When enabled, hides Custom API Schema / API Set management and all model/prototype UI for custom API sets.',
     category: 'model_prototype',
   },
+  {
+    key: 'HIDE_VEHICLE_MODELS_PAGE',
+    scope: 'site',
+    value: false,
+    secret: false,
+    valueType: 'boolean',
+    description:
+      'Hide the /model (Vehicle Models) list page. When enabled: visiting /model redirects to Home, the "Vehicle Models" breadcrumb item is removed, and any home buttons whose URL is /model are hidden. Model detail pages (/model/:id) remain accessible.',
+    category: 'model_prototype',
+  },
 ]
 
 export const PREDEFINED_GENAI_CONFIG_KEYS: string[] = PREDEFINED_SITE_CONFIGS.filter(


### PR DESCRIPTION
Allow admins to hide the /model list page while keeping model detail routes accessible. When enabled, redirects /model to home, removes the Vehicle Models breadcrumb, hides /model home buttons, and redirects post-delete to home instead of the model list.