### PR TITLE
Add home model list to home component map

### DIFF
--- a/frontend/src/components/molecules/DaModelCard.tsx
+++ b/frontend/src/components/molecules/DaModelCard.tsx
@@ -1,0 +1,580 @@
+// Copyright (c) 2025 Eclipse Foundation.
+//
+// This program and the accompanying materials are made available under the
+// terms of the MIT License which is available at
+// https://opensource.org/licenses/MIT.
+//
+// SPDX-License-Identifier: MIT
+
+import * as React from 'react'
+import { ModelLite } from '@/types/model.type'
+import {
+  getModelStatsByIds,
+  updateModelService,
+  getComputedAPIs,
+} from '@/services/model.service'
+import { uploadFileService } from '@/services/upload.service'
+import { downloadModelZip } from '@/lib/zipUtils'
+import DaImportFile from '@/components/atoms/DaImportFile'
+import { TbLoader } from 'react-icons/tb'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/atoms/tooltip'
+import {
+  TbAffiliate,
+  TbApi,
+  TbCode,
+  TbDotsVertical,
+  TbDownload,
+  TbEdit,
+  TbHistoryToggle,
+  TbPhotoEdit,
+  TbTrashX,
+  TbUsers,
+} from 'react-icons/tb'
+import { HiPlus } from 'react-icons/hi'
+import { cn } from '@/lib/utils'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/atoms/dropdown-menu'
+import {
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuSeparator,
+  ContextMenuTrigger,
+} from '@/components/atoms/context-menu'
+import useSelfProfileQuery from '@/hooks/useSelfProfile'
+import usePermissionHook from '@/hooks/usePermissionHook'
+import { PERMISSIONS } from '@/data/permission'
+import { useDefaultModelImage } from '@/utils/siteConfig'
+import { useToast } from '@/components/molecules/toaster/use-toast'
+import { DaImage } from '@/components/atoms/DaImage'
+
+export interface DaModelCardProps {
+  model: Partial<ModelLite>
+  className?: string
+  variant?: 'default' | 'home'
+  isDeleting?: boolean
+  onAction?: (action: string, modelId: string) => void
+}
+
+type ModelStats = NonNullable<ModelLite['stats']>
+
+const modelStatsMemo = new Map<string, ModelStats>()
+
+const modelStatsPromises = new Map<string, Promise<ModelStats | undefined>>()
+const modelStatsResolvers = new Map<
+  string,
+  (value: ModelStats | undefined) => void
+>()
+
+const pendingIds = new Set<string>()
+let batchTimer: ReturnType<typeof setTimeout> | undefined
+let isBatchInFlight = false
+
+const STATS_DEBOUNCE_MS = 150
+const MAX_BATCH_SIZE = 25
+
+const flushStatsQueue = async () => {
+  if (isBatchInFlight) return
+  if (batchTimer) {
+    clearTimeout(batchTimer)
+    batchTimer = undefined
+  }
+
+  const ids = Array.from(pendingIds)
+  pendingIds.clear()
+  if (ids.length === 0) return
+
+  isBatchInFlight = true
+  try {
+    const statsById = await getModelStatsByIds(ids)
+    ids.forEach((id) => {
+      const stats = statsById?.[id]
+      if (stats) modelStatsMemo.set(id, stats)
+
+      const resolve = modelStatsResolvers.get(id)
+      if (resolve) resolve(stats)
+
+      modelStatsPromises.delete(id)
+      modelStatsResolvers.delete(id)
+    })
+  } catch {
+    ids.forEach((id) => {
+      const resolve = modelStatsResolvers.get(id)
+      if (resolve) resolve(undefined)
+
+      modelStatsPromises.delete(id)
+      modelStatsResolvers.delete(id)
+    })
+  } finally {
+    isBatchInFlight = false
+
+    if (pendingIds.size > 0) {
+      batchTimer = setTimeout(() => {
+        void flushStatsQueue()
+      }, STATS_DEBOUNCE_MS)
+    }
+  }
+}
+
+const enqueueModelStats = (id: string) => {
+  const cached = modelStatsMemo.get(id)
+  if (cached) return Promise.resolve(cached)
+
+  const existing = modelStatsPromises.get(id)
+  if (existing) return existing
+
+  const p = new Promise<ModelStats | undefined>((resolve) => {
+    modelStatsResolvers.set(id, resolve)
+  })
+  modelStatsPromises.set(id, p)
+  pendingIds.add(id)
+
+  if (pendingIds.size >= MAX_BATCH_SIZE) {
+    void flushStatsQueue()
+    return p
+  }
+
+  if (!batchTimer) {
+    batchTimer = setTimeout(() => {
+      void flushStatsQueue()
+    }, STATS_DEBOUNCE_MS)
+  }
+
+  return p
+}
+
+export const DaModelCard = React.memo(
+  ({
+    model,
+    className,
+    variant = 'default',
+    isDeleting = false,
+    onAction,
+  }: DaModelCardProps) => {
+    const rootRef = React.useRef<HTMLDivElement | null>(null)
+    const modelId = model?.id
+
+    const { data: user } = useSelfProfileQuery()
+    const defaultModelImage = useDefaultModelImage()
+    const { toast } = useToast()
+    const createdBy = model?.created_by as unknown as
+      | string
+      | { id?: string }
+      | undefined
+    const createdById =
+      typeof createdBy === 'string' ? createdBy : createdBy?.id
+    const isCreator = !!user && !!createdById && user.id === createdById
+    const [hasWritePermission] = usePermissionHook([
+      PERMISSIONS.WRITE_MODEL,
+      model?.id,
+    ])
+    const isOwner = isCreator || hasWritePermission
+
+    const [lazyStats, setLazyStats] = React.useState<ModelStats | undefined>(
+      model?.stats,
+    )
+
+    React.useEffect(() => {
+      setLazyStats(model?.stats)
+    }, [modelId, model?.stats])
+
+    const requestStats = React.useCallback(async () => {
+      if (!modelId) return
+      const result = await enqueueModelStats(modelId)
+      setLazyStats(result)
+    }, [modelId])
+
+    React.useEffect(() => {
+      if (variant !== 'default') return
+      if (!modelId) return
+      if (lazyStats) return
+      if (!rootRef.current) return
+
+      if (
+        typeof window === 'undefined' ||
+        !('IntersectionObserver' in window)
+      ) {
+        void requestStats()
+        return
+      }
+
+      let isMounted = true
+      const observer = new IntersectionObserver(
+        (entries) => {
+          const entry = entries[0]
+          if (!entry?.isIntersecting) return
+          observer.disconnect()
+          void (async () => {
+            const result = await enqueueModelStats(modelId)
+            if (isMounted) setLazyStats(result)
+          })()
+        },
+        {
+          root: null,
+          rootMargin: '200px 0px',
+          threshold: 0.01,
+        },
+      )
+
+      observer.observe(rootRef.current)
+      return () => {
+        isMounted = false
+        observer.disconnect()
+      }
+    }, [modelId, lazyStats, requestStats, variant])
+
+    const [isExporting, setIsExporting] = React.useState(false)
+    const [isDownloading, setIsDownloading] = React.useState(false)
+    const [isUploading, setIsUploading] = React.useState(false)
+    const [dotsMenuOpen, setDotsMenuOpen] = React.useState(false)
+    const suppressClickRef = React.useRef(false)
+    const suppressTimeoutRef = React.useRef<ReturnType<typeof setTimeout>>()
+
+    const runAfterMenuClose = React.useCallback((action: () => void) => {
+      document.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }),
+      )
+      suppressClickRef.current = true
+      clearTimeout(suppressTimeoutRef.current)
+      suppressTimeoutRef.current = setTimeout(() => {
+        suppressClickRef.current = false
+      }, 200)
+      window.setTimeout(action, 0)
+    }, [])
+
+    const runAfterDropdownClose = React.useCallback((action: () => void) => {
+      setDotsMenuOpen(false)
+      suppressClickRef.current = true
+      clearTimeout(suppressTimeoutRef.current)
+      suppressTimeoutRef.current = setTimeout(() => {
+        suppressClickRef.current = false
+      }, 200)
+      window.setTimeout(action, 0)
+    }, [])
+
+    const handleImageFileChange = React.useCallback(
+      async (file: File) => {
+        if (!modelId) return
+        document.dispatchEvent(
+          new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }),
+        )
+        setIsUploading(true)
+        try {
+          const { url } = await uploadFileService(file)
+          await updateModelService(modelId, {
+            model_home_image_file: url,
+          } as any)
+          onAction?.('imageUpdated', modelId)
+        } catch (error) {
+          console.error('Failed to update model image:', error)
+        } finally {
+          setIsUploading(false)
+        }
+      },
+      [modelId, onAction],
+    )
+
+    const handleExport = React.useCallback(async () => {
+      if (!model) return
+      setIsExporting(true)
+      try {
+        await downloadModelZip(model as any)
+      } catch (error) {
+        console.error('Failed to export model:', error)
+      } finally {
+        setIsExporting(false)
+      }
+    }, [model])
+
+    const handleDownload = React.useCallback(async () => {
+      if (!modelId || !model?.name) return
+      setIsDownloading(true)
+      try {
+        const data = await getComputedAPIs(modelId)
+        const link = document.createElement('a')
+        link.href = `data:text/json;charset=utf-8,${encodeURIComponent(JSON.stringify(data, null, 4))}`
+        link.download = `${model.name}_vss.json`
+        document.body.appendChild(link)
+        link.click()
+        document.body.removeChild(link)
+      } catch (error) {
+        console.error('Failed to download signal data:', error)
+      } finally {
+        setIsDownloading(false)
+      }
+    }, [modelId, model?.name])
+
+    const stats = lazyStats
+    const contributorsCount = stats?.collaboration?.contributors?.count ?? 0
+    const membersCount = stats?.collaboration?.members?.count ?? 0
+    const totalCount = contributorsCount + membersCount
+    const hasStats = Boolean(stats)
+
+    const renderMenuItems = (
+      MenuItem: React.ComponentType<any>,
+      MenuSeparator: React.ComponentType<any>,
+      wrapAction: (action: () => void) => void = (action) => action(),
+    ) => (
+      <>
+        <MenuItem
+          className="gap-2 cursor-pointer"
+          onSelect={() =>
+            wrapAction(() => onAction?.('rename', model?.id ?? ''))
+          }
+        >
+          <TbEdit className="size-4" /> Rename
+        </MenuItem>
+        <MenuItem
+          className="gap-2 cursor-pointer p-0!"
+          onSelect={(e: Event) => e.preventDefault()}
+        >
+          <DaImportFile
+            onFileChange={handleImageFileChange}
+            accept=".png,.jpg,.jpeg"
+            className="flex w-full items-center gap-2 px-2 py-1.5 text-sm cursor-pointer"
+          >
+            <TbPhotoEdit className="size-4 shrink-0" /> Update Image
+          </DaImportFile>
+        </MenuItem>
+        <MenuSeparator />
+        <MenuItem
+          className="gap-2 cursor-pointer"
+          disabled={isDownloading}
+          onSelect={handleDownload}
+        >
+          {isDownloading ? (
+            <TbLoader className="size-4 animate-spin" />
+          ) : (
+            <TbApi className="size-4" />
+          )}
+          {isDownloading ? 'Downloading Vehicle API...' : 'Download Vehicle API'}
+        </MenuItem>
+        <MenuItem
+          className="gap-2 cursor-pointer"
+          disabled={isExporting}
+          onSelect={handleExport}
+        >
+          {isExporting ? (
+            <TbLoader className="size-4 animate-spin" />
+          ) : (
+            <TbDownload className="size-4" />
+          )}
+          {isExporting ? 'Exporting...' : 'Export Model'}
+        </MenuItem>
+        <MenuItem
+          className="gap-2 cursor-pointer text-red-600 focus:text-red-600 focus:bg-red-50"
+          onSelect={() =>
+            wrapAction(() => onAction?.('delete', model?.id ?? ''))
+          }
+        >
+          <TbTrashX className="size-4" /> Delete Model
+        </MenuItem>
+      </>
+    )
+
+    const cardContent = (
+      <div
+        ref={rootRef}
+        className={cn(
+          'lg:w-full lg:h-full group rounded-lg cursor-pointer bg-white p-3 border',
+          className,
+        )}
+        id={model?.id ?? ''}
+        aria-label={model?.name || 'Model'}
+      >
+        <div className="flex flex-col items-center space-y-1 text-muted-foreground overflow-hidden">
+          <div className="flex w-full h-full relative overflow-hidden aspect-video rounded-lg">
+            {(isUploading || isDeleting) && (
+              <div className="absolute inset-0 z-10 flex items-center justify-center rounded-lg bg-black/40">
+                <TbLoader className="size-6 animate-spin text-white" />
+              </div>
+            )}
+            <DaImage
+              src={model?.model_home_image_file}
+              fallbackSrc={defaultModelImage}
+              alt={model?.name || 'Model image'}
+              className="w-full h-full rounded-lg aspect-video object-cover"
+            />
+            <div className="absolute bottom-0 w-full h-[30px] blur-xl bg-black/80 transition-opacity duration-200 ease-in-out opacity-0 group-hover:opacity-100" />
+            <div className="absolute bottom-0 w-full h-[50px] transition-opacity duration-200 ease-in-out opacity-0 group-hover:opacity-100">
+              <div className="flex h-full w-full px-3 items-center justify-between text-white rounded-b-lg">
+                <div className="flex w-fit justify-end items-center gap-2 ml-2">
+                  COVESA VSS {model.api_version}
+                </div>
+                <div className="grow" />
+              </div>
+            </div>
+          </div>
+          <div className="flex items-center w-full pt-0.5">
+            <h3 className="text-base font-semibold overflow-hidden text-ellipsis text-foreground whitespace-nowrap min-w-0">
+              {model?.name ?? ''}
+            </h3>
+            <div className="grow" />
+            <div className="flex text-sm items-center gap-3">
+              {variant === 'home' ? (
+                <div className="flex items-center gap-1">
+                  <button
+                    title="Add new Prototype"
+                    type="button"
+                    tabIndex={-1}
+                    onClick={(e) => {
+                      e.preventDefault()
+                      e.stopPropagation()
+                      onAction?.('add', model?.id ?? '')
+                    }}
+                    className="p-1 rounded-md shrink-0 cursor-pointer border border-transparent hover:border-[#7B838B] active:bg-gray-300 transition-all duration-150 focus-visible:outline-none"
+                  >
+                    <HiPlus className="size-4 text-[#7B838B]" />
+                  </button>
+                  <button
+                    title="Open recently Prototype"
+                    type="button"
+                    tabIndex={-1}
+                    onClick={(e) => {
+                      e.preventDefault()
+                      e.stopPropagation()
+                      onAction?.('history', model?.id ?? '')
+                    }}
+                    className="p-1 rounded-md shrink-0 cursor-pointer border border-transparent hover:border-[#7B838B] active:bg-gray-300 transition-all duration-150 focus-visible:outline-none"
+                  >
+                    <TbHistoryToggle className="size-4 text-[#7B838B]" />
+                  </button>
+                  <DropdownMenu open={dotsMenuOpen} onOpenChange={setDotsMenuOpen}>
+                    <DropdownMenuTrigger asChild disabled={!isOwner}>
+                      <button
+                        title="Menu"
+                        type="button"
+                        tabIndex={-1}
+                        disabled={!isOwner}
+                        onClick={(e) => {
+                          e.preventDefault()
+                          e.stopPropagation()
+                        }}
+                        className="p-1 rounded-md shrink-0 cursor-pointer border border-transparent hover:border-[#7B838B] active:bg-gray-300 transition-all duration-150 focus-visible:outline-none disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:bg-transparent disabled:hover:text-muted-foreground"
+                      >
+                        <TbDotsVertical className="size-4 text-[#7B838B]" />
+                      </button>
+                    </DropdownMenuTrigger>
+                    <DropdownMenuContent
+                      className="w-52"
+                      align="end"
+                      onClick={(e) => e.stopPropagation()}
+                      onPointerDown={(e) => e.stopPropagation()}
+                    >
+                      {renderMenuItems(
+                        DropdownMenuItem,
+                        DropdownMenuSeparator,
+                        runAfterDropdownClose,
+                      )}
+                    </DropdownMenuContent>
+                  </DropdownMenu>
+                </div>
+              ) : (
+                <TooltipProvider>
+                  {totalCount > 0 && (
+                    <Tooltip delayDuration={300}>
+                      <TooltipTrigger asChild>
+                        <div className="flex items-center font-semibold">
+                          <TbUsers className="text-primary size-4 mr-1" />
+                          {totalCount}
+                        </div>
+                      </TooltipTrigger>
+                      <TooltipContent>
+                        <p>Contributors</p>
+                      </TooltipContent>
+                    </Tooltip>
+                  )}
+
+                  {hasStats && (
+                    <Tooltip delayDuration={300}>
+                      <TooltipTrigger asChild>
+                        <div className="flex items-center font-semibold">
+                          <TbAffiliate className="text-primary size-4 mr-1" />
+                          {stats?.apis?.used?.count || 0}
+                        </div>
+                      </TooltipTrigger>
+                      <TooltipContent>
+                        <p>Utilized VSS Signals</p>
+                      </TooltipContent>
+                    </Tooltip>
+                  )}
+
+                  {hasStats && (
+                    <Tooltip delayDuration={300}>
+                      <TooltipTrigger asChild>
+                        <div className="flex items-center font-semibold">
+                          <TbCode className="text-primary size-4 mr-1" />
+                          {stats?.prototypes?.count || 0}
+                        </div>
+                      </TooltipTrigger>
+                      <TooltipContent>
+                        <p>Prototypes</p>
+                      </TooltipContent>
+                    </Tooltip>
+                  )}
+                </TooltipProvider>
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+    )
+
+    if (!user) {
+      return cardContent
+    }
+
+    return (
+      <div
+        className="overflow-hidden"
+        onClick={(e) => {
+          if (dotsMenuOpen || suppressClickRef.current) {
+            e.stopPropagation()
+          }
+        }}
+      >
+        {isOwner ? (
+          <ContextMenu>
+            <ContextMenuTrigger asChild>{cardContent}</ContextMenuTrigger>
+            <ContextMenuContent
+              className="w-52"
+              onClick={(e) => e.stopPropagation()}
+              onPointerDown={(e) => e.stopPropagation()}
+            >
+              {renderMenuItems(
+                ContextMenuItem,
+                ContextMenuSeparator,
+                runAfterMenuClose,
+              )}
+            </ContextMenuContent>
+          </ContextMenu>
+        ) : (
+          <div
+            onContextMenu={(e) => {
+              e.preventDefault()
+              toast({
+                title: 'Permission denied',
+                description: `You do not have permission to edit "${model?.name ?? 'this model'}".`,
+                duration: 3000,
+              })
+            }}
+          >
+            {cardContent}
+          </div>
+        )}
+      </div>
+    )
+  },
+)
+
+DaModelCard.displayName = 'DaModelCard'

