### PR TITLE
chore(instance-setup): move template off EOL mongo 4.4 to 7.0

### DIFF
--- a/instance-setup/docker-compose.prod.yml
+++ b/instance-setup/docker-compose.prod.yml
@@ -51,16 +51,28 @@ services:
   autowrx-db:
     # platform: linux/amd64  # Commented out for local testing on non-AMD64 machines
     container_name: ${NAME:-prod}-autowrx-db
-    image: mongo:4.4.6-bionic
+    # 4.4 is end-of-life (Feb 2024, no security patches). 7.0 is a drop-in for
+    # this stack (Mongoose 8 / Node driver 6). Upgrading an EXISTING 4.4 volume
+    # in place is not supported — dump from 4.4, wipe the volume, restore into 7.0
+    # (restoring rebuilds all indexes and needs no stepwise FCV upgrades).
+    image: mongo:7.0
     # ports:
     #   - "${MONGODB_PORT:-27010}:27017"
     volumes:
       - autowrx-dbdata:/data/db
+      # MongoDB 7 images do not bundle database tools (mongodump/mongorestore).
+      # If your backup tooling execs mongodump inside the container, download the
+      # tools once and mount them, e.g.:
+      #   curl -fsSL -o /tmp/tools.tgz https://fastdl.mongodb.org/tools/db/mongodb-database-tools-ubuntu2204-x86_64-100.9.5.tgz
+      #   mkdir -p tools && tar -xzf /tmp/tools.tgz -C tools
+      #   (then uncomment the next line)
+      # - ./tools/mongodb-database-tools-ubuntu2204-x86_64-100.9.5/bin:/opt/dbtools:ro
     networks:
       - autowrx-network
     restart: always
     healthcheck:
-      test: ["CMD", "mongo", "--eval", "db.adminCommand('ping')", "--quiet"]
+      # mongosh only — the legacy `mongo` shell was removed from images in 6.0+
+      test: ["CMD", "mongosh", "--quiet", "--eval", "db.adminCommand('ping')"]
       interval: 5s
       timeout: 5s
       retries: 10


### PR DESCRIPTION
## What

- `instance-setup/docker-compose.prod.yml`: `mongo:4.4.6-bionic` → `mongo:7.0`
- Healthcheck switched from the legacy `mongo` shell to `mongosh`
- Commented tools bind-mount + instructions for `mongodump`/`mongorestore` (not bundled in 6.0+ images)
- In-file note: existing 4.4 volumes migrate via dump → wipe → restore (restoring rebuilds indexes; no stepwise FCV upgrades needed)

## Why

MongoDB 4.4 has been end-of-life since February 2024 — new deployments should not inherit an unpatched engine. Two operational differences with 7.0 are handled inline so the template works out of the box:

1. The legacy `mongo` shell doesn't exist in 6.0+ images — left unchanged, the healthcheck fails, the container reports unhealthy, and the app's `depends_on: service_healthy` gate blocks startup entirely
2. Database tools are no longer in the image — deployments that exec `mongodump` in-container need the documented one-time tools mount

Compatibility: the backend runs Mongoose 8 (Node driver 6), which supports 7.0 — no application changes required.

## How verified

- Template validated on a live staging instance on 2026-08-25: fresh 7.0.30 volume created via dump → restore (95k+ documents, 0 failures, indexes rebuilt), `mongosh` healthcheck green, in-container backup tooling working through the exact tools mount documented here
- YAML validated (`docker compose config`)
- No application code touched; no test surface affected

No docs-capability changes (deployment template only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
