### PR TITLE
fix(docker-compose): simplify volume mounts for local deployment

### DIFF
--- a/instance-setup/docker-compose.prod.yml
+++ b/instance-setup/docker-compose.prod.yml
@@ -35,9 +35,8 @@ services:
       GENAI_URL: ${GENAI_URL:-}
       KIT_SERVER_URL: ${KIT_SERVER_URL:-}
     volumes:
-      - '${UPLOAD_PATH_HOST:-./data/upload}:/usr/src/playground-be/static/uploads'
-      - '${PLUGIN_PATH_HOST:-./data/plugin}:/usr/src/playground-be/static/plugin'
-      - '${GLOBAL_CSS_PATH_HOST:-./data/global.css}:/usr/src/playground-be/static/global.css'
+      - './data/upload:/usr/src/playground-be/static/uploads'
+      - './data/plugin:/usr/src/playground-be/static/plugin'
     depends_on:
       autowrx-db:
         condition: service_healthy


### PR DESCRIPTION
Remove environment variable overrides for upload and plugin paths, using hardcoded relative paths instead. Remove unnecessary global.css mount since it's built into the Docker image during the build stage.

This simplifies the docker-compose configuration for local development where data is always in ./data/ relative to instance-setup/.