--- a/frontend/src/components/organisms/HomeConfigSection.tsx
+++ b/frontend/src/components/organisms/HomeConfigSection.tsx
@@ -488,7 +488,7 @@ const HomeConfigSection: React.FC = () => {
                             const Component = getHomeComponent(element?.type)
                             if (!Component) return null
                             const blockId = `block-${index}-${element?.type ?? 'unknown'}`
-                            const isPlaceholderBlock = element?.type === 'recent' || element?.type === 'popular' || element?.type === 'prototype-list'
+                            const isPlaceholderBlock = element?.type === 'recent' || element?.type === 'popular' || element?.type === 'prototype-list' || element?.type === 'model-list'
                             return (
                               <Draggable key={blockId} draggableId={blockId} index={index}>
                                 {(provided, snapshot) => (

--- a/frontend/src/components/organisms/HomeModelList.tsx
+++ b/frontend/src/components/organisms/HomeModelList.tsx
@@ -1,0 +1,645 @@
+// Copyright (c) 2025 Eclipse Foundation.
+//
+// This program and the accompanying materials are made available under the
+// terms of the MIT License which is available at
+// https://opensource.org/licenses/MIT.
+//
+// SPDX-License-Identifier: MIT
+
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { ModelLite } from '@/types/model.type'
+import {
+  listAllModels,
+  listModelsLite,
+  updateModelService,
+  deleteModelService,
+} from '@/services/model.service'
+import { listModelPrototypes } from '@/services/prototype.service'
+import useSelfProfileQuery from '@/hooks/useSelfProfile'
+import useImportModel from '@/hooks/useImportModel'
+import { useUrlQueryParam } from '@/hooks/useUrlQueryParam'
+import { HiPlus } from 'react-icons/hi'
+import {
+  TbChevronDown,
+  TbSortDescending,
+  TbInfoCircle,
+  TbLoader,
+  TbUpload,
+} from 'react-icons/tb'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '../atoms/tooltip'
+import { Button } from '../atoms/button'
+import { Input } from '../atoms/input'
+import { DaModelCard } from '../molecules/DaModelCard'
+import DaSkeletonGrid from '../molecules/DaSkeletonGrid'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '../atoms/dropdown-menu'
+import DaImportFile from '../atoms/DaImportFile'
+import DaDialog from '../molecules/DaDialog'
+import DaConfirmPopup from '../molecules/DaConfirmPopup'
+import FormCreateModel from '../molecules/forms/FormCreateModel'
+
+import { getLastViewedMap } from '@/utils/modelLastViewed'
+import { cn } from '@/lib/utils'
+
+type SortOption =
+  | 'last-viewed'
+  | 'first-viewed'
+  | 'newest'
+  | 'oldest'
+  | 'name-az'
+  | 'name-za'
+type ModelCategory = 'all' | 'myModel' | 'myContribution' | 'public'
+
+const MODEL_CATEGORIES: readonly ModelCategory[] = [
+  'all',
+  'myModel',
+  'myContribution',
+  'public',
+]
+const MODEL_SORT_OPTIONS: readonly SortOption[] = [
+  'last-viewed',
+  'first-viewed',
+  'newest',
+  'oldest',
+  'name-az',
+  'name-za',
+]
+
+const SORT_LABELS: Record<SortOption, string> = {
+  'last-viewed': 'Last viewed',
+  'first-viewed': 'First viewed',
+  newest: 'Newest',
+  oldest: 'Oldest',
+  'name-az': 'Name A-Z',
+  'name-za': 'Name Z-A',
+}
+
+type HomeModelListProps = {
+  title?: string
+}
+
+const BREAKPOINT_COLS: { query: string; cols: number }[] = [
+  { query: '(min-width: 1280px)', cols: 5 },
+  { query: '(min-width: 1024px)', cols: 3 },
+  { query: '(min-width: 768px)', cols: 2 },
+  { query: '(min-width: 640px)', cols: 2 },
+]
+
+function getColsPerRow(): number {
+  if (typeof window === 'undefined' || !window.matchMedia) return 1
+  for (const bp of BREAKPOINT_COLS) {
+    if (window.matchMedia(bp.query).matches) return bp.cols
+  }
+  return 1
+}
+
+function useColsPerRow(): number {
+  const [cols, setCols] = useState<number>(() => getColsPerRow())
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || !window.matchMedia) return
+    const mqls = BREAKPOINT_COLS.map((bp) => window.matchMedia(bp.query))
+    const handler = () => setCols(getColsPerRow())
+    mqls.forEach((mql) => mql.addEventListener('change', handler))
+    return () => {
+      mqls.forEach((mql) => mql.removeEventListener('change', handler))
+    }
+  }, [])
+
+  return cols
+}
+
+function sortModels(models: ModelLite[], sort: SortOption): ModelLite[] {
+  const copy = [...models]
+  if (sort === 'name-az') {
+    copy.sort((a, b) => a.name.localeCompare(b.name))
+  } else if (sort === 'name-za') {
+    copy.sort((a, b) => b.name.localeCompare(a.name))
+  } else if (sort === 'newest') {
+    copy.sort((a, b) => {
+      const ta = a.created_at ? new Date(a.created_at).getTime() : 0
+      const tb = b.created_at ? new Date(b.created_at).getTime() : 0
+      if (ta !== tb) return tb - ta
+      return b.id.localeCompare(a.id)
+    })
+  } else if (sort === 'oldest') {
+    copy.sort((a, b) => {
+      const ta = a.created_at ? new Date(a.created_at).getTime() : 0
+      const tb = b.created_at ? new Date(b.created_at).getTime() : 0
+      if (ta !== tb) return ta - tb
+      return a.id.localeCompare(b.id)
+    })
+  } else if (sort === 'last-viewed') {
+    const viewedMap = getLastViewedMap()
+    copy.sort((a, b) => {
+      const diff = (viewedMap[b.id] ?? 0) - (viewedMap[a.id] ?? 0)
+      return diff !== 0 ? diff : b.id.localeCompare(a.id)
+    })
+  } else if (sort === 'first-viewed') {
+    const viewedMap = getLastViewedMap()
+    copy.sort((a, b) => {
+      const diff = (viewedMap[a.id] ?? 0) - (viewedMap[b.id] ?? 0)
+      return diff !== 0 ? diff : a.id.localeCompare(b.id)
+    })
+  }
+  return copy
+}
+
+interface ModelGroups {
+  owned: ModelLite[]
+  contributed: ModelLite[]
+  publicReleased: ModelLite[]
+}
+
+const HomeModelList = ({ title }: HomeModelListProps) => {
+  const { data: user, isLoading: userLoading } = useSelfProfileQuery()
+  const [groups, setGroups] = useState<ModelGroups | undefined>(undefined)
+  const [rowsShown, setRowsShown] = useState<number>(1)
+  const [sortBy, setSortBy] = useUrlQueryParam(
+    'model-sort',
+    MODEL_SORT_OPTIONS,
+    'last-viewed',
+  )
+  const colsPerRow = useColsPerRow()
+  const [activeCategory, setActiveCategory] = useUrlQueryParam(
+    'model-category',
+    MODEL_CATEGORIES,
+    'all',
+  )
+  const [createDialogOpen, setCreateDialogOpen] = useState(false)
+  const [infoOpen, setInfoOpen] = useState(false)
+  const [renameModelId, setRenameModelId] = useState<string | null>(null)
+  const [renameValue, setRenameValue] = useState('')
+  const [isRenaming, setIsRenaming] = useState(false)
+  const [deleteModelId, setDeleteModelId] = useState<string | null>(null)
+  const [isDeletingModel, setIsDeletingModel] = useState(false)
+  const [confirmDeleteOpen, setConfirmDeleteOpen] = useState(false)
+  const navigate = useNavigate()
+
+  useEffect(() => {
+    if (!userLoading && !user && activeCategory !== 'all') {
+      setActiveCategory('all')
+    }
+  }, [userLoading, user, activeCategory, setActiveCategory])
+
+  const refetchModels = useCallback(async () => {
+    if (!user) return
+    const res = await listAllModels()
+    setGroups({
+      owned: res.ownedModels.results,
+      contributed: res.contributedModels.results,
+      publicReleased: res.publicReleasedModels.results,
+    })
+  }, [user])
+
+  const { isImporting, handleImportModelZip } = useImportModel({
+    onSuccess: refetchModels,
+  })
+
+  const handleRenameModel = useCallback(async () => {
+    if (!renameModelId || !renameValue.trim()) return
+    setIsRenaming(true)
+    try {
+      await updateModelService(renameModelId, {
+        name: renameValue.trim(),
+      } as any)
+      await refetchModels()
+      setRenameModelId(null)
+      setTimeout(() => {
+        document.body.style.removeProperty('pointer-events')
+      }, 100)
+    } catch (error) {
+      console.error('Failed to rename model:', error)
+    } finally {
+      setIsRenaming(false)
+    }
+  }, [renameModelId, renameValue, refetchModels])
+
+  const handleDeleteModel = useCallback(async () => {
+    if (!deleteModelId) return
+    setIsDeletingModel(true)
+    try {
+      await deleteModelService(deleteModelId)
+      await refetchModels()
+      window.dispatchEvent(new CustomEvent('model:list-changed'))
+    } catch (error) {
+      console.error('Failed to delete model:', error)
+    } finally {
+      setIsDeletingModel(false)
+      setDeleteModelId(null)
+    }
+  }, [deleteModelId, refetchModels])
+
+  useEffect(() => {
+    if (userLoading) return
+
+    const fetchModels = async () => {
+      if (user) {
+        await refetchModels()
+      } else {
+        const res = await listModelsLite({
+          visibility: 'public',
+          state: 'released',
+        })
+        setGroups({
+          owned: [],
+          contributed: [],
+          publicReleased: res.results.slice(0, 20),
+        })
+      }
+    }
+
+    fetchModels()
+  }, [user, userLoading, refetchModels])
+
+  const filteredModels = useMemo(() => {
+    if (!groups) return undefined
+    let models: ModelLite[]
+    if (activeCategory === 'myModel') {
+      models = groups.owned
+    } else if (activeCategory === 'myContribution') {
+      models = groups.contributed
+    } else if (activeCategory === 'public') {
+      models = groups.publicReleased
+    } else {
+      const seen = new Set<string>()
+      models = []
+      for (const m of [
+        ...groups.owned,
+        ...groups.contributed,
+        ...groups.publicReleased,
+      ]) {
+        if (!seen.has(m.id)) {
+          seen.add(m.id)
+          models.push(m)
+        }
+      }
+    }
+    return sortModels(models, sortBy)
+  }, [groups, activeCategory, sortBy])
+
+  const allEmpty =
+    groups &&
+    groups.owned.length === 0 &&
+    groups.contributed.length === 0 &&
+    groups.publicReleased.length === 0
+
+  const visibleCount = colsPerRow * rowsShown
+  const visible = filteredModels
+    ? filteredModels.slice(0, visibleCount)
+    : undefined
+
+  const categoryButtons: { label: string; value: ModelCategory }[] = user
+    ? [
+        { label: 'All', value: 'all' },
+        { label: 'My Models', value: 'myModel' },
+        { label: 'My Contributions', value: 'myContribution' },
+        { label: 'Public', value: 'public' },
+      ]
+    : []
+
+  return (
+    <div className="flex flex-col w-full container">
+      <div className="flex flex-wrap items-center justify-between gap-y-2">
+        <div className="flex flex-wrap items-center gap-3">
+          <h2 className="flex items-center gap-1.5 text-lg font-semibold text-primary">
+            {title || 'Vehicle Models'}
+            <TooltipProvider>
+              <Tooltip open={infoOpen} onOpenChange={setInfoOpen}>
+                <TooltipTrigger asChild>
+                  <span
+                    className="inline-flex"
+                    onPointerDown={(e) => {
+                      e.preventDefault()
+                    }}
+                    onClick={(e) => {
+                      e.preventDefault()
+                      e.stopPropagation()
+                      setInfoOpen(!infoOpen)
+                    }}
+                  >
+                    <TbInfoCircle className="size-5 shrink-0 cursor-pointer text-muted-foreground" />
+                  </span>
+                </TooltipTrigger>
+                <TooltipContent className="max-w-sm text-xs">
+                  Based on COVESA's Vehicle Signal Specification (VSS) syntax
+                  the vehicle interface can be quickly defined via the available
+                  VSS catalogue or by extending specific signals. This
+                  abstraction conveniently allows the reuse of vehicle
+                  applications on different vehicle models and types.
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
+          </h2>
+          {categoryButtons.length > 0 && (
+            <>
+              <div className="min-[1080px]:hidden">
+                <DropdownMenu>
+                  <DropdownMenuTrigger asChild>
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      disabled={allEmpty}
+                      className="border text-base"
+                    >
+                      {categoryButtons.find((c) => c.value === activeCategory)
+                        ?.label ?? 'All'}
+                      <TbChevronDown className="ml-1" />
+                    </Button>
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent align="start">
+                    {categoryButtons.map((cat) => (
+                      <DropdownMenuItem
+                        key={cat.value}
+                        onClick={() => {
+                          setActiveCategory(cat.value)
+                          setRowsShown(1)
+                        }}
+                        className={
+                          activeCategory === cat.value
+                            ? 'font-semibold bg-accent'
+                            : ''
+                        }
+                      >
+                        {cat.label}
+                      </DropdownMenuItem>
+                    ))}
+                  </DropdownMenuContent>
+                </DropdownMenu>
+              </div>
+              <div className="flex max-[1080px]:hidden flex-wrap items-center gap-2">
+                {categoryButtons.map((cat) => (
+                  <Button
+                    key={cat.value}
+                    variant="ghost"
+                    disabled={allEmpty}
+                    className={cn(
+                      activeCategory === cat.value
+                        ? 'border-[#7B838B]'
+                        : 'border-transparent hover:border-[#7B838B]',
+                      'border hover:border text-base bg-transparent!',
+                    )}
+                    size="sm"
+                    onClick={() => {
+                      setActiveCategory(cat.value)
+                      setRowsShown(1)
+                    }}
+                  >
+                    {cat.label}
+                  </Button>
+                ))}
+              </div>
+            </>
+          )}
+        </div>
+        <div className="flex flex-wrap items-center gap-2">
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button variant="ghost" size="sm" disabled={allEmpty}>
+                <TbSortDescending className="min-[1080px]:mr-1 text-base" />
+                <span className="inline max-[1080px]:hidden text-base">
+                  {SORT_LABELS[sortBy]}
+                </span>
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end">
+              <DropdownMenuItem
+                onClick={() => setSortBy('last-viewed')}
+                className={
+                  sortBy === 'last-viewed' ? 'font-semibold bg-accent' : ''
+                }
+              >
+                Last viewed
+              </DropdownMenuItem>
+              <DropdownMenuItem
+                onClick={() => setSortBy('first-viewed')}
+                className={
+                  sortBy === 'first-viewed' ? 'font-semibold bg-accent' : ''
+                }
+              >
+                First viewed
+              </DropdownMenuItem>
+              <DropdownMenuItem
+                onClick={() => setSortBy('newest')}
+                className={sortBy === 'newest' ? 'font-semibold bg-accent' : ''}
+              >
+                Newest
+              </DropdownMenuItem>
+              <DropdownMenuItem
+                onClick={() => setSortBy('oldest')}
+                className={sortBy === 'oldest' ? 'font-semibold bg-accent' : ''}
+              >
+                Oldest
+              </DropdownMenuItem>
+              <DropdownMenuItem
+                onClick={() => setSortBy('name-az')}
+                className={
+                  sortBy === 'name-az' ? 'font-semibold bg-accent' : ''
+                }
+              >
+                Name A-Z
+              </DropdownMenuItem>
+              <DropdownMenuItem
+                onClick={() => setSortBy('name-za')}
+                className={
+                  sortBy === 'name-za' ? 'font-semibold bg-accent' : ''
+                }
+              >
+                Name Z-A
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+          {user && (
+            <>
+              {!isImporting ? (
+                <DaImportFile accept=".zip" onFileChange={handleImportModelZip}>
+                  <Button variant="ghost" size="sm">
+                    <TbUpload className="min-[1080px]:mr-1 text-base" />
+                    <span className="inline max-[1080px]:hidden text-base">
+                      Import Model
+                    </span>
+                  </Button>
+                </DaImportFile>
+              ) : (
+                <p className="flex items-center text-base text-muted-foreground">
+                  <TbLoader className="animate-spin text-lg mr-2" />
+                  Importing model ...
+                </p>
+              )}
+              <DaDialog
+                open={createDialogOpen}
+                onOpenChange={setCreateDialogOpen}
+                trigger={
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    className="border-primary bg-transparent text-primary max-[1080px]:px-[7px]!"
+                  >
+                    <HiPlus className="text-base" />
+                    <span className="inline max-[1080px]:hidden">
+                      Add Model
+                    </span>
+                  </Button>
+                }
+              >
+                <FormCreateModel />
+              </DaDialog>
+            </>
+          )}
+        </div>
+      </div>
+
+      {allEmpty && visible?.length === 0 ? (
+        <div className="flex items-center justify-center min-h-[200px] text-sm text-muted-foreground mt-2">
+          No vehicle models available yet
+        </div>
+      ) : visible ? (
+        <div className="mt-2 mx-12 min-[1440px]:mx-0 grid grid-cols-1 sm:grid-cols-2 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-5 gap-2.5">
+          {visible.map((model) => (
+            <div
+              key={model.id}
+              className="cursor-pointer"
+              onClick={() => navigate(`/model/${model.id}`)}
+            >
+              <DaModelCard
+                model={model}
+                variant="home"
+                isDeleting={isDeletingModel && deleteModelId === model.id}
+                onAction={async (action, modelId) => {
+                  if (action === 'add') {
+                    navigate(`/new-prototype?model_id=${modelId}`)
+                  }
+                  if (action === 'rename') {
+                    const m = visible?.find((v) => v.id === modelId)
+                    setTimeout(() => {
+                      setRenameValue(m?.name ?? '')
+                      setRenameModelId(modelId)
+                    }, 100)
+                  }
+                  if (action === 'imageUpdated') {
+                    await refetchModels()
+                  }
+                  if (action === 'delete') {
+                    setTimeout(() => {
+                      setDeleteModelId(modelId)
+                      setConfirmDeleteOpen(true)
+                    }, 100)
+                  }
+                  if (action === 'history') {
+                    const prototypes = await listModelPrototypes(modelId)
+                    if (prototypes.length > 0) {
+                      const latestTime = (p: any) => {
+                        const created = p.created_at
+                          ? new Date(p.created_at).getTime()
+                          : 0
+                        const updated = p.updated_at
+                          ? new Date(p.updated_at).getTime()
+                          : 0
+                        return Math.max(created, updated)
+                      }
+                      const recent = prototypes.sort(
+                        (a, b) => latestTime(b) - latestTime(a),
+                      )[0]
+                      navigate(
+                        `/model/${modelId}/library/prototype/${recent.id}/view`,
+                      )
+                    } else {
+                      navigate(`/model/${modelId}/library/list`)
+                    }
+                  }
+                }}
+              />
+            </div>
+          ))}
+        </div>
+      ) : (
+        <div className="mt-2 mx-12 min-[1440px]:mx-0">
+          <DaSkeletonGrid
+            timeout={15}
+            timeoutText="No vehicle models available yet"
+            maxItems={{ sm: 1, md: 2, lg: 3, xl: 5 }}
+            itemWrapperClassName="grid-cols-1 sm:grid-cols-2 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-5"
+            containerHeight="min-h-[200px]"
+          />
+        </div>
+      )}
+
+      {filteredModels && filteredModels.length > visibleCount && (
+        <div className="flex justify-center mt-4">
+          <Button
+            variant="default"
+            size="sm"
+            onClick={() => setRowsShown((r) => r + 1)}
+          >
+            Load More Models
+            <TbChevronDown className="ml-1" />
+          </Button>
+        </div>
+      )}
+
+      <DaDialog
+        open={!!renameModelId}
+        onOpenChange={(open) => {
+          if (!open) {
+            setRenameModelId(null)
+            setTimeout(() => {
+              document.body.style.removeProperty('pointer-events')
+            }, 100)
+          }
+        }}
+        dialogTitle="Rename Model"
+      >
+        <div className="flex flex-col gap-4">
+          <Input
+            value={renameValue}
+            onChange={(e) => setRenameValue(e.target.value)}
+            onKeyDown={(e) => e.key === 'Enter' && handleRenameModel()}
+            placeholder="Model name"
+            className="!rounded-md"
+          />
+          <div className="flex justify-end gap-2">
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => setRenameModelId(null)}
+            >
+              Cancel
+            </Button>
+            <Button
+              size="sm"
+              onClick={handleRenameModel}
+              disabled={isRenaming || !renameValue.trim()}
+            >
+              {isRenaming ? (
+                <TbLoader className="mr-1 size-4 animate-spin" />
+              ) : null}
+              Save
+            </Button>
+          </div>
+        </div>
+      </DaDialog>
+
+      <DaConfirmPopup
+        onConfirm={handleDeleteModel}
+        title="Delete Model"
+        label="This action cannot be undone and will delete all of your model and prototypes data. Please proceed with caution."
+        confirmText={visible?.find((m) => m.id === deleteModelId)?.name}
+        state={[confirmDeleteOpen, setConfirmDeleteOpen]}
+      >
+        <></>
+      </DaConfirmPopup>
+    </div>
+  )
+}
+
+export default HomeModelList

