### PR TITLE
feat(frontend): add Prototype Library paging and fix tab count

### DIFF
--- a/.agents/SITEMAP.md
+++ b/.agents/SITEMAP.md
@@ -82,6 +82,8 @@
 | Delete prototype | Via API, card removed from UI | ✅ `prototype.spec.ts` |
 | Search / filter | Filter prototypes by name | ✅ `prototype-extended.spec.ts` |
 | Sort prototypes | Sort by date/name | ✅ `prototype-extended.spec.ts` |
+| Library paging (CAP-PROTO-09) | Page-number buttons (max 7 + ellipsis) when more than 50 prototypes | ✅ `prototype-extended.spec.ts` / `pagination-utils.spec.ts` |
+| Tab prototype count | Model tab badge matches API `totalResults` | ✅ `prototype-extended.spec.ts` |
 | Prototype image cover | Thumbnail display | ❌ |
 
 ---

--- a/.agents/SITEMAP.md
+++ b/.agents/SITEMAP.md
@@ -82,8 +82,8 @@
 | Delete prototype | Via API, card removed from UI | ✅ `prototype.spec.ts` |
 | Search / filter | Filter prototypes by name | ✅ `prototype-extended.spec.ts` |
 | Sort prototypes | Sort by date/name | ✅ `prototype-extended.spec.ts` |
-| Library paging (CAP-PROTO-09) | Page-number buttons (max 7 + ellipsis) when more than 50 prototypes | ✅ `prototype-extended.spec.ts` / `pagination-utils.spec.ts` |
-| Tab prototype count | Model tab badge matches API `totalResults` | ✅ `prototype-extended.spec.ts` |
+| Library paging (CAP-PROTO-09) | Page-number buttons (max 7 + ellipsis) when more than 50 prototypes | ❌ |
+| Tab prototype count | Model tab badge matches API `totalResults` | ❌ |
 | Prototype image cover | Thumbnail display | ❌ |
 
 ---

--- a/docs/capabilities/README.md
+++ b/docs/capabilities/README.md
@@ -113,7 +113,7 @@ Each cluster has an ID prefix (`CAP-<CODE>-NN`).
 | `CAP-IDENTITY` | Identity & Access | login/refresh/logout, register, password reset + email verify, SSO, profile, user management, RBAC v1 + Casbin v2, manage users/features | [identity-access.md](./identity-access.md) |
 | `CAP-MODEL` | Models | model list/create/import, detail/edit, tabs & addons, contributors & permissions, stats, model templates | [models.md](./models.md) |
 | `CAP-VAPI` | Vehicle APIs | VSS versions/trees, per-model API CRUD + computed, replace APIs, vehicle API view, extended APIs, custom API schemas, custom API sets | [vehicle-apis.md](./vehicle-apis.md) |
-| `CAP-PROTO` | Prototypes & Code | prototype library, new-prototype, CRUD/recent/popular, workspace tabs, code editor, project editor, feedback, project templates | [prototypes-code.md](./prototypes-code.md) |
+| `CAP-PROTO` | Prototypes & Code | prototype library, new-prototype, CRUD/recent/popular, workspace tabs, code editor, project editor, feedback, project templates, page-number buttons | [prototypes-code.md](./prototypes-code.md) |
 | `CAP-DASHBOARD` | Dashboards & Widgets | dashboard renderer/editor, widget sources, builtin widgets, dashboard templates, Widget ProtoPilot (roadmap) | [dashboards-widgets.md](./dashboards-widgets.md) |
 | `CAP-RUNTIME` | Runtime & Hardware Kits | runtime control, runtime/asset manager, hardware kit manager, asset access tokens, kit server proxy, runtime server config | [runtime-hardware-kits.md](./runtime-hardware-kits.md) |
 | `CAP-ASSET` | Assets & Sharing | user assets CRUD, admin all-assets, My Assets, asset sharing, model contributors, access invitation, user lookup | [assets-sharing.md](./assets-sharing.md) |

--- a/docs/capabilities/prototypes-code.md
+++ b/docs/capabilities/prototypes-code.md
@@ -7,7 +7,7 @@ As a model author or contributor, I can create, organize, and iterate on a model
 ```mermaid
 flowchart TD
     subgraph Authoring
-        L["Library / portfolio<br/>(list · portfolio · search)"] --> C["Create / import ZIP"]
+        L["Library / portfolio<br/>(list · portfolio · search · page buttons)"] --> C["Create / import ZIP"]
         C --> NP["New prototype layout<br/>(shell preview)"]
         C --> CRUD["Prototype CRUD / bulk / recent / popular"]
         CRUD --> WS["Workspace tabs<br/>(view · journey · code · dashboard · feedback · staging · plug)"]
@@ -39,6 +39,7 @@ flowchart TD
 | [CAP-PROTO-06](#cap-proto-06--project-editor-multi-file) | Project editor (multi-file) |
 | [CAP-PROTO-07](#cap-proto-07--prototype-feedback) | Prototype feedback |
 | [CAP-PROTO-08](#cap-proto-08--project-templates) | Project templates |
+| [CAP-PROTO-09](#cap-proto-09--page-number-buttons) | Page-number buttons (medium) |
 
 
 ## CAP-PROTO-01 — Prototype library
@@ -58,6 +59,8 @@ Model owners/contributors (manage prototypes); end users (browse/portfolio).
 ### Acceptance criteria
 
 - When a **user** opens the Library page at **Prototype library (`/model/:id/library`)**, they see the model's prototypes as cards in a list view, and they can switch between List and Portfolio views.
+- When a **user** opens a large library at **Prototype library (`/model/:id/library`)**, they page through prototypes via CAP-PROTO-09 (Previous / page-number / Next).
+- When a **user** views a model at **Prototype library (`/model/:id/library`)**, the Prototype Library tab badge shows the API `totalResults` count for that model, not the length of a single page of results.
 - When a **user** types in the search box at **Prototype library (`/model/:id/library`)**, the list filters to prototypes whose name matches; when they pick a sort option (Last view, First view, Newest, Oldest, Name A-Z, Name Z-A, Rating), the list reorders accordingly.
 - When a **guest** (or a **user** lacking write permission) views the library at **Prototype library (`/model/:id/library`)**, the Create New Prototype and Import Prototype controls appear dimmed and are not clickable; when an **owner** with write permission views it, they can open the create dialog or import a prototype.
 - When an **owner** imports a ZIP at **Prototype library (`/model/:id/library`)**, they are limited to `.zip` files under 10 MB; a non-ZIP or oversized file shows an error message and the import is blocked.
@@ -76,7 +79,7 @@ Model owners/contributors (manage prototypes); end users (browse/portfolio).
 
 ### Quality control
 
-As a creator, I create a prototype and it appears in the list; I switch between list and portfolio views; I import a prototype ZIP and a prototype is created; I sort by name and the list is ordered.
+As a creator, I create a prototype and it appears in the list; I switch between list and portfolio views; I import a prototype ZIP and a prototype is created; I sort by name and the list is ordered; the Prototype Library tab count matches the API total (paging controls: CAP-PROTO-09).
 
 ```mermaid
 flowchart LR
