### PR TITLE
chore(license): add MIT SPDX headers to .agents test files

### DIFF
--- a/.agents/tests/helpers.ts
+++ b/.agents/tests/helpers.ts
@@ -1,3 +1,11 @@
+// Copyright (c) 2026 Eclipse Foundation.
+//
+// This program and the accompanying materials are made available under the
+// terms of the MIT License which is available at
+// https://opensource.org/licenses/MIT.
+//
+// SPDX-License-Identifier: MIT
+
 import { copyFile, mkdir, readFile, rm } from 'fs/promises';
 import { join } from 'path';
 import { tmpdir } from 'os';

--- a/.agents/tests/model-editable-visibility.spec.ts
+++ b/.agents/tests/model-editable-visibility.spec.ts
@@ -1,3 +1,11 @@
+// Copyright (c) 2026 Eclipse Foundation.
+//
+// This program and the accompanying materials are made available under the
+// terms of the MIT License which is available at
+// https://opensource.org/licenses/MIT.
+//
+// SPDX-License-Identifier: MIT
+
 import { test, expect, Page } from '@playwright/test';
 import {
   loginAsAdmin,


### PR DESCRIPTION
## What

Adds the canonical Eclipse/MIT `SPDX-License-Identifier: MIT` header block to the two `.agents` test files that were merged in #621 without it:

- `.agents/tests/helpers.ts`
- `.agents/tests/model-editable-visibility.spec.ts`

## Why

The `license-headers-check` workflow only inspects *changed* files, so #621 itself never triggered it (its path filter covers `backend/`/`frontend/` only). But both files landed on `main` headerless, and every PR whose base commit predates that merge now carries them in its three-dot diff — the check has failed spuriously on #624 and is currently failing on #645. This two-file hotfix clears the check repo-wide.

No code changes — header comments only, prepended above existing imports. `.agents` sibling specs historically carried no headers; this brings the two newest files in line with the repo convention (every new `.js/.ts/.tsx` file starts with the MIT block) and unblocks CI.

## How verified

- `bash scripts/check-license-headers.sh main` → `license-headers OK: 2 changed source file(s) all carry the MIT SPDX header` (this is the same script CI runs)
- No runtime surface touched — Playwright specs are loaded by transpile-only, comment-only change

Ref #621; unblocks the red `check` on #645.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
