### PR TITLE
fix: serialize populated model ids in has-permission query

### DIFF
--- a/frontend/src/services/permission.service.ts
+++ b/frontend/src/services/permission.service.ts
@@ -8,14 +8,29 @@
 
 import { serverAxios } from './base'
 
+const toPermissionRef = (value: unknown): string | undefined => {
+  if (value == null || value === '') return undefined
+  if (typeof value === 'string') return value
+  if (typeof value === 'object') {
+    const obj = value as { id?: unknown; _id?: unknown }
+    if (typeof obj.id === 'string' && obj.id) return obj.id
+    if (obj._id != null) return String(obj._id)
+  }
+  return undefined
+}
+
 export const checkPermissionService = async (
   permissions: [string, string?][],
 ) => {
+  const list = Array.isArray(permissions) ? permissions : [permissions]
   return (
     await serverAxios.get<boolean[]>(`/permissions/has-permission`, {
       params: {
-        permissions: (Array.isArray(permissions) ? permissions : [permissions])
-          .map((perm) => perm.join(':'))
+        permissions: list
+          .map(([action, ref]) => {
+            const refId = toPermissionRef(ref)
+            return refId ? `${action}:${refId}` : action
+          })
           .join(','),
       },
     })


### PR DESCRIPTION
# Summary

Fix permission query serialization so a populated model object is sent as a real ID (`writeModel:<id>`) instead of `writeModel:[object Object]`. Prototype detail pages can then resolve `WRITE_MODEL` correctly.

# Motivation

## What problem does it solve?

On the prototype detail page, `useCanEditPrototype` calls:

```ts
usePermissionHook([MANAGE_USERS], [WRITE_MODEL, prototype.model_id])
```

`GET /v2/prototypes/:id` populates `model_id` (`getPrototypeById` uses `populate({ path: 'model_id' })`), so the frontend receives `{ id, name, visibility }` rather than a string.

`checkPermissionService` used `perm.join(':')`, which stringified that object to `[object Object]`.

The request looked like:

```text
/v2/permissions/has-permission?permissions=manageUsers,writeModel:%5Bobject+Object%5D
```

## What was difficult or missing before?

`[object Object]` is not a valid `ObjectId`. Mongoose throws `CastError` (400). The controller `Promise.all` then fails the entire batch, so `manageUsers` is also lost.

`usePermissionHook` falls back to `fill(false)` — fail-closed, but edit/admin UI on that page was wrong.

## Why this approach?

One change in `checkPermissionService` covers every caller.

Empty/null refs still become a bare action (`writeModel`), which matches the old `writeModel` global-check path.

No backend populate change is needed; that populate is still required for visibility checks.

# Changes

* Added `toPermissionRef()` in `frontend/src/services/permission.service.ts` to:

  * Take a string as-is.
  * Extract `id` from a populated object.
  * Fall back to `_id` from a populated object.
* Updated `checkPermissionService` to build `ACTION:ref` from that helper instead of using `Array.join(':')`.

# Behavior

## Before

Prototype detail pages (and any hook passing a populated `model_id`) requested:

```text
writeModel:[object Object]
```

The batch returned 400, causing both write and admin flags on that page to become `false`.

## After

The same call becomes:

```text
writeModel:6a7e8a1690eecd2e4e9e523e
```

Scoped `WRITE_MODEL` and sibling `manageUsers` permissions in the same request both return real booleans.

Missing refs are still sent as the bare action name.

# Testing

* [ ] Unit tests
* [ ] Integration tests
* [x] Manual testing
* [ ] Existing test suite passes

**Tested with:**

Open a prototype detail page and confirm the network call is:

```text
/v2/permissions/has-permission?permissions=manageUsers,writeModel:<actualModelId>
```

and not:

```text
writeModel:%5Bobject+Object%5D
```

Check that contributor write UI and admin actions match the user's actual permissions.

# Breaking Changes

None.

# Additional Notes

* **Trigger:** `GET /v2/prototypes/:id` → populated `model_id` → `useCanEditPrototype` (`frontend/src/hooks/useCanEditPrototype.ts`).
* An object with neither `id` nor `_id` is sent as a bare action (global check). This is true only for users who already have the permission on `*` (e.g. admin `WRITE_MODEL`). It does not grant write access to a normal contributor. Writes remain enforced server-side.
* **Optional follow-up:** Extract a string ID in `useCanEditPrototype` before calling the hook. This is not required for the fix.