--- a/frontend/src/hooks/useImportModel.ts
+++ b/frontend/src/hooks/useImportModel.ts
@@ -1,0 +1,156 @@
+// Copyright (c) 2025 Eclipse Foundation.
+//
+// This program and the accompanying materials are made available under the
+// terms of the MIT License which is available at
+// https://opensource.org/licenses/MIT.
+//
+// SPDX-License-Identifier: MIT
+
+import { useCallback, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { useQueryClient } from '@tanstack/react-query'
+import { isAxiosError } from 'axios'
+import { ModelCreate, Prototype } from '@/types/model.type'
+import { createModelService } from '@/services/model.service'
+import { listModelTemplates } from '@/services/modelTemplate.service'
+import { createPrototypeService } from '@/services/prototype.service'
+import { zipToModel } from '@/lib/zipUtils'
+import { addLog } from '@/services/log.service'
+import useSelfProfileQuery from '@/hooks/useSelfProfile'
+import { useToast } from '@/components/molecules/toaster/use-toast'
+
+interface UseImportModelOptions {
+  onSuccess?: () => void | Promise<void>
+}
+
+const useImportModel = (options?: UseImportModelOptions) => {
+  const navigate = useNavigate()
+  const queryClient = useQueryClient()
+  const { data: user } = useSelfProfileQuery()
+  const { toast } = useToast()
+  const [isImporting, setIsImporting] = useState(false)
+
+  const createNewModel = useCallback(
+    async (importedModel: any) => {
+      if (!importedModel?.model) return
+      try {
+        const newModel: ModelCreate = {
+          custom_apis: importedModel.model.custom_apis
+            ? JSON.stringify(importedModel.model.custom_apis)
+            : 'Empty',
+          cvi: importedModel.model.cvi,
+          main_api: importedModel.model.main_api || 'Vehicle',
+          model_home_image_file:
+            importedModel.model.model_home_image_file || '/ref/E-Car_Full_Vehicle.png',
+          model_files: importedModel.model.model_files || {},
+          name: importedModel.model.name || 'New Imported Model',
+          extended_apis: importedModel.model.extended_apis || [],
+          ...(importedModel.model.api_version && { api_version: importedModel.model.api_version }),
+          visibility: 'private',
+        }
+
+        if (importedModel.model.custom_template) {
+          ;(newModel as ModelCreate & { custom_template?: unknown }).custom_template =
+            importedModel.model.custom_template
+        } else {
+          try {
+            const templatesData = await listModelTemplates({ limit: 100, page: 1 })
+            const defaultTemplate = templatesData?.results?.find(
+              (t) => t.visibility === 'default',
+            )
+            if (defaultTemplate) {
+              newModel.model_template_id = defaultTemplate.id
+            }
+          } catch (err) {
+            console.warn('Could not fetch default model template:', err)
+          }
+        }
+        const createdModel = await createModelService(newModel)
+        addLog({
+          name: `New model '${createdModel.name}' with visibility: ${createdModel.visibility}`,
+          description: `New model '${createdModel.name}' was created by ${user?.email || user?.name || user?.id}`,
+          type: 'new-model',
+          create_by: user?.id!,
+          ref_id: createdModel.id,
+          ref_type: 'model',
+        })
+
+        if (importedModel.prototypes?.length > 0) {
+          await Promise.all(
+            importedModel.prototypes.map(async (proto: Partial<Prototype>) => {
+              const newPrototype: Partial<Prototype> = {
+                state: proto.state || 'development',
+                apis: { VSS: [], VSC: [] },
+                code: proto.code || '',
+                widget_config: proto.widget_config || '{}',
+                description: proto.description,
+                tags: proto.tags || [],
+                image_file: proto.image_file,
+                model_id: createdModel,
+                name: proto.name,
+                complexity_level: proto.complexity_level || '3',
+                customer_journey: proto.customer_journey || '{}',
+                portfolio: proto.portfolio || {},
+                extend: proto.extend || {},
+              }
+              return createPrototypeService(newPrototype)
+            }),
+          )
+        }
+        await options?.onSuccess?.()
+        queryClient.invalidateQueries({ queryKey: ['modelsList', user?.id ?? 'anonymous'] })
+        navigate(`/model/${createdModel}`)
+      } catch (err) {
+        console.error('Error creating model from zip: ', err)
+        const description = isAxiosError(err)
+          ? err.response?.data?.message ?? 'Something went wrong'
+          : err instanceof Error
+            ? err.message
+            : 'Something went wrong'
+        toast({
+          title: 'Import failed',
+          description,
+          variant: 'destructive',
+        })
+      } finally {
+        setIsImporting(false)
+      }
+    },
+    [user, options?.onSuccess, navigate, queryClient, toast],
+  )
+
+  const handleImportModelZip = useCallback(
+    async (file: File) => {
+      try {
+        setIsImporting(true)
+        const model = await zipToModel(file)
+        if (!model) {
+          toast({
+            title: 'Invalid model file',
+            description: 'Could not read the selected zip file.',
+            variant: 'destructive',
+          })
+          setIsImporting(false)
+          return
+        }
+        await createNewModel(model)
+      } catch (err) {
+        console.error('Failed to import model zip: ', err)
+        toast({
+          title: 'Invalid model file',
+          description:
+            err instanceof Error
+              ? err.message
+              : 'Could not parse the selected file.',
+          variant: 'destructive',
+        })
+        setIsImporting(false)
+      }
+    },
+    [createNewModel, toast],
+  )
+
+  return { isImporting, handleImportModelZip }
+}
+
+export default useImportModel

--- a/frontend/src/layouts/ModelDetailLayout.tsx
+++ b/frontend/src/layouts/ModelDetailLayout.tsx
@@ -44,6 +44,7 @@ import useSelfProfileQuery from '@/hooks/useSelfProfile'
 import usePermissionHook from '@/hooks/usePermissionHook'
 import { PERMISSIONS } from '@/data/permission'
 import { useSiteConfig } from '@/utils/siteConfig'
+import { recordModelView } from '@/utils/modelLastViewed'
 
 const ModelDetailLayout = () => {
   const { data: fetchedModel, isLoading: isModelLoading } = useCurrentModel()
@@ -97,6 +98,7 @@ const ModelDetailLayout = () => {
 
   useEffect(() => {
     if (model) {
+      recordModelView(model.id)
       setLastAccessedModel(model.id)
     }
   }, [model])

--- a/frontend/src/pages/PageHome.tsx
+++ b/frontend/src/pages/PageHome.tsx
@@ -57,7 +57,7 @@ const PageHome = () => {
   }
 
   return (
-    <div className="space-y-12 da-page-home">
+    <div className="space-y-12 pb-12 pt-4 lg:pt-0 [@media(max-height:720px)]:!pt-4 da-page-home">
       {homeElements.map((element, index) => {
         const Component = getHomeComponent(element.type) as any
         if (!Component) return null

--- a/frontend/src/utils/homeComponentMap.ts
+++ b/frontend/src/utils/homeComponentMap.ts
@@ -15,6 +15,7 @@ import HomePrototypePopular from '@/components/organisms/HomePrototypePopular'
 import HomePrototypeList from '@/components/organisms/HomePrototypeList'
 import HomeNews from '@/components/organisms/HomeNews'
 import HomeFooterSection from '@/components/organisms/HomeFooterSection'
+import HomeModelList from '@/components/organisms/HomeModelList'
 
 const homeComponentMap: Record<string, React.ComponentType<any>> = {
   'hero': HomeHeroSection,
@@ -26,6 +27,7 @@ const homeComponentMap: Record<string, React.ComponentType<any>> = {
   'prototype-list': HomePrototypeList,
   'partner-list': HomePartners,
   'home-footer': HomeFooterSection,
+  'model-list': HomeModelList,
 }
 
 export const getHomeComponent = (
@@ -45,6 +47,7 @@ export const getBlockTypeLabel = (type: string): string => {
     'prototype-list': 'All prototypes',
     'partner-list': 'Partners',
     'home-footer': 'Footer',
+    'model-list': 'Vehicle models',
   }
   return labels[type] ?? type
 }

--- a/frontend/src/utils/modelLastViewed.ts
+++ b/frontend/src/utils/modelLastViewed.ts
@@ -1,0 +1,25 @@
+// Copyright (c) 2025 Eclipse Foundation.
+//
+// This program and the accompanying materials are made available under the
+// terms of the MIT License which is available at
+// https://opensource.org/licenses/MIT.
+//
+// SPDX-License-Identifier: MIT
+
+const LS_LAST_VIEWED_KEY = 'model_last_viewed'
+
+export function getLastViewedMap(): Record<string, number> {
+  try {
+    return JSON.parse(localStorage.getItem(LS_LAST_VIEWED_KEY) || '{}')
+  } catch {
+    return {}
+  }
+}
+
+export function recordModelView(modelId: string): void {
+  try {
+    const map = getLastViewedMap()
+    map[modelId] = Date.now()
+    localStorage.setItem(LS_LAST_VIEWED_KEY, JSON.stringify(map))
+  } catch {}
+}


### PR DESCRIPTION
Introduce HomeModelList and DaModelCard on the home page so users can browse, import, rename, export, and manage models from the grid. Model cards support right-click and dots-menu actions with upload loading feedback and permission checks for non-owners.