### PR TITLE
fix: cache and dedupe public site-config fetches

### DIFF
--- a/frontend/src/utils/siteConfig.ts
+++ b/frontend/src/utils/siteConfig.ts
@@ -270,7 +270,9 @@ export const useSiteConfigs = (
         }
       } catch (err) {
         if (!cancelled) {
-          setError(err instanceof Error ? err.message : 'Failed to fetch configs')
+          setError(
+            err instanceof Error ? err.message : 'Failed to fetch configs',
+          )
         }
       } finally {
         if (!cancelled) {
@@ -301,7 +303,10 @@ export const useSiteConfig = (
 ) => {
   const defaultVal = fallback ?? DEFAULT_SITE_CONFIGS[key]
   const [value, setValue] = useState<any>(() =>
-    parseConfigValue(getConfigSync(key, defaultVal, scope, target_id), defaultVal),
+    parseConfigValue(
+      getConfigSync(key, defaultVal, scope, target_id),
+      defaultVal,
+    ),
   )
 
   useEffect(() => {

--- a/frontend/src/utils/siteConfig.ts
+++ b/frontend/src/utils/siteConfig.ts
@@ -9,10 +9,57 @@
 import { useState, useEffect } from 'react'
 import { configManagementService } from '../services/configManagement.service'
 
-// Cache for site configs to avoid repeated API calls
-let configCache = new Map<string, any>()
-let cacheExpiry: number | null = null
 const CACHE_DURATION = 5 * 60 * 1000 // 5 minutes
+
+const DEFAULT_SITE_CONFIGS: Record<string, any> = {
+  SITE_LOGO_WIDE: '/imgs/logo-wide.png',
+  DEFAULT_MODEL_IMAGE: '/imgs/default-model-image.png',
+  DEFAULT_PROTOTYPE_IMAGE: '/imgs/default_prototype_cover.jpg',
+  SITE_TITLE: 'AutoWRX',
+  SITE_DESCRIPTION: 'Vehicle Signal Specification Management Platform',
+  SITE_FAVICON: '/imgs/favicon.ico',
+  SITE_THEME_COLOR: '#198100',
+  DISABLE_CUSTOM_API_SETS: false,
+  GENAI_SDV_APP_ENDPOINT:
+    'https://workflow.digital.auto/webhook/c0ba14bc-c6a3-4319-ad0a-ad89b1460b36',
+  VSS_PLUGINS: [{ label: 'A2L Importer', plugin: 'a2l-importer' }],
+}
+
+type CachedBulkConfigs = { data: Record<string, any>; expiry: number }
+
+const bulkCache = new Map<string, CachedBulkConfigs>()
+const inFlightBulk = new Map<string, Promise<Record<string, any>>>()
+
+const makeBulkCacheKey = (scope: string, target_id?: string) =>
+  `public_${scope}_${target_id ?? ''}`
+
+const readCachedBulk = (
+  scope: string,
+  target_id?: string,
+): Record<string, any> | null => {
+  const cached = bulkCache.get(makeBulkCacheKey(scope, target_id))
+  if (cached && Date.now() < cached.expiry) {
+    return cached.data
+  }
+  return null
+}
+
+const resolveConfigValue = (raw: any, key: string, defaultValue: any): any => {
+  if (raw !== null && raw !== undefined) {
+    return raw
+  }
+  return defaultValue !== null ? defaultValue : DEFAULT_SITE_CONFIGS[key]
+}
+
+const pickConfigValue = (
+  configs: Record<string, any> | null | undefined,
+  key: string,
+): any => {
+  if (configs && Object.prototype.hasOwnProperty.call(configs, key)) {
+    return configs[key]
+  }
+  return undefined
+}
 
 const parseConfigValue = (raw: any, defaultVal: any): any => {
   if (raw === null || raw === undefined || raw === '') {
@@ -46,28 +93,9 @@ const parseConfigValue = (raw: any, defaultVal: any): any => {
   return raw
 }
 
-// Default fallback values for site configs
-const DEFAULT_SITE_CONFIGS: Record<string, any> = {
-  SITE_LOGO_WIDE: '/imgs/logo-wide.png',
-  DEFAULT_MODEL_IMAGE: '/imgs/default-model-image.png',
-  DEFAULT_PROTOTYPE_IMAGE: '/imgs/default_prototype_cover.jpg',
-  SITE_TITLE: 'AutoWRX',
-  SITE_DESCRIPTION: 'Vehicle Signal Specification Management Platform',
-  SITE_FAVICON: '/imgs/favicon.ico',
-  SITE_THEME_COLOR: '#198100',
-  DISABLE_CUSTOM_API_SETS: false,
-  GENAI_SDV_APP_ENDPOINT:
-    'https://workflow.digital.auto/webhook/c0ba14bc-c6a3-4319-ad0a-ad89b1460b36',
-  VSS_PLUGINS: [{ label: 'A2L Importer', plugin: 'a2l-importer' }],
-}
-
 /**
- * Get a single site config value by key with fallback to default
- * @param key - The config key
- * @param scope - The scope (site, user, model, etc.)
- * @param target_id - The target ID for scoped configs
- * @param defaultValue - Default value if key not found
- * @returns Promise with the config value or default value
+ * Get a single site config value by key with fallback to default.
+ * Reads from the shared public-config bulk cache so many keys share one request.
  */
 export const getConfig = async (
   key: string,
@@ -76,17 +104,8 @@ export const getConfig = async (
   defaultValue: any = null,
 ): Promise<any> => {
   try {
-    const result = await configManagementService.getPublicConfig(
-      key,
-      scope,
-      target_id,
-    )
-    const value = result?.value
-    return value !== null && value !== undefined
-      ? value
-      : defaultValue !== null
-        ? defaultValue
-        : DEFAULT_SITE_CONFIGS[key]
+    const configs = await getPublicConfigs(scope, target_id)
+    return resolveConfigValue(pickConfigValue(configs, key), key, defaultValue)
   } catch (error) {
     console.warn(`Failed to get config for key "${key}":`, error)
     return defaultValue !== null ? defaultValue : DEFAULT_SITE_CONFIGS[key]
@@ -95,24 +114,20 @@ export const getConfig = async (
 
 /**
  * Get a site config value synchronously from cache or return default
- * @param key - The config key
- * @returns The config value or default value
  */
 export const getSiteConfigSync = (key: string): any => {
-  const cacheKey = `public_site_`
-  const cached = configCache.get(cacheKey)
-  if (cached && cached[key]) {
-    return cached[key]
+  const cached = readCachedBulk('site')
+  if (cached && Object.prototype.hasOwnProperty.call(cached, key)) {
+    const raw = cached[key]
+    if (raw !== undefined && raw !== null) {
+      return raw
+    }
   }
   return DEFAULT_SITE_CONFIGS[key]
 }
 
 /**
  * Get multiple site config values by keys
- * @param keys - Array of config keys
- * @param scope - The scope (site, user, model, etc.)
- * @param target_id - The target ID for scoped configs
- * @returns Promise with object containing key-value pairs
  */
 export const getConfigs = async (
   keys: string[],
@@ -120,11 +135,11 @@ export const getConfigs = async (
   target_id?: string,
 ): Promise<Record<string, any>> => {
   try {
-    const all = await configManagementService.getPublicConfigs(scope, target_id)
+    const all = await getPublicConfigs(scope, target_id)
     const result: Record<string, any> = {}
     keys.forEach((k) => {
-      if (all && Object.prototype.hasOwnProperty.call(all, k)) {
-        result[k] = (all as any)[k]
+      if (Object.prototype.hasOwnProperty.call(all, k)) {
+        result[k] = all[k]
       }
     })
     return result
@@ -135,100 +150,94 @@ export const getConfigs = async (
 }
 
 /**
- * Get all public site configs (cached)
- * @param scope - The scope (site, user, model, etc.)
- * @param target_id - The target ID for scoped configs
- * @param forceRefresh - Force refresh cache
- * @returns Promise with object containing all public configs
+ * Get all public site configs (cached, in-flight deduped)
  */
 export const getPublicConfigs = async (
   scope: string = 'site',
   target_id?: string,
   forceRefresh: boolean = false,
 ): Promise<Record<string, any>> => {
-  const now = Date.now()
-  const cacheKey = `public_${scope}_${target_id || 'site'}`
+  const cacheKey = makeBulkCacheKey(scope, target_id)
 
-  // Return cached data if still valid and not forcing refresh
-  if (
-    !forceRefresh &&
-    cacheExpiry &&
-    now < cacheExpiry &&
-    configCache.has(cacheKey)
-  ) {
-    return configCache.get(cacheKey)!
+  if (!forceRefresh) {
+    const cached = readCachedBulk(scope, target_id)
+    if (cached) {
+      return cached
+    }
+
+    const inFlight = inFlightBulk.get(cacheKey)
+    if (inFlight) {
+      return inFlight
+    }
   }
 
+  const request = (async () => {
+    try {
+      const configs =
+        (await configManagementService.getPublicConfigs(scope, target_id)) || {}
+      bulkCache.set(cacheKey, {
+        data: configs,
+        expiry: Date.now() + CACHE_DURATION,
+      })
+      return configs
+    } catch (error) {
+      console.warn('Failed to get public configs:', error)
+      return bulkCache.get(cacheKey)?.data || {}
+    }
+  })()
+
+  inFlightBulk.set(cacheKey, request)
   try {
-    const configs = await configManagementService.getPublicConfigs(
-      scope,
-      target_id,
-    )
-
-    // Update cache
-    configCache.set(cacheKey, configs)
-    cacheExpiry = now + CACHE_DURATION
-
-    return configs
-  } catch (error) {
-    console.warn('Failed to get public configs:', error)
-    return configCache.get(cacheKey) || {}
+    return await request
+  } finally {
+    inFlightBulk.delete(cacheKey)
   }
 }
 
 /**
  * Get a config value synchronously from cache (if available)
- * @param key - The config key
- * @param defaultValue - Default value if key not found
- * @returns The cached config value or default value
  */
-export const getConfigSync = (key: string, defaultValue: any = null): any => {
-  // Try common cache keys for site scope
-  const siteCacheKey = `public_site_site`
-  const fallbackKey = 'public'
-  if (configCache.has(siteCacheKey)) {
-    const publicConfigs = configCache.get(siteCacheKey)!
-    return publicConfigs[key] !== undefined ? publicConfigs[key] : defaultValue
+export const getConfigSync = (
+  key: string,
+  defaultValue: any = null,
+  scope: string = 'site',
+  target_id?: string,
+): any => {
+  const cached = readCachedBulk(scope, target_id)
+  if (!cached) {
+    return defaultValue
   }
-  if (configCache.has(fallbackKey)) {
-    const publicConfigs = configCache.get(fallbackKey)!
-    return publicConfigs[key] !== undefined ? publicConfigs[key] : defaultValue
-  }
-  return defaultValue
+  const raw = pickConfigValue(cached, key)
+  return raw !== undefined && raw !== null ? raw : defaultValue
 }
 
 /**
  * Get multiple config values synchronously from cache (if available)
- * @param keys - Array of config keys
- * @returns Object with key-value pairs
  */
 export const getConfigsSync = (keys: string[]): Record<string, any> => {
-  if (configCache.has('public')) {
-    const publicConfigs = configCache.get('public')!
-    const result: Record<string, any> = {}
-    keys.forEach((key) => {
-      if (publicConfigs[key] !== undefined) {
-        result[key] = publicConfigs[key]
-      }
-    })
-    return result
+  const publicConfigs = readCachedBulk('site')
+  if (!publicConfigs) {
+    return {}
   }
-  return {}
+  const result: Record<string, any> = {}
+  keys.forEach((key) => {
+    if (Object.prototype.hasOwnProperty.call(publicConfigs, key)) {
+      result[key] = publicConfigs[key]
+    }
+  })
+  return result
 }
 
 /**
  * Clear the config cache
  */
 export const clearCache = (): void => {
-  configCache.clear()
-  cacheExpiry = null
+  bulkCache.clear()
+  inFlightBulk.clear()
 }
 
 /**
  * React hook for getting site configs
- * @param keys - Array of config keys to watch
- * @param defaultValue - Default values for the keys
- * @returns Object with config values and loading state
  */
 export const useSiteConfigs = (
   keys: string[],
@@ -239,41 +248,50 @@ export const useSiteConfigs = (
   const [error, setError] = useState<string | null>(null)
 
   useEffect(() => {
+    let cancelled = false
+
     const fetchConfigs = async () => {
       try {
         setLoading(true)
         setError(null)
 
-        // Try to get from cache first
         const cachedConfigs = getConfigsSync(keys)
         if (Object.keys(cachedConfigs).length === keys.length) {
-          setConfigs(cachedConfigs)
-          setLoading(false)
+          if (!cancelled) {
+            setConfigs(cachedConfigs)
+            setLoading(false)
+          }
           return
         }
 
-        // Fetch from API
         const fetchedConfigs = await getConfigs(keys)
-        setConfigs(fetchedConfigs)
+        if (!cancelled) {
+          setConfigs(fetchedConfigs)
+        }
       } catch (err) {
-        setError(err instanceof Error ? err.message : 'Failed to fetch configs')
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : 'Failed to fetch configs')
+        }
       } finally {
-        setLoading(false)
+        if (!cancelled) {
+          setLoading(false)
+        }
       }
     }
 
     fetchConfigs()
+    return () => {
+      cancelled = true
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [keys.join(',')])
 
   return { configs, loading, error }
 }
 
 /**
- * React hook for getting a single site config value
- * @param key - The config key
- * @param scope - The scope (site, user, model, etc.)
- * @param target_id - The target ID for scoped configs
- * @returns Object with value, loading state, and error
+ * React hook for getting a single site config value.
+ * All keys in the same scope share one `/site-config/public` request.
  */
 export const useSiteConfig = (
   key: string,
@@ -283,23 +301,44 @@ export const useSiteConfig = (
 ) => {
   const defaultVal = fallback ?? DEFAULT_SITE_CONFIGS[key]
   const [value, setValue] = useState<any>(() =>
-    parseConfigValue(getConfigSync(key, defaultVal), defaultVal),
+    parseConfigValue(getConfigSync(key, defaultVal, scope, target_id), defaultVal),
   )
 
   useEffect(() => {
-    const loadConfig = async () => {
-      try {
-        const result = await getConfig(key, scope, target_id, defaultVal)
-        const next = parseConfigValue(result, defaultVal)
-        setValue((prev: any) => (Object.is(prev, next) ? prev : next))
-      } catch {
-        setValue((prev: any) =>
-          Object.is(prev, defaultVal) ? prev : defaultVal,
-        )
-      }
+    let cancelled = false
+
+    const applyValue = (raw: any) => {
+      const next = parseConfigValue(
+        resolveConfigValue(raw, key, defaultVal),
+        defaultVal,
+      )
+      setValue((prev: any) => (Object.is(prev, next) ? prev : next))
     }
 
-    loadConfig()
+    const cached = readCachedBulk(scope, target_id)
+    if (cached) {
+      applyValue(pickConfigValue(cached, key))
+      return
+    }
+
+    getConfig(key, scope, target_id, defaultVal)
+      .then((result) => {
+        if (!cancelled) {
+          const next = parseConfigValue(result, defaultVal)
+          setValue((prev: any) => (Object.is(prev, next) ? prev : next))
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setValue((prev: any) =>
+            Object.is(prev, defaultVal) ? prev : defaultVal,
+          )
+        }
+      })
+
+    return () => {
+      cancelled = true
+    }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [key, scope, target_id])
 


### PR DESCRIPTION
## Summary

Share one cached bulk `GET /site-config/public` request across all `useSiteConfig` / `getConfig` callers so the prototype library no longer fires a separate `DEFAULT_PROTOTYPE_IMAGE` request per card.

## Motivation

**What problem does it solve?**

Opening Prototype Library (and similar lists) caused many identical calls to:

`GET /v2/site-config/public/DEFAULT_PROTOTYPE_IMAGE?scope=site`

Each `DaPrototypeCard` called `useDefaultPrototypeImage()` → `useSiteConfig()`, and that hook always hit the per-key public endpoint with no shared cache.

**What was difficult or missing before?**

* No in-flight dedupe: 20 cards mounting together meant 20 identical HTTP requests.
* No shared single-key cache: remounts/re-renders fetched again.
* Bulk `/public` was already cached, but single-key lookups did not use it.
* Nav/layout also fetched other keys (`SITE_TITLE`, `SITE_LOGO_WIDE`, …) as separate per-key requests.

**Why this approach?**

Keep the existing `useSiteConfig` / `getConfig` API so cards and lists do not need to change. Make `getConfig` read from one bulk public-config fetch (cached 5 minutes, in-flight requests shared). All keys in the same scope reuse that one response.

## Changes

* Updated `frontend/src/utils/siteConfig.ts` to use one bulk public-config cache as the source of truth for `getConfig`, `getConfigs`, `getPublicConfigs`, and `useSiteConfig`.
* Added in-flight dedupe so concurrent callers share the same request.
* Per-scope cache expiry (no longer one global expiry for all scopes).
* Fixed stale sync helpers (`getSiteConfigSync`, `getConfigsSync`) so they read the real bulk cache key.
* `useSiteConfig` / `useSiteConfigs` ignore results after unmount.
* No component changes in `DaPrototypeCard` or `PrototypeLibraryList`.

## Behavior

**Before:**

* N prototype cards → N calls to `/site-config/public/DEFAULT_PROTOTYPE_IMAGE`.
* Nav/layout each unique key → its own `/site-config/public/{KEY}` request.

**After:**

* One `GET /v2/site-config/public?scope=site` per scope for 5 minutes.
* Cards, nav, and layout read keys from that cached object.
* Missing/null values still fall back to the hook argument or `DEFAULT_SITE_CONFIGS`.

## Testing

* [ ] Unit tests
* [ ] Integration tests
* [x] Manual testing
* [ ] Existing test suite passes (frontend has no unit-test runner)

**Tested with:**

* Open Prototype Library with many cards.
* Network tab filtered to `site-config/public`.
* Expected: **one** bulk `/public?scope=site` request, **zero** `/public/DEFAULT_PROTOTYPE_IMAGE` from cards.
* Also check home prototype/model lists and nav logo/title still resolve correctly.

## Breaking Changes

None. Public helpers (`getConfig`, `useSiteConfig`, `useDefaultPrototypeImage`, `useDefaultModelImage`) keep the same signatures.

## Additional Notes

* Direct `configManagementService.getPublicConfig(...)` callers are unchanged (home `CFG_HOME_CONTENT`, staging, privacy policy). Those still use the per-key route.
* `useAuthConfigs` still fetches bulk public configs on its own; wiring it through `getPublicConfigs` would collapse a duplicate bulk call (follow-up).
* `clearCache()` is unused today. If we later call it after admin save, an in-flight request can write pre-clear data back into the cache; fix then with a generation token or skip-write-after-clear.
* Cache entries expire lazily and are not pruned. Current callers are site-scope only, so this is one Map entry in practice.
* Backend `GET /site-config/public/:key` still does not filter `secret: false` (pre-existing). Out of scope; worth a separate backend PR on both per-key public routes.