@@ -787,3 +790,86 @@ Template data (code/widget_config/journey) is stored; no secrets.
 - **E2E (Playwright):** 0 — not covered — SITEMAP: ❌
 - **Estimated coverage:** ≈0% (est.) — no E2E spec.
 - **Unit (Jest):** none
+## CAP-PROTO-09 — Page-number buttons
+
+| Actor | Where | Personal data | E2E coverage |
+|---|---|---|---|
+| owner / user / guest | Prototype library (`/model/:id/library`) | ❌ No | ✅ 3 UI + helper cases, ≈85% (est.) |
+
+**Complexity:** medium
+
+### Description
+
+As a model owner, contributor, or guest browsing a model, I can jump directly to a page of prototypes via numbered buttons (and Previous / Next) on the Prototype Library list so I can reach every prototype without scrolling an unbounded grid.
+
+### Who uses it / value
+
+Model owners/contributors and end users browsing large libraries (50+ prototypes after search/sort).
+
+### Acceptance criteria
+
+- When a **user** opens a library with more than 50 prototypes (after search/sort) at **Prototype library (`/model/:id/library`)**, they see Previous / page-number / Next controls under the card grid; at or below 50 filtered prototypes, the pager is hidden.
+- When a **user** opens a library with more than 7 pages at **Prototype library (`/model/:id/library`)**, they see a truncated page-number window (at most 7 number buttons) with ellipsis; every page remains reachable via Previous / Next and the visible numbers.
+- When a **user** clicks a page-number button at **Prototype library (`/model/:id/library`)**, the grid shows that page’s up-to-50 cards and the clicked number is marked active.
+- When a **user** clicks Next or Previous at **Prototype library (`/model/:id/library`)**, the grid moves one page forward or back; Previous is disabled on page 1 and Next is disabled on the last page.
+- When a **user** changes search or sort at **Prototype library (`/model/:id/library`)**, paging resets to page 1 over the newly filtered/sorted full set (search and sort apply to all prototypes, then the result is paged).
+
+### API contract
+
+- No dedicated HTTP surface — UI paging over the full model prototype list already loaded for CAP-PROTO-01 (`GET /v2/prototypes?model_id=…` walked page-by-page client-side).
+- Page size is fixed at 50 cards per page in the library list UI.
+- Visible page-number buttons are capped at 7 (sliding window with ellipsis) via `getVisiblePageItems`.
+
+### Quality control
+
+Open a model with more than 50 prototypes at `/model/:id/library/list`, confirm page-number buttons appear, click `2`, confirm a different set of cards, click Previous back to page 1; narrow search so results ≤ 50 and confirm the pager disappears. With 8+ pages, confirm ellipsis appears and not every page number is shown.
+
+```mermaid
+flowchart LR
+    U([User]) --> L["Library list<br/>filtered + sorted"]
+    L --> P{filtered count > 50?}
+    P -->|no| G["Show all cards<br/>no pager"]
+    P -->|yes| N["Previous · 1 … 4 5 6 … N · Next"]
+    N -->|click page N| S["Slice cards<br/>(N-1)*50 .. N*50"]
+```
+
+### Security
+
+Same read gating as CAP-PROTO-01 (library browse). Page-number buttons only change client-side slicing of already-authorized results.
+
+**Coverage:**
+- **Auth:** Optional via `PUBLIC_VIEWING` for library reads (same as CAP-PROTO-01).
+- **Authorization:** private-model reads gated by `READ_MODEL`; pager does not widen access.
+- **Input validation:** page index clamped to `1..totalPages` in the UI; no server input.
+- **Rate limiting:** N/A (no extra HTTP calls for page clicks).
+- **Secrets:** none.
+
+**Risks:**
+- **Stale full-list cache:** if the client holds an outdated full prototype list, page-number navigation could show deleted or omit newly created prototypes until refetch. *Mitigation:* invalidate/refetch model prototype queries after create/import/delete (same cache keys as CAP-PROTO-01).
+
+### Personal data processing
+
+❌ No — this capability does not process personal data.
+
+**Risks:**
+- none — no personal data processed.
+
+### AutoWRX data
+
+None beyond the prototype list already loaded for CAP-PROTO-01; page selection is ephemeral UI state.
+
+**Coverage:**
+- **Stored data:** none (page index is client state only).
+- **Retention:** N/A.
+- **Encryption:** N/A.
+- **Logging:** none.
+
+**Risks:**
+- none — no additional operational data stored.
+
+### Test coverage
+- **E2E (Playwright):** 3 UI case(s) in `prototype-extended.spec.ts` + helper cases in `pagination-utils.spec.ts` — SITEMAP: ✅
+- **Estimated coverage:** ≈85% (est.) — pager visibility, page-2 navigation, ellipsis truncation; search/sort reset-to-page-1 lightly covered via existing search/sort cases.
+- **Unit (Jest):** none (frontend has no Jest runner; helper covered via Playwright `pagination-utils.spec.ts`)
+
+**Implementation:** `frontend/src/utils/pagination.ts` (`getVisiblePageItems`); `frontend/src/components/organisms/PrototypeLibraryList.tsx` (`DaPaging` / page-number buttons / `DaPaginationEllipsis`, `PAGE_SIZE = 50`).

--- a/docs/capabilities/prototypes-code.md
+++ b/docs/capabilities/prototypes-code.md
@@ -790,11 +790,12 @@ Template data (code/widget_config/journey) is stored; no secrets.
 - **E2E (Playwright):** 0 — not covered — SITEMAP: ❌
 - **Estimated coverage:** ≈0% (est.) — no E2E spec.
 - **Unit (Jest):** none
+
 ## CAP-PROTO-09 — Page-number buttons
 
 | Actor | Where | Personal data | E2E coverage |
 |---|---|---|---|
-| owner / user / guest | Prototype library (`/model/:id/library`) | ❌ No | ✅ 3 UI + helper cases, ≈85% (est.) |
+| owner / user / guest | Prototype library (`/model/:id/library`) | ❌ No | ❌ 0 — not covered |
 
 **Complexity:** medium
 
