### PR TITLE
feat(frontend): allow staging tab to render as a prototype plugin

### DIFF
--- a/frontend/src/components/molecules/DaDialog.tsx
+++ b/frontend/src/components/molecules/DaDialog.tsx
@@ -30,6 +30,7 @@ interface DaDialogProps {
   onClose?: () => void
   preventOutsideClose?: boolean
   disabled?: boolean
+  hideHeaderDivider?: boolean
 }
 
 const DaDialog = ({
@@ -46,6 +47,7 @@ const DaDialog = ({
   onClose,
   preventOutsideClose = false,
   disabled = false,
+  hideHeaderDivider = false,
 }: DaDialogProps) => {
   const [uncontrolledOpen, setUncontrolledOpen] = useState(false)
   const isOpen = controlledOpen ?? uncontrolledOpen
@@ -135,7 +137,12 @@ const DaDialog = ({
       >
         {dialogTitle || description ? (
           // Titled dialog: full header zone with inline close button.
-          <div className="flex items-center justify-between gap-2 px-6 py-3 border-b border-border shrink-0">
+          <div
+            className={cn(
+              'flex items-center justify-between gap-2 px-6 pt-3 shrink-0',
+              !hideHeaderDivider && 'border-b border-border pb-3',
+            )}
+          >
             <div className="flex flex-col gap-0.5 min-w-0">
               {dialogTitle && (
                 <h2 className="text-base font-semibold text-primary leading-tight">{dialogTitle}</h2>

--- a/frontend/src/components/molecules/DaPrototypeCard.tsx
+++ b/frontend/src/components/molecules/DaPrototypeCard.tsx
@@ -56,8 +56,9 @@ import { Input } from '../atoms/input'
 import PrototypeTabStaging from '@/components/organisms/PrototypeTabStaging'
 import { useToast } from '@/components/molecules/toaster/use-toast'
 import { Skeleton } from '../atoms/skeleton'
-import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { useListModelPrototypes } from '@/hooks/usePrototypeQueries'
+import { getModel } from '@/services/model.service'
 
 export interface DaPrototypeCardProps {
   prototype: Prototype
@@ -114,6 +115,19 @@ export const DaPrototypeCard = ({
   const [isUploading, setIsUploading] = useState(false)
   const [deployOpen, setDeployOpen] = useState(false)
   const [dotsMenuOpen, setDotsMenuOpen] = useState(false)
+
+  const { data: deployModel, isLoading: isDeployModelLoading } = useQuery({
+    queryKey: ['model', prototype.model_id],
+    queryFn: () => getModel(prototype.model_id),
+    enabled: deployOpen && !!prototype.model_id,
+  })
+
+  const stagingRenderPlugin = useMemo(() => {
+    const buttons =
+      deployModel?.custom_template?.prototype_right_nav_buttons ?? []
+    return buttons.find((b: { builtin?: string }) => b.builtin === 'staging')
+      ?.renderPlugin as string | undefined
+  }, [deployModel])
 
   const suppressClickRef = useRef(false)
   const suppressTimeoutRef = useRef<ReturnType<typeof setTimeout>>()
@@ -503,10 +517,24 @@ export const DaPrototypeCard = ({
         open={deployOpen}
         onOpenChange={withClickSuppression(setDeployOpen)}
         dialogTitle="Deploy"
+        hideHeaderDivider
+        contentContainerClassName={
+          stagingRenderPlugin ? 'p-0! px-2!' : undefined
+        }
         className="max-w-[95vw] w-[1200px]"
       >
-        <div className="flex overflow-y-auto max-h-[80vh]">
-          <PrototypeTabStaging prototype={prototype} />
+        <div className="flex overflow-y-auto max-h-[80vh] min-h-[20vh] [&>div]:p-0!">
+          {isDeployModelLoading ? (
+            <div className="flex w-full items-center justify-center py-12">
+              <TbLoader className="size-6 animate-spin text-muted-foreground" />
+            </div>
+          ) : (
+            <PrototypeTabStaging
+              prototype={prototype}
+              renderPlugin={stagingRenderPlugin}
+              model={deployModel}
+            />
+          )}
         </div>
       </DaDialog>
 

--- a/frontend/src/components/organisms/ActionButtonsTab.tsx
+++ b/frontend/src/components/organisms/ActionButtonsTab.tsx
@@ -44,6 +44,9 @@ const ActionButtonEditor = ({
   onOpenModeChange,
   onVariantChange,
   onCornersChange,
+  onRenderPluginChange,
+  pluginsData,
+  pluginsLoading,
 }: {
   prefixElement?: React.ReactNode
   config: RightNavPluginButton
@@ -57,7 +60,28 @@ const ActionButtonEditor = ({
   onOpenModeChange: (newMode: 'dialog' | 'page') => void
   onVariantChange: (newVariant: 'tab' | 'primary' | 'outline' | 'ghost') => void
   onCornersChange: (newCorners: 'none' | 'round' | 'full') => void
+  onRenderPluginChange?: (slug: string | null) => void
+  pluginsData?: Paged<Plugin>
+  pluginsLoading?: boolean
 }) => {
+  const [showRenderPluginPicker, setShowRenderPluginPicker] = useState(false)
+  const [renderPluginSearchTerm, setRenderPluginSearchTerm] = useState('')
+
+  const selectedRenderPlugin = pluginsData?.results?.find(
+    (p) => p.slug === config.renderPlugin,
+  )
+
+  const filteredRenderPlugins =
+    pluginsData?.results?.filter(
+      (plugin) =>
+        plugin.name
+          .toLowerCase()
+          .includes(renderPluginSearchTerm.toLowerCase()) ||
+        plugin.slug
+          ?.toLowerCase()
+          .includes(renderPluginSearchTerm.toLowerCase()),
+    ) ?? []
+
   return (
     <div className={`border border-border rounded bg-background`}>
       <div className="flex items-center gap-3 p-3">
@@ -126,6 +150,139 @@ const ActionButtonEditor = ({
       </div>
       {expanded && (
         <div className="border-t border-border p-3 flex flex-col gap-3">
+          {/* Render Plugin (staging only) */}
+          {config.builtin === 'staging' && onRenderPluginChange && (
+            <div className="flex items-start gap-3">
+              <Label className="text-xs w-20 shrink-0 text-foreground mt-1">
+                Render as
+              </Label>
+              <div className="flex flex-col gap-2 flex-1">
+                <p className="text-xs text-muted-foreground">
+                  Render this plugin as the full staging page instead of the
+                  default table.
+                </p>
+                {config.renderPlugin && !showRenderPluginPicker ? (
+                  <div className="flex items-center gap-3 p-2 border border-border rounded bg-accent/50">
+                    <TbPuzzle className="w-4 h-4 text-muted-foreground shrink-0" />
+                    <div className="flex-1 min-w-0">
+                      <p className="text-sm font-medium text-foreground truncate">
+                        {selectedRenderPlugin?.name || config.renderPlugin}
+                      </p>
+                      <p className="text-xs text-muted-foreground font-mono truncate">
+                        plugin: {config.renderPlugin}
+                      </p>
+                    </div>
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      onClick={() => setShowRenderPluginPicker(true)}
+                      className="h-8 w-8"
+                      title="Change plugin"
+                    >
+                      <TbPencil className="w-4 h-4" />
+                    </Button>
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      onClick={() => {
+                        onRenderPluginChange(null)
+                        setShowRenderPluginPicker(false)
+                      }}
+                      className="h-8 w-8 text-destructive hover:text-destructive"
+                      title="Remove render plugin"
+                    >
+                      <TbTrash className="w-4 h-4" />
+                    </Button>
+                  </div>
+                ) : showRenderPluginPicker ? (
+                  <div className="flex flex-col gap-2 border border-border rounded p-2">
+                    <div className="relative">
+                      <TbSearch className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground" />
+                      <Input
+                        type="text"
+                        placeholder="Search plugins..."
+                        value={renderPluginSearchTerm}
+                        onChange={(e) =>
+                          setRenderPluginSearchTerm(e.target.value)
+                        }
+                        className="pl-10 text-sm"
+                        autoFocus
+                      />
+                    </div>
+                    <div className="flex flex-col max-h-48 overflow-y-auto">
+                      {pluginsLoading ? (
+                        <div className="flex items-center justify-center p-4">
+                          <Spinner size={20} />
+                        </div>
+                      ) : filteredRenderPlugins.length === 0 ? (
+                        <p className="text-xs text-muted-foreground p-4 text-center">
+                          {renderPluginSearchTerm
+                            ? 'No plugins found'
+                            : 'No plugins available'}
+                        </p>
+                      ) : (
+                        filteredRenderPlugins.map((plugin) => (
+                          <button
+                            key={plugin.id}
+                            onClick={() => {
+                              onRenderPluginChange(plugin.slug)
+                              setShowRenderPluginPicker(false)
+                              setRenderPluginSearchTerm('')
+                            }}
+                            className="flex items-center gap-3 p-2 hover:bg-accent rounded transition-colors text-left"
+                          >
+                            {plugin.image ? (
+                              <img
+                                src={plugin.image}
+                                alt={plugin.name}
+                                className="w-8 h-8 rounded object-cover shrink-0"
+                              />
+                            ) : (
+                              <div className="w-8 h-8 rounded bg-muted flex items-center justify-center shrink-0">
+                                <span className="text-xs text-muted-foreground">
+                                  {plugin.name.charAt(0).toUpperCase()}
+                                </span>
+                              </div>
+                            )}
+                            <div className="flex-1 min-w-0">
+                              <p className="text-sm font-medium text-foreground truncate">
+                                {plugin.name}
+                              </p>
+                              <p className="text-xs text-muted-foreground font-mono truncate">
+                                {plugin.slug}
+                              </p>
+                            </div>
+                          </button>
+                        ))
+                      )}
+                    </div>
+                    <div className="flex justify-end">
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => {
+                          setShowRenderPluginPicker(false)
+                          setRenderPluginSearchTerm('')
+                        }}
+                      >
+                        Cancel
+                      </Button>
+                    </div>
+                  </div>
+                ) : (
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    className="w-fit"
+                    onClick={() => setShowRenderPluginPicker(true)}
+                  >
+                    <TbPuzzle className="w-4 h-4 mr-2" />
+                    Set Render Plugin
+                  </Button>
+                )}
+              </div>
+            </div>
+          )}
           {/* Show Icon */}
           <div className="flex items-center gap-3">
             <Label className="text-xs w-20 shrink-0 text-foreground">
@@ -356,6 +513,9 @@ const ActionButtonsTab = ({
                     onVariantChange={() => {}}
                     onOpenModeChange={() => {}}
                     onCornersChange={() => {}}
+                    onRenderPluginChange={() => {}}
+                    pluginsData={pluginsData}
+                    pluginsLoading={pluginsLoading}
                   />
                 </div>
               )
@@ -467,6 +627,17 @@ const ActionButtonsTab = ({
                                 ),
                               )
                             }
+                            onRenderPluginChange={(slug) =>
+                              setLocalRightNavPlugins((prev) =>
+                                prev.map((b, idx) =>
+                                  idx === i
+                                    ? { ...b, renderPlugin: slug ?? undefined }
+                                    : b,
+                                ),
+                              )
+                            }
+                            pluginsData={pluginsData}
+                            pluginsLoading={pluginsLoading}
                           />
                         </div>
                       )}

--- a/frontend/src/components/organisms/CustomTabEditor.tsx
+++ b/frontend/src/components/organisms/CustomTabEditor.tsx
@@ -75,6 +75,8 @@ export interface TabConfig {
   openMode?: 'dialog' | 'page'
   hideIcon?: boolean
   corners?: 'none' | 'round' | 'full'
+  /** For builtin staging: plugin slug to render as the full staging page instead of the default table */
+  renderPlugin?: string
 }
 
 export interface StagingConfig {
@@ -84,6 +86,8 @@ export interface StagingConfig {
   iconSvg?: string
   variant?: 'tab' | 'primary' | 'outline' | 'ghost'
   corners?: 'none' | 'round' | 'full'
+  /** Plugin slug to render as the full staging page instead of the default table */
+  renderPlugin?: string
 }
 
 export interface RightNavPluginButton {
@@ -96,6 +100,8 @@ export interface RightNavPluginButton {
   openMode?: 'dialog' | 'page'
   hidden?: boolean
   corners?: 'none' | 'round' | 'full'
+  /** For builtin staging: plugin slug to render as the full staging page instead of the default table */
+  renderPlugin?: string
 }
 
 export const DEFAULT_STAGING_RIGHT_NAV_BUTTON: RightNavPluginButton = {
@@ -117,6 +123,7 @@ export function ensureStagingRightNavButton(
       variant: stagingConfig?.variant,
       corners: stagingConfig?.corners,
       hidden: stagingConfig?.hidden,
+      renderPlugin: stagingConfig?.renderPlugin,
     },
     ...buttons,
   ]

--- a/frontend/src/components/organisms/PrototypeTabStaging.tsx
+++ b/frontend/src/components/organisms/PrototypeTabStaging.tsx
@@ -10,7 +10,7 @@ import React, { useState, useEffect } from 'react'
 import { configManagementService } from '@/services/configManagement.service'
 import { useToast } from '@/components/molecules/toaster/use-toast'
 import { Spinner } from '@/components/atoms/spinner'
-import { Prototype } from '@/types/model.type'
+import { Model, Prototype } from '@/types/model.type'
 import { DaImage } from '@/components/atoms/DaImage'
 import { TbChevronRight, TbChevronDown, TbArrowLeft } from 'react-icons/tb'
 import { cn } from '@/lib/utils'
@@ -109,6 +109,10 @@ interface StageItem {
 
 interface PrototypeTabStagingProps {
   prototype: Prototype
+  /** When set, render this plugin as the full staging page instead of the default table */
+  renderPlugin?: string
+  /** Optional model override when not on a prototype detail route (e.g. deploy dialog from home) */
+  model?: Model | null
 }
 
 interface PluginDropdownItemProps {
@@ -166,7 +170,11 @@ const PluginDropdownItem: React.FC<PluginDropdownItemProps> = ({ plugin, onClick
 
 type PublicConfig = { key: string; value: any } | null
 
-const PrototypeTabStaging: React.FC<PrototypeTabStagingProps> = ({ prototype }) => {
+const PrototypeTabStaging: React.FC<PrototypeTabStagingProps> = ({
+  prototype,
+  renderPlugin,
+  model: modelProp,
+}) => {
   const { data: self, isLoading: selfLoading } = useSelfProfileQuery()
   const { setOpenLoginDialog } = useAuthStore()
   const [stagingFrameConfig, setStagingFrameConfig] = useState<PublicConfig>(null)
@@ -178,15 +186,18 @@ const PrototypeTabStaging: React.FC<PrototypeTabStagingProps> = ({ prototype }) 
   const [selectedStageName, setSelectedStageName] = useState<string | null>(null) // Stage name for back button
   const [openStageMenuName, setOpenStageMenuName] = useState<string | null>(null)
   const { toast } = useToast()
-  const { data: model } = useCurrentModel()
+  const { data: routeModel } = useCurrentModel()
+  const model = modelProp ?? routeModel
 
   useEffect(() => {
+    // When a render plugin overrides the whole page, skip loading the default staging configs
+    if (renderPlugin) return
     // Wait for user authentication to complete before loading configs
     if (selfLoading) return
     if (!self) return // Will show auth required message
     loadConfigs()
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [selfLoading, !!self])
+  }, [selfLoading, !!self, renderPlugin])
 
   const loadConfigs = async () => {
     try {
@@ -557,6 +568,21 @@ const PrototypeTabStaging: React.FC<PrototypeTabStagingProps> = ({ prototype }) 
           </>
         )}
       </>
+    )
+  }
+
+  // If a render plugin is configured, render it as the full staging page
+  if (renderPlugin) {
+    return (
+      <div className="w-full h-full min-h-[300px]">
+        <PluginPageRender
+          plugin_id={renderPlugin}
+          data={{
+            model: model || null,
+            prototype: prototype || null,
+          }}
+        />
+      </div>
     )
   }
 

--- a/frontend/src/components/organisms/StagingTabButton.tsx
+++ b/frontend/src/components/organisms/StagingTabButton.tsx
@@ -64,6 +64,14 @@ const StagingTabButton = ({
         </span>
       )
     }
+    if (onClick) {
+      return (
+        <DaTabItem active={isActive} onClick={onClick} dataId="tab-staging">
+          {stagingIcon}
+          {stagingLabel}
+        </DaTabItem>
+      )
+    }
     return (
       <DaTabItem active={isActive} to={stagingTo} dataId="tab-staging">
         {stagingIcon}

--- a/frontend/src/pages/PagePrototypeDetail.tsx
+++ b/frontend/src/pages/PagePrototypeDetail.tsx
@@ -165,6 +165,7 @@ const PagePrototypeDetail: FC<ViewPrototypeProps> = ({}) => {
         hideIcon: _stagingNavItem.hideIcon,
         variant: _stagingNavItem.variant,
         corners: _stagingNavItem.corners,
+        renderPlugin: _stagingNavItem.renderPlugin,
       }
     : {}
 
@@ -506,7 +507,10 @@ const PagePrototypeDetail: FC<ViewPrototypeProps> = ({}) => {
             {tab == 'dashboard' && <PrototypeTabDashboard />}
             {tab == 'feedback' && <PrototypeTabFeedback />}
             {tab == 'staging' && hasPrototypeCode(prototype?.code) && (
-              <PrototypeTabStaging prototype={prototype} />
+              <PrototypeTabStaging
+                prototype={prototype}
+                renderPlugin={_stagingNavItem?.renderPlugin}
+              />
             )}
 
             {/* Render ALL plugin components unconditionally - they stay mounted and cached */}

--- a/frontend/src/pages/PrototypeRightAction.tsx
+++ b/frontend/src/pages/PrototypeRightAction.tsx
@@ -34,11 +34,18 @@ const PrototypeRightAction = ({
             dialogTitle={
               action.builtin ? action.label || 'Staging' : action.label
             }
+            hideHeaderDivider
+            contentContainerClassName={
+              action.builtin && action.renderPlugin ? 'p-0! px-2!' : undefined
+            }
             className="max-w-[95vw] w-[1200px]"
           >
             <div className="flex overflow-y-auto max-h-[80vh]  min-h-[20vh] [&>div]:p-0!">
               {action.builtin ? (
-                <PrototypeTabStaging prototype={prototype} />
+                <PrototypeTabStaging
+                  prototype={prototype}
+                  renderPlugin={action.renderPlugin}
+                />
               ) : (
                 <PagePrototypePlugin
                   pluginSlug={action.plugin}


### PR DESCRIPTION
Add renderPlugin on the builtin staging action button so admins can replace the default staging table with a full-page plugin render. Wire config through ActionButtonsTab, CustomTabEditor, PagePrototypeDetail, PrototypeRightAction, and DaPrototypeCard deploy dialog.