@@ -816,9 +817,12 @@ Model owners/contributors and end users browsing large libraries (50+ prototypes
 
 ### API contract
 
-- No dedicated HTTP surface — UI paging over the full model prototype list already loaded for CAP-PROTO-01 (`GET /v2/prototypes?model_id=…` walked page-by-page client-side).
+- Server paging: `GET /v2/prototypes?model_id=…&page=&limit=&sortBy=` for Newest / Oldest / Name A-Z / Name Z-A with an empty search box. Each page click fetches that page only.
+- Hybrid client fallback: Last view, First view, Rating, and substring search still walk all API pages, then filter/sort/slice in the browser (those modes cannot be expressed as server `sortBy` / exact `name` today).
 - Page size is fixed at 50 cards per page in the library list UI.
 - Visible page-number buttons are capped at 7 (sliding window with ellipsis) via `getVisiblePageItems`.
+- Current page is persisted as `?page=N` on the library URL (omitted when page is 1).
+- Tab badge count is `totalResults` from a `limit=1` paged query for the model (not a second full-list walk).
 
 ### Quality control
 
@@ -826,26 +830,29 @@ Open a model with more than 50 prototypes at `/model/:id/library/list`, confirm 
 
 ```mermaid
 flowchart LR
-    U([User]) --> L["Library list<br/>filtered + sorted"]
-    L --> P{filtered count > 50?}
+    U([User]) --> L["Library list"]
+    L --> M{Client-only sort or search?}
+    M -->|no| S["GET /prototypes page+limit+sortBy"]
+    M -->|yes| C["Walk all pages, filter, slice"]
+    S --> P{total > 50?}
+    C --> P
     P -->|no| G["Show all cards<br/>no pager"]
-    P -->|yes| N["Previous · 1 … 4 5 6 … N · Next"]
-    N -->|click page N| S["Slice cards<br/>(N-1)*50 .. N*50"]
+    P -->|yes| N["Previous · 1 … N · Next"]
 ```
 
 ### Security
 
-Same read gating as CAP-PROTO-01 (library browse). Page-number buttons only change client-side slicing of already-authorized results.
+Same read gating as CAP-PROTO-01 (library browse). Server-paged clicks reuse `GET /v2/prototypes` with the same `READ_MODEL` / `PUBLIC_VIEWING` checks; client fallback only slices already-authorized results.
 
 **Coverage:**
 - **Auth:** Optional via `PUBLIC_VIEWING` for library reads (same as CAP-PROTO-01).
 - **Authorization:** private-model reads gated by `READ_MODEL`; pager does not widen access.
-- **Input validation:** page index clamped to `1..totalPages` in the UI; no server input.
-- **Rate limiting:** N/A (no extra HTTP calls for page clicks).
+- **Input validation:** page index clamped to `1..totalPages` in the UI; server paginate plugin also rejects non-positive `page`/`limit`.
+- **Rate limiting:** page clicks issue `GET /v2/prototypes` (same list endpoint as CAP-PROTO-01).
 - **Secrets:** none.
 
 **Risks:**
-- **Stale full-list cache:** if the client holds an outdated full prototype list, page-number navigation could show deleted or omit newly created prototypes until refetch. *Mitigation:* invalidate/refetch model prototype queries after create/import/delete (same cache keys as CAP-PROTO-01).
+- **Stale page cache:** a cached paged or full-list query could show deleted or omit newly created prototypes until refetch. *Mitigation:* invalidate `listModelPrototypes` query keys after create/import/delete (same prefix as CAP-PROTO-01).
 
 ### Personal data processing
 
@@ -856,10 +863,10 @@ Same read gating as CAP-PROTO-01 (library browse). Page-number buttons only chan
 
 ### AutoWRX data
 
-None beyond the prototype list already loaded for CAP-PROTO-01; page selection is ephemeral UI state.
+None beyond the prototype list already loaded for CAP-PROTO-01; page selection is a URL search param (`?page=N`) plus React Query cache.
 
 **Coverage:**
-- **Stored data:** none (page index is client state only).
+- **Stored data:** none (page index is URL state only).
 - **Retention:** N/A.
 - **Encryption:** N/A.
 - **Logging:** none.
@@ -868,8 +875,8 @@ None beyond the prototype list already loaded for CAP-PROTO-01; page selection i
 - none — no additional operational data stored.
 
 ### Test coverage
-- **E2E (Playwright):** 3 UI case(s) in `prototype-extended.spec.ts` + helper cases in `pagination-utils.spec.ts` — SITEMAP: ✅
-- **Estimated coverage:** ≈85% (est.) — pager visibility, page-2 navigation, ellipsis truncation; search/sort reset-to-page-1 lightly covered via existing search/sort cases.
-- **Unit (Jest):** none (frontend has no Jest runner; helper covered via Playwright `pagination-utils.spec.ts`)
+- **E2E (Playwright):** 0 — not covered — SITEMAP: ❌
+- **Estimated coverage:** ≈0% (est.) — no paging E2E spec.
+- **Unit (Jest):** none
 
-**Implementation:** `frontend/src/utils/pagination.ts` (`getVisiblePageItems`); `frontend/src/components/organisms/PrototypeLibraryList.tsx` (`DaPaging` / page-number buttons / `DaPaginationEllipsis`, `PAGE_SIZE = 50`).
+**Implementation:** `frontend/src/utils/pagination.ts` (`getVisiblePageItems`); `frontend/src/components/organisms/PrototypeLibraryList.tsx` (`DaPaging` / page-number buttons / `DaPaginationEllipsis`, `PAGE_SIZE = 50`); `listModelPrototypesPaged` / `useModelPrototypesPaged` / `useModelPrototypeTotal`.

--- a/frontend/src/components/atoms/DaPaging.tsx
+++ b/frontend/src/components/atoms/DaPaging.tsx
@@ -7,7 +7,11 @@
 // SPDX-License-Identifier: MIT
 
 import React from 'react'
-import { ChevronLeftIcon, ChevronRightIcon } from '@radix-ui/react-icons'
+import {
+    ChevronLeftIcon,
+    ChevronRightIcon,
+    DotsHorizontalIcon,
+} from '@radix-ui/react-icons'
 import { cn } from '@/lib/utils'
 import { DaText } from './DaText'
 
@@ -106,6 +110,24 @@ const DaPaginationNext = ({
 )
 DaPaginationNext.displayName = 'PaginationNext'
 
+const DaPaginationEllipsis = ({
+    className,
+    ...props
+}: React.ComponentProps<'span'>) => (
+    <span
+        aria-hidden
+        className={cn(
+            'flex items-center justify-center px-2 py-1 text-slate-500',
+            className,
+        )}
+        {...props}
+    >
+        <DotsHorizontalIcon className="h-4 w-4" />
+        <span className="sr-only">More pages</span>
+    </span>
+)
+DaPaginationEllipsis.displayName = 'PaginationEllipsis'
+
 export {
     DaPaging,
     DaPaginationContent,
@@ -113,4 +135,5 @@ export {
     DaPaginationLink,
     DaPaginationPrevious,
     DaPaginationNext,
+    DaPaginationEllipsis,
 }

--- a/frontend/src/components/organisms/PrototypeLibraryList.tsx
+++ b/frontend/src/components/organisms/PrototypeLibraryList.tsx
@@ -6,7 +6,7 @@
 //
 // SPDX-License-Identifier: MIT
 
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useMemo } from 'react'
 import { Prototype } from '@/types/model.type'
 import { useListModelPrototypes } from '@/hooks/usePrototypeQueries'
 import useCurrentModel from '@/hooks/useCurrentModel'
@@ -15,6 +15,18 @@ import { DaPrototypeCard } from '../molecules/DaPrototypeCard'
 import DaErrorDisplay from '../molecules/DaErrorDisplay'
 import DaSkeletonGrid from '../molecules/DaSkeletonGrid'
 import { sortPrototypesByViewed } from '@/utils/prototypeSort'
+import { getVisiblePageItems } from '@/utils/pagination'
+import {
+  DaPaging,
+  DaPaginationContent,
+  DaPaginationItem,
+  DaPaginationLink,
+  DaPaginationPrevious,
+  DaPaginationNext,
+  DaPaginationEllipsis,
+} from '../atoms/DaPaging'
+
+const PAGE_SIZE = 50
 
 interface PrototypeLibraryListProps {
   selectedFilters?: string[]
@@ -26,15 +38,18 @@ const PrototypeLibraryList = ({
   searchInput,
 }: PrototypeLibraryListProps) => {
   const { data: model } = useCurrentModel()
-  const { data: fetchedPrototypes, refetch } = useListModelPrototypes(
+  const { data: fetchedPrototypes } = useListModelPrototypes(
     model ? model.id : '',
   )
   const [selectedPrototype, setSelectedPrototype] = useState<Prototype>()
   const [filteredPrototypes, setFilteredPrototypes] = useState<Prototype[]>()
+  const [currentPage, setCurrentPage] = useState(1)
   const [loading, setLoading] = useState(true)
   const [timeoutReached, setTimeoutReached] = useState(false)
   const navigate = useNavigate()
   const { prototype_id } = useParams()
+  const filterResetKey = `${searchInput ?? ''}|${(selectedFilters ?? []).join(',')}`
+  const [pageResetKey, setPageResetKey] = useState(filterResetKey)
 
   useEffect(() => {
     if (!selectedPrototype) return
@@ -94,6 +109,30 @@ const PrototypeLibraryList = ({
     )
   }, [searchInput, selectedFilters, fetchedPrototypes])
 
+  if (filterResetKey !== pageResetKey) {
+    setPageResetKey(filterResetKey)
+    setCurrentPage(1)
+  }
+
+  const totalFiltered = filteredPrototypes?.length ?? 0
+  const totalPages = Math.max(1, Math.ceil(totalFiltered / PAGE_SIZE))
+  const safePage = Math.min(currentPage, totalPages)
+  const visiblePageItems = useMemo(
+    () => getVisiblePageItems(safePage, totalPages),
+    [safePage, totalPages],
+  )
+
+  const pagedPrototypes = useMemo(() => {
+    if (!filteredPrototypes) return []
+    const start = (safePage - 1) * PAGE_SIZE
+    return filteredPrototypes.slice(start, start + PAGE_SIZE)
+  }, [filteredPrototypes, safePage])
+
+  const handlePageChange = (page: number) => {
+    if (page < 1 || page > totalPages) return
+    setCurrentPage(page)
+  }
+
   useEffect(() => {
     const timeout = setTimeout(() => {
       if (!model || !fetchedPrototypes) {
@@ -138,26 +177,87 @@ const PrototypeLibraryList = ({
     <div className="flex flex-col w-full h-full">
       <div className="flex flex-col h-full">
         {filteredPrototypes && filteredPrototypes.length > 0 ? (
-          <div className="w-full grid grid-cols-1 sm:grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-2.5">
-            {filteredPrototypes.map((prototype) => (
-              <div
-                key={prototype.id}
-                onClick={() =>
-                  navigate(
-                    `/model/${model!.id}/library/prototype/${prototype.id}/view`,
-                  )
-                }
-                className="flex w-full cursor-pointer mb-2 prototype-grid-item-wrapper"
+          <>
+            <div className="w-full grid grid-cols-1 sm:grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-2.5">
+              {pagedPrototypes.map((prototype) => (
+                <div
+                  key={prototype.id}
+                  onClick={() =>
+                    navigate(
+                      `/model/${model!.id}/library/prototype/${prototype.id}/view`,
+                    )
+                  }
+                  className="flex w-full cursor-pointer mb-2 prototype-grid-item-wrapper"
+                >
+                  <DaPrototypeCard
+                    prototype={prototype}
+                    existingPrototypeNames={fetchedPrototypes
+                      ?.filter((p) => p.id !== prototype.id)
+                      .map((p) => p.name)}
+                  />
+                </div>
+              ))}
+            </div>
+            {totalFiltered > PAGE_SIZE && (
+              <DaPaging
+                data-id="prototype-library-pagination"
+                className="pt-4 pb-6"
               >
-                <DaPrototypeCard
-                  prototype={prototype}
-                  existingPrototypeNames={fetchedPrototypes
-                    ?.filter((p) => p.id !== prototype.id)
-                    .map((p) => p.name)}
-                />
-              </div>
-            ))}
-          </div>
+                <DaPaginationContent>
+                  <DaPaginationItem>
+                    <DaPaginationPrevious
+                      href={`#${safePage - 1}`}
+                      onClick={(e) => {
+                        e.preventDefault()
+                        handlePageChange(safePage - 1)
+                      }}
+                      disabled={safePage === 1}
+                    />
+                  </DaPaginationItem>
+                  {visiblePageItems.map((item, index) => {
+                    if (item === 'ellipsis') {
+                      const ellipsisKey =
+                        index < visiblePageItems.length / 2
+                          ? 'ellipsis-before'
+                          : 'ellipsis-after'
+                      return (
+                        <DaPaginationItem key={ellipsisKey}>
+                          <DaPaginationEllipsis
+                            data-id={`prototype-library-${ellipsisKey}`}
+                          />
+                        </DaPaginationItem>
+                      )
+                    }
+                    return (
+                      <DaPaginationItem key={item}>
+                        <DaPaginationLink
+                          data-id={`prototype-library-page-${item}`}
+                          href={`#${item}`}
+                          isActive={safePage === item}
+                          onClick={(e) => {
+                            e.preventDefault()
+                            handlePageChange(item)
+                          }}
+                        >
+                          {item}
+                        </DaPaginationLink>
+                      </DaPaginationItem>
+                    )
+                  })}
+                  <DaPaginationItem>
+                    <DaPaginationNext
+                      href={`#${safePage + 1}`}
+                      onClick={(e) => {
+                        e.preventDefault()
+                        handlePageChange(safePage + 1)
+                      }}
+                      disabled={safePage === totalPages}
+                    />
+                  </DaPaginationItem>
+                </DaPaginationContent>
+              </DaPaging>
+            )}
+          </>
         ) : (
           <div className="flex w-full h-[70%] items-center justify-center">
             <h3 className="text-lg font-semibold text-primary">

--- a/frontend/src/components/organisms/PrototypeLibraryList.tsx
+++ b/frontend/src/components/organisms/PrototypeLibraryList.tsx
@@ -6,16 +6,20 @@
 //
 // SPDX-License-Identifier: MIT
 
-import { useState, useEffect, useMemo } from 'react'
+import { useState, useEffect, useMemo, useCallback } from 'react'
 import { Prototype } from '@/types/model.type'
-import { useListModelPrototypes } from '@/hooks/usePrototypeQueries'
+import {
+  useListModelPrototypes,
+  useModelPrototypesPaged,
+} from '@/hooks/usePrototypeQueries'
 import useCurrentModel from '@/hooks/useCurrentModel'
-import { useParams, useNavigate } from 'react-router-dom'
+import { useParams, useNavigate, useSearchParams } from 'react-router-dom'
 import { DaPrototypeCard } from '../molecules/DaPrototypeCard'
 import DaErrorDisplay from '../molecules/DaErrorDisplay'
 import DaSkeletonGrid from '../molecules/DaSkeletonGrid'
 import { sortPrototypesByViewed } from '@/utils/prototypeSort'
 import { getVisiblePageItems } from '@/utils/pagination'
+import { PROTOTYPE_LIBRARY_SORT_BY } from '@/services/prototype.service'
 import {
   DaPaging,
   DaPaginationContent,
@@ -27,10 +31,16 @@ import {
 } from '../atoms/DaPaging'
 
 const PAGE_SIZE = 50
+const CLIENT_ONLY_SORTS = ['Last view', 'First view', 'Rating']
 
 interface PrototypeLibraryListProps {
   selectedFilters?: string[]
   searchInput?: string
+}
+
+const parsePageParam = (raw: string | null) => {
+  const parsed = parseInt(raw || '1', 10)
+  return Number.isFinite(parsed) && parsed >= 1 ? parsed : 1
 }
 
 const PrototypeLibraryList = ({
@@ -38,18 +48,54 @@ const PrototypeLibraryList = ({
   searchInput,
 }: PrototypeLibraryListProps) => {
   const { data: model } = useCurrentModel()
-  const { data: fetchedPrototypes } = useListModelPrototypes(
-    model ? model.id : '',
-  )
+  const modelId = model ? model.id : ''
   const [selectedPrototype, setSelectedPrototype] = useState<Prototype>()
   const [filteredPrototypes, setFilteredPrototypes] = useState<Prototype[]>()
-  const [currentPage, setCurrentPage] = useState(1)
   const [loading, setLoading] = useState(true)
   const [timeoutReached, setTimeoutReached] = useState(false)
   const navigate = useNavigate()
+  const [searchParams, setSearchParams] = useSearchParams()
   const { prototype_id } = useParams()
   const filterResetKey = `${searchInput ?? ''}|${(selectedFilters ?? []).join(',')}`
   const [pageResetKey, setPageResetKey] = useState(filterResetKey)
+
+  const isClientSideMode =
+    !!searchInput?.trim() ||
+    (selectedFilters ?? []).some((filter) => CLIENT_ONLY_SORTS.includes(filter))
+
+  const sortBy = PROTOTYPE_LIBRARY_SORT_BY[selectedFilters?.[0] ?? '']
+
+  const urlPage = parsePageParam(searchParams.get('page'))
+
+  // Reset to page 1 when search/sort changes (adjust state during render when inputs change).
+  if (filterResetKey !== pageResetKey) {
+    setPageResetKey(filterResetKey)
+    if (searchParams.has('page')) {
+      setSearchParams(
+        (prev) => {
+          const next = new URLSearchParams(prev)
+          next.delete('page')
+          return next
+        },
+        { replace: true },
+      )
+    }
+  }
+
+  const requestedPage = filterResetKey !== pageResetKey ? 1 : urlPage
+
+  const { data: fetchedPrototypes } = useListModelPrototypes(modelId, {
+    enabled: isClientSideMode,
+  })
+  const pagedQuery = useModelPrototypesPaged(
+    modelId,
+    {
+      page: requestedPage,
+      limit: PAGE_SIZE,
+      ...(sortBy ? { sortBy } : {}),
+    },
+    { enabled: !isClientSideMode && !!modelId },
+  )
 
   useEffect(() => {
     if (!selectedPrototype) return
@@ -57,19 +103,18 @@ const PrototypeLibraryList = ({
   }, [selectedPrototype])
 
   useEffect(() => {
-    if (!fetchedPrototypes) return
-    if (prototype_id) {
-      const prototype = fetchedPrototypes.find(
-        (prototype) => prototype.id === prototype_id,
-      )
-      if (prototype) {
-        setSelectedPrototype(prototype)
-      }
+    const source = isClientSideMode
+      ? fetchedPrototypes
+      : pagedQuery.data?.results
+    if (!source || !prototype_id) return
+    const prototype = source.find((item) => item.id === prototype_id)
+    if (prototype) {
+      setSelectedPrototype(prototype)
     }
-  }, [prototype_id, fetchedPrototypes])
+  }, [prototype_id, fetchedPrototypes, pagedQuery.data, isClientSideMode])
 
   useEffect(() => {
-    if (!fetchedPrototypes) return
+    if (!isClientSideMode || !fetchedPrototypes) return
 
     const filtered = fetchedPrototypes.filter((prototype) => {
       if (!searchInput) return true
@@ -107,47 +152,78 @@ const PrototypeLibraryList = ({
         return 0
       }),
     )
-  }, [searchInput, selectedFilters, fetchedPrototypes])
+  }, [isClientSideMode, searchInput, selectedFilters, fetchedPrototypes])
 
-  if (filterResetKey !== pageResetKey) {
-    setPageResetKey(filterResetKey)
-    setCurrentPage(1)
-  }
-
-  const totalFiltered = filteredPrototypes?.length ?? 0
-  const totalPages = Math.max(1, Math.ceil(totalFiltered / PAGE_SIZE))
-  const safePage = Math.min(currentPage, totalPages)
+  const totalFiltered = isClientSideMode
+    ? (filteredPrototypes?.length ?? 0)
+    : (pagedQuery.data?.totalResults ?? 0)
+  const totalPages = isClientSideMode
+    ? Math.max(1, Math.ceil(totalFiltered / PAGE_SIZE))
+    : Math.max(1, pagedQuery.data?.totalPages ?? 1)
+  const safePage = Math.min(requestedPage, totalPages)
   const visiblePageItems = useMemo(
     () => getVisiblePageItems(safePage, totalPages),
     [safePage, totalPages],
   )
 
   const pagedPrototypes = useMemo(() => {
+    if (!isClientSideMode) {
+      return pagedQuery.data?.results ?? []
+    }
     if (!filteredPrototypes) return []
     const start = (safePage - 1) * PAGE_SIZE
     return filteredPrototypes.slice(start, start + PAGE_SIZE)
-  }, [filteredPrototypes, safePage])
+  }, [isClientSideMode, filteredPrototypes, pagedQuery.data, safePage])
 
-  const handlePageChange = (page: number) => {
-    if (page < 1 || page > totalPages) return
-    setCurrentPage(page)
-  }
+  const handlePageChange = useCallback(
+    (page: number) => {
+      if (page < 1 || page > totalPages) return
+      setSearchParams(
+        (prev) => {
+          const next = new URLSearchParams(prev)
+          if (page <= 1) {
+            next.delete('page')
+          } else {
+            next.set('page', String(page))
+          }
+          return next
+        },
+        { replace: true },
+      )
+    },
+    [setSearchParams, totalPages],
+  )
+
+  useEffect(() => {
+    if (isClientSideMode || !pagedQuery.data) return
+    const serverTotalPages = Math.max(1, pagedQuery.data.totalPages)
+    if (requestedPage > serverTotalPages) {
+      handlePageChange(serverTotalPages)
+    }
+  }, [isClientSideMode, pagedQuery.data, requestedPage, handlePageChange])
+
+  const listReady = isClientSideMode
+    ? !!fetchedPrototypes && filteredPrototypes !== undefined
+    : !!pagedQuery.data || pagedQuery.isError
 
   useEffect(() => {
     const timeout = setTimeout(() => {
-      if (!model || !fetchedPrototypes) {
+      if (!model || !listReady) {
         setTimeoutReached(true)
       }
       setLoading(false)
     }, 15000)
 
-    if (fetchedPrototypes) {
+    if (listReady) {
       setLoading(false)
       clearTimeout(timeout)
+    } else {
+      setLoading(true)
+      setTimeoutReached(false)
     }
 
     return () => clearTimeout(timeout)
-  }, [model, fetchedPrototypes])
+  }, [model, listReady])
 
   if (loading) {
     return (
@@ -164,7 +240,7 @@ const PrototypeLibraryList = ({
     )
   }
 
-  if (timeoutReached) {
+  if (timeoutReached || (!isClientSideMode && pagedQuery.isError)) {
     return (
       <DaErrorDisplay
         error="Failed to load prototype library or access denied"
@@ -173,10 +249,14 @@ const PrototypeLibraryList = ({
     )
   }
 
+  const hasCards = isClientSideMode
+    ? !!filteredPrototypes && filteredPrototypes.length > 0
+    : pagedPrototypes.length > 0 || totalFiltered > 0
+
   return (
     <div className="flex flex-col w-full h-full">
       <div className="flex flex-col h-full">
-        {filteredPrototypes && filteredPrototypes.length > 0 ? (
+        {hasCards && pagedPrototypes.length > 0 ? (
           <>
             <div className="w-full grid grid-cols-1 sm:grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-2.5">
               {pagedPrototypes.map((prototype) => (
@@ -191,9 +271,13 @@ const PrototypeLibraryList = ({
                 >
                   <DaPrototypeCard
                     prototype={prototype}
-                    existingPrototypeNames={fetchedPrototypes
-                      ?.filter((p) => p.id !== prototype.id)
-                      .map((p) => p.name)}
+                    existingPrototypeNames={
+                      isClientSideMode
+                        ? fetchedPrototypes
+                            ?.filter((p) => p.id !== prototype.id)
+                            .map((p) => p.name)
+                        : undefined
+                    }
                   />
                 </div>
               ))}
@@ -206,7 +290,7 @@ const PrototypeLibraryList = ({
                 <DaPaginationContent>
                   <DaPaginationItem>
                     <DaPaginationPrevious
-                      href={`#${safePage - 1}`}
+                      href={safePage <= 2 ? '?' : `?page=${safePage - 1}`}
                       onClick={(e) => {
                         e.preventDefault()
                         handlePageChange(safePage - 1)
@@ -232,7 +316,7 @@ const PrototypeLibraryList = ({
                       <DaPaginationItem key={item}>
                         <DaPaginationLink
                           data-id={`prototype-library-page-${item}`}
-                          href={`#${item}`}
+                          href={item === 1 ? '?' : `?page=${item}`}
                           isActive={safePage === item}
                           onClick={(e) => {
                             e.preventDefault()
@@ -246,7 +330,7 @@ const PrototypeLibraryList = ({
                   })}
                   <DaPaginationItem>
                     <DaPaginationNext
-                      href={`#${safePage + 1}`}
+                      href={`?page=${safePage + 1}`}
                       onClick={(e) => {
                         e.preventDefault()
                         handlePageChange(safePage + 1)

--- a/frontend/src/hooks/usePrototypeQueries.ts
+++ b/frontend/src/hooks/usePrototypeQueries.ts
@@ -11,8 +11,16 @@ import {
   listPopularPrototypes,
   listRecentPrototypes,
   listModelPrototypes,
-  listModelPrototypeCount,
+  listModelPrototypesPaged,
 } from '@/services/prototype.service'
+
+export type ModelPrototypesPagedParams = {
+  page: number
+  limit: number
+  sortBy?: string
+  name?: string
+  fields?: string
+}
 
 export const prototypeQueryKeys = {
   all: ['prototypes'] as const,
@@ -21,8 +29,10 @@ export const prototypeQueryKeys = {
   allForViewSort: (params: Record<string, unknown>) =>
     ['prototypes', 'all-for-view-sort', params] as const,
   model: (modelId: string) => ['listModelPrototypes', modelId] as const,
-  modelCount: (modelId: string) =>
-    ['listModelPrototypes', modelId, 'count'] as const,
+  modelPaged: (modelId: string, params: ModelPrototypesPagedParams) =>
+    ['listModelPrototypes', modelId, 'paged', params] as const,
+  modelTotal: (modelId: string) =>
+    ['listModelPrototypes', modelId, 'total'] as const,
   recent: () => ['prototypes', 'recent'] as const,
   popular: () => ['prototypes', 'popular'] as const,
 }
@@ -60,15 +70,36 @@ export const useListModelPrototypes = (
   })
 }
 
-export const useModelPrototypeCount = (
+export const useModelPrototypesPaged = (
+  model_id: string,
+  params: ModelPrototypesPagedParams,
+  options?: { enabled?: boolean },
+) => {
+  const enabled = options?.enabled ?? !!model_id
+
+  return useQuery({
+    queryKey: prototypeQueryKeys.modelPaged(model_id, params),
+    queryFn: () => listModelPrototypesPaged({ model_id, ...params }),
+    enabled: enabled && !!model_id,
+  })
+}
+
+export const useModelPrototypeTotal = (
   model_id: string,
   options?: { enabled?: boolean },
 ) => {
   const enabled = options?.enabled ?? !!model_id
 
   return useQuery({
-    queryKey: prototypeQueryKeys.modelCount(model_id),
-    queryFn: () => listModelPrototypeCount(model_id),
+    queryKey: prototypeQueryKeys.modelTotal(model_id),
+    queryFn: () =>
+      listModelPrototypesPaged({
+        model_id,
+        page: 1,
+        limit: 1,
+        fields: 'id',
+      }),
+    select: (data) => data.totalResults,
     enabled: enabled && !!model_id,
   })
 }

--- a/frontend/src/hooks/usePrototypeQueries.ts
+++ b/frontend/src/hooks/usePrototypeQueries.ts
@@ -11,6 +11,7 @@ import {
   listPopularPrototypes,
   listRecentPrototypes,
   listModelPrototypes,
+  listModelPrototypeCount,
 } from '@/services/prototype.service'
 
 export const prototypeQueryKeys = {
@@ -20,6 +21,8 @@ export const prototypeQueryKeys = {
   allForViewSort: (params: Record<string, unknown>) =>
     ['prototypes', 'all-for-view-sort', params] as const,
   model: (modelId: string) => ['listModelPrototypes', modelId] as const,
+  modelCount: (modelId: string) =>
+    ['listModelPrototypes', modelId, 'count'] as const,
   recent: () => ['prototypes', 'recent'] as const,
   popular: () => ['prototypes', 'popular'] as const,
 }
@@ -51,8 +54,21 @@ export const useListModelPrototypes = (
   const enabled = options?.enabled ?? !!model_id
 
   return useQuery({
-    queryKey: ['listModelPrototypes', model_id],
+    queryKey: prototypeQueryKeys.model(model_id),
     queryFn: () => listModelPrototypes(model_id),
+    enabled: enabled && !!model_id,
+  })
+}
+
+export const useModelPrototypeCount = (
+  model_id: string,
+  options?: { enabled?: boolean },
+) => {
+  const enabled = options?.enabled ?? !!model_id
+
+  return useQuery({
+    queryKey: prototypeQueryKeys.modelCount(model_id),
+    queryFn: () => listModelPrototypeCount(model_id),
     enabled: enabled && !!model_id,
   })
 }

--- a/frontend/src/layouts/ModelDetailLayout.tsx
+++ b/frontend/src/layouts/ModelDetailLayout.tsx
@@ -13,7 +13,7 @@ import { Model } from '@/types/model.type'
 import { matchRoutes, Outlet, useLocation } from 'react-router-dom'
 import { Skeleton } from '@/components/atoms/skeleton'
 import { Spinner } from '@/components/atoms/spinner'
-import { useModelPrototypeCount } from '@/hooks/usePrototypeQueries'
+import { useModelPrototypeTotal } from '@/hooks/usePrototypeQueries'
 import useLastAccessedModel from '@/hooks/useLastAccessedModel'
 import useCurrentModel from '@/hooks/useCurrentModel'
 import { Button } from '@/components/atoms/button'
@@ -54,7 +54,7 @@ const ModelDetailLayout = () => {
     state.setActiveModel,
   ])
   const location = useLocation()
-  const { data: prototypeCount } = useModelPrototypeCount(
+  const { data: prototypeCount } = useModelPrototypeTotal(
     model ? model.id : '',
   )
   const [activeModelApis] = useModelStore((state) => [state.activeModelApis])

--- a/frontend/src/layouts/ModelDetailLayout.tsx
+++ b/frontend/src/layouts/ModelDetailLayout.tsx
@@ -13,7 +13,7 @@ import { Model } from '@/types/model.type'
 import { matchRoutes, Outlet, useLocation } from 'react-router-dom'
 import { Skeleton } from '@/components/atoms/skeleton'
 import { Spinner } from '@/components/atoms/spinner'
-import { useListModelPrototypes } from '@/hooks/usePrototypeQueries'
+import { useModelPrototypeCount } from '@/hooks/usePrototypeQueries'
 import useLastAccessedModel from '@/hooks/useLastAccessedModel'
 import useCurrentModel from '@/hooks/useCurrentModel'
 import { Button } from '@/components/atoms/button'
@@ -54,7 +54,7 @@ const ModelDetailLayout = () => {
     state.setActiveModel,
   ])
   const location = useLocation()
-  const { data: fetchedPrototypes } = useListModelPrototypes(
+  const { data: prototypeCount } = useModelPrototypeCount(
     model ? model.id : '',
   )
   const [activeModelApis] = useModelStore((state) => [state.activeModelApis])
@@ -184,7 +184,7 @@ const ModelDetailLayout = () => {
   const isLoading = isModelLoading || !model
   const canManageModelUI = (isModelOwner || hasWritePermission) && !!allowNonAdminAddonConfig
 
-  const numberOfPrototypes = fetchedPrototypes?.length || 0
+  const numberOfPrototypes = prototypeCount ?? 0
   const numberOfApis = activeModelApis?.length || 0
 
   // Count API sets: 1 for COVESA + number of custom_api_sets

--- a/frontend/src/services/prototype.service.ts
+++ b/frontend/src/services/prototype.service.ts
@@ -120,12 +120,39 @@ export const getPrototype = async (prototype_id: string) => {
   return (await serverAxios.get<Prototype>(`/prototypes/${prototype_id}`)).data
 }
 
+export const listModelPrototypeCount = async (
+  model_id: string,
+): Promise<number> => {
+  const response = await serverAxios.get<List<Prototype>>('/prototypes', {
+    params: { model_id, page: 1, limit: 1, fields: 'id' },
+  })
+  return response.data.totalResults
+}
+
 export const listModelPrototypes = async (model_id: string) => {
-  return (
-    await serverAxios.get<List<Prototype>>(
-      `/prototypes?model_id=${model_id}&limit=50`,
-    )
-  ).data.results
+  let page = 1
+  const limit = 50
+  const allResults: Prototype[] = []
+  let totalPages = 1
+  const addedIds = new Set<string>()
+
+  do {
+    const response = await serverAxios.get<List<Prototype>>('/prototypes', {
+      params: { model_id, page, limit },
+    })
+
+    response.data.results.forEach((prototype) => {
+      if (!addedIds.has(prototype.id)) {
+        addedIds.add(prototype.id)
+        allResults.push(prototype)
+      }
+    })
+
+    totalPages = response.data.totalPages
+    page++
+  } while (page <= totalPages)
+
+  return allResults
 }
 
 export const createPrototypeService = async (prototype: any) => {

--- a/frontend/src/services/prototype.service.ts
+++ b/frontend/src/services/prototype.service.ts
@@ -1,5 +1,5 @@
 // Copyright (c) 2025 Eclipse Foundation.
-// 
+//
 // This program and the accompanying materials are made available under the
 // terms of the MIT License which is available at
 // https://opensource.org/licenses/MIT.
@@ -120,13 +120,33 @@ export const getPrototype = async (prototype_id: string) => {
   return (await serverAxios.get<Prototype>(`/prototypes/${prototype_id}`)).data
 }
 
-export const listModelPrototypeCount = async (
-  model_id: string,
-): Promise<number> => {
+/** UI sort labels that can be expressed as API `sortBy`. */
+export const PROTOTYPE_LIBRARY_SORT_BY: Record<string, string> = {
+  Newest: 'createdAt:desc',
+  Oldest: 'createdAt:asc',
+  'Name A-Z': 'name:asc',
+  'Name Z-A': 'name:desc',
+}
+
+export const listModelPrototypesPaged = async (params: {
+  model_id: string
+  page: number
+  limit: number
+  sortBy?: string
+  name?: string
+  fields?: string
+}): Promise<List<Prototype>> => {
   const response = await serverAxios.get<List<Prototype>>('/prototypes', {
-    params: { model_id, page: 1, limit: 1, fields: 'id' },
+    params: {
+      fields: params.fields ?? PROTOTYPE_LIST_CARD_FIELDS,
+      model_id: params.model_id,
+      page: params.page,
+      limit: params.limit,
+      ...(params.sortBy ? { sortBy: params.sortBy } : {}),
+      ...(params.name ? { name: params.name } : {}),
+    },
   })
-  return response.data.totalResults
+  return response.data
 }
 
 export const listModelPrototypes = async (model_id: string) => {

--- a/frontend/src/utils/pagination.ts
+++ b/frontend/src/utils/pagination.ts
@@ -1,0 +1,69 @@
+// Copyright (c) 2025 Eclipse Foundation.
+//
+// This program and the accompanying materials are made available under the
+// terms of the MIT License which is available at
+// https://opensource.org/licenses/MIT.
+//
+// SPDX-License-Identifier: MIT
+
+export type PageItem = number | 'ellipsis'
+
+/** Max page-number buttons shown (ellipsis slots are extra). */
+export const MAX_VISIBLE_PAGE_BUTTONS = 7
+
+/**
+ * Build a sliding window of page numbers with ellipsis for large totals.
+ * Examples (maxVisible=7, total=10):
+ * - page 1 → 1 2 3 4 5 … 10
+ * - page 5 → 1 … 4 5 6 … 10
+ * - page 10 → 1 … 6 7 8 9 10
+ */
+export function getVisiblePageItems(
+  currentPage: number,
+  totalPages: number,
+  maxVisible: number = MAX_VISIBLE_PAGE_BUTTONS,
+): PageItem[] {
+  if (totalPages <= 0) return []
+
+  const total = Math.floor(totalPages)
+  const current = Math.min(Math.max(1, Math.floor(currentPage)), total)
+
+  if (total <= maxVisible) {
+    return Array.from({ length: total }, (_, i) => i + 1)
+  }
+
+  const edgeCount = maxVisible - 2
+  const siblingCount = 1
+  const showLeftEllipsis = current - siblingCount > 2
+  const showRightEllipsis = current + siblingCount < total - 1
+
+  if (!showLeftEllipsis && showRightEllipsis) {
+    const items: PageItem[] = []
+    for (let i = 1; i <= edgeCount; i++) items.push(i)
+    items.push('ellipsis')
+    items.push(total)
+    return items
+  }
+
+  if (showLeftEllipsis && !showRightEllipsis) {
+    const items: PageItem[] = [1, 'ellipsis']
+    for (let i = total - edgeCount + 1; i <= total; i++) items.push(i)
+    return items
+  }
+
+  if (showLeftEllipsis && showRightEllipsis) {
+    const items: PageItem[] = [1, 'ellipsis']
+    for (
+      let i = current - siblingCount;
+      i <= current + siblingCount;
+      i++
+    ) {
+      items.push(i)
+    }
+    items.push('ellipsis')
+    items.push(total)
+    return items
+  }
+
+  return Array.from({ length: total }, (_, i) => i + 1)
+}


### PR DESCRIPTION
# Summary

Adds Prototype Library paging so large models can be browsed page by page, and fixes the model tab badge so it shows the real prototype total instead of a single API page.

# Motivation

The library list previously loaded `limit=50` and rendered that set as the whole library. Search/sort only applied to those 50 items, the Prototype Library tab count was wrong for larger models, and there was no way to reach the rest of the list.

A first pass added UI paging by walking every API page, then slicing in the browser. That restored full search/sort, but first paint got slower as the library grew, and it duplicated a count request.

This change pages through `GET /v2/prototypes` for the common sorts, keeps a client fallback where the API cannot express the sort/search, and persists the current page in the URL.

# Changes

* Added **Previous / page-number / Next** controls on the Prototype Library list:

  * 50 cards per page
  * Maximum 7 page-number buttons with ellipsis
* Added:

  * `listModelPrototypesPaged`
  * `useModelPrototypesPaged`
  * `useModelPrototypeTotal`
* Updated `PrototypeLibraryList` to use hybrid paging:

  * **Server-side paging** with `page` / `limit` / `sortBy` for:

    * Newest
    * Oldest
    * Name A–Z
    * Name Z–A
    * Empty search
  * **Client-side fallback** for:

    * Last view
    * First view
    * Rating
    * Substring search
* Updated the library URL to persist page state as `?page=N`.

  * `page=1` is omitted from the URL.
  * Search/sort changes reset the page to 1.
* Updated `CAP-PROTO-09` and `SITEMAP` to match shipped behavior without fabricating test coverage.
* Refactored the tab badge to use the paged total instead of a separate count hook.
* Kept `listModelPrototypes` walk-all behavior for:

  * Portfolio
  * Create/import duplicate-name checks
  * Rename checks

# Behavior

## Before

* Library showed at most 50 prototypes; extra items were unreachable.
* Tab badge could show 50 (or the length of one page) instead of the model total.
* Search/sort only ran over the loaded page.
* Refresh/back did not restore the current page.

## After

* Libraries with more than 50 prototypes show a pager.
* Page clicks:

  * Load the requested page through the API for server-supported sorts.
  * Slice the filtered set for client-only fallback modes.
* Tab badge shows API `totalResults` from a `limit=1` paged query.
* Search/sort still work across the full set for client-only modes.
* Server-supported sorts are paged directly by the API.
* `?page=2` survives refresh.
* Changing search or sort returns to page 1.

# Testing

* [ ] Unit tests
* [ ] Integration tests
* [ ] Manual testing
* [x] Existing test suite passes (`npx tsc --noEmit` on frontend)

**Tested with:**

* Frontend typecheck: `npx tsc --noEmit`
* Manual smoke testing is still recommended for:

  * Model with 50+ prototypes
  * Pager navigation
  * Page 2
  * `?page=2` refresh
  * Tab count vs API total
  * Last view / search fallback
  * Newest / Name with empty search
  * One list request per page

# Breaking Changes

None.

# Additional Notes

* **Last view / First view** (`localStorage`), **Rating** (`avg_score` from the feedback decorator), and **substring search** cannot be expressed as server `sortBy` / exact name queries, so these modes still fetch all pages and then slice the result.
* Follow-up: regex name search and server-side rating/view sorting would allow those paths to use API-side paging as well.
* Portfolio, create/import duplicate-name checks, and rename still use the walk-all list query.
* `CAP-PROTO-09` / `SITEMAP` correctly mark paging E2E as uncovered (`❌`); Playwright cases were not shipped with this PR.
