### PR TITLE
feat(e2e): fail-closed environment guard — abort runs on non-test instances

### DIFF
--- a/.agents/TESTING.md
+++ b/.agents/TESTING.md
@@ -80,6 +80,14 @@ npx playwright test tests/model-editable-visibility.spec.ts
 | `tests/model-editable-visibility.spec.ts` | Editable model visibility: non-owner prototype create, guest home shows editable+public, template inheritance |
 | `tests/layout.spec.ts` | Layout, responsive, visual snapshots |
 
+## Environment guard (fail-closed)
+
+Every run checks the target environment **before any test executes** (`e2e-env-guard.ts` global setup): it fetches the public site-config key `E2E_TEST_ENABLED` from `API_URL` and **aborts the whole run unless the value is exactly `true`**. Instances that have not opted in — production, shared staging, fresh deployments — are un-testable by default.
+
+- **Disposable test stacks**: after seeding the admin, set the key once — `PATCH /v2/site-config/key/E2E_TEST_ENABLED {"value": true}` — and the guard passes
+- **Production-grade instances**: never set the key. To run suites in a maintenance window, set `E2E_ALLOW_ANY_ENV=1` for that run only — the suites mutate site-config (homepage/nav) and create `E2E_*` data, and their restore hooks do not run if the run is killed mid-flight
+- **Non-mutating subset** (auth, image-fallback, read-only flows) is the only category ever defensible outside a window
+
 ## Environment
 
 Copy `.env.example` to `.env` and fill in your values:

--- a/.agents/e2e-env-guard.ts
+++ b/.agents/e2e-env-guard.ts
@@ -1,0 +1,56 @@
+/**
+ * Fail-closed environment guard for E2E runs.
+ *
+ * The suites mutate state (site-config, E2E_* entities) and must only run
+ * against disposable test environments. Production and shared instances
+ * live at the same kinds of URLs as test stacks (often plain localhost),
+ * so the hostname cannot distinguish them — the TARGET INSTANCE declares
+ * itself a test target instead, via the public site-config key
+ * `E2E_TEST_ENABLED` (exactly `true`).
+ *
+ * - Key absent / not `true`  → the whole run aborts before any test.
+ * - `E2E_ALLOW_ANY_ENV=1`   → deliberate override (maintenance window on a
+ *                             production-grade instance, or an environment
+ *                             where the public config route is unreachable).
+ *
+ * Set the key on disposable stacks after seeding the admin, e.g.:
+ *   PATCH /v2/site-config/key/E2E_TEST_ENABLED  { "value": true }
+ */
+export default async function globalSetup() {
+  if (process.env.E2E_ALLOW_ANY_ENV === '1') {
+    console.warn(
+      '[e2e-env-guard] E2E_ALLOW_ANY_ENV=1 set — skipping environment check. ' +
+        'Ensure this is intentional (maintenance window) and the target is not a shared instance.',
+    );
+    return;
+  }
+
+  const baseUrl = process.env.BASE_URL || '';
+  const apiUrl = process.env.API_URL || baseUrl.replace(':3210', ':3200') || '';
+  if (!apiUrl) {
+    throw new Error(
+      '[e2e-env-guard] No API_URL/BASE_URL configured — cannot verify the target environment. ' +
+        'Set .env, or set E2E_ALLOW_ANY_ENV=1 to override deliberately.',
+    );
+  }
+
+  const url = `${apiUrl.replace(/\/$/, '')}/v2/site-config/public/E2E_TEST_ENABLED?scope=site`;
+  let payload = null;
+  try {
+    const res = await fetch(url);
+    if (res.ok) payload = await res.json();
+  } catch {
+    // unreachable endpoint — treat as not-a-test-env (fail closed)
+  }
+
+  if (!payload || payload.value !== true) {
+    throw new Error(
+      '[e2e-env-guard] ABORTED: target environment does not allow E2E tests ' +
+        `(E2E_TEST_ENABLED is not true at ${apiUrl}).\n` +
+        '  - Disposable test stack: set the site-config key E2E_TEST_ENABLED=true after seeding.\n' +
+        '  - Production-grade instance: use a maintenance window and set E2E_ALLOW_ANY_ENV=1 ' +
+        'for that run only, understanding the suites mutate site-config and create data.',
+    );
+  }
+  console.log(`[e2e-env-guard] ${apiUrl} declares E2E_TEST_ENABLED=true — proceeding.`);
+}

--- a/.agents/package-lock.json
+++ b/.agents/package-lock.json
@@ -9,7 +9,8 @@
       "version": "1.0.0",
       "devDependencies": {
         "@playwright/test": "^1.40.0",
-        "@types/node": "^20.0.0"
+        "@types/node": "^20.0.0",
+        "dotenv": "^17.3.1"
       }
     },
     "node_modules/@playwright/test": {
@@ -36,6 +37,19 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "17.4.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
+      "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/fsevents": {

--- a/.agents/playwright.config.ts
+++ b/.agents/playwright.config.ts
@@ -5,6 +5,7 @@ dotenvConfig({ path: resolve(__dirname, '.env') });
 
 export default defineConfig({
   testDir: './tests',
+  globalSetup: resolve(__dirname, 'e2e-env-guard.ts'),
   timeout: 60000,
   expect: { timeout: 8000 },
   fullyParallel: false,

--- a/agentic/skills/run-tests.md
+++ b/agentic/skills/run-tests.md
@@ -56,6 +56,7 @@ cd frontend && npm run lint
 - Distinguish: assertion failure (your code) vs infrastructure (DB down, port in use, missing `.env`) vs flake (re-run once to confirm).
 
 ## Guardrails
+- **Environment guard is fail-closed**: the suites abort unless the target sets site-config `E2E_TEST_ENABLED=true`. Never set that key on production or shared instances. For a maintenance-window run on production, `E2E_ALLOW_ANY_ENV=1` is the explicit override — confirm the window first. Treat any target you didn't bootstrap yourself as production until proven otherwise (hostname is NOT a signal: production often runs on localhost too).
 - Don't mark done if tests fail. If you can't run a suite (no DB, no browser, no env), say so explicitly and report what you did run.
 - Don't disable lint/test rules silently to make green — fix the code or surface the conflict.
 - Don't run destructive commands (`rm -rf`, `down.sh` on prod) to "fix" a test env.


### PR DESCRIPTION
## What

- **Fail-closed E2E environment guard**: a `globalSetup` (`e2e-env-guard.ts`) runs before any test, fetches the public site-config key `E2E_TEST_ENABLED` from the target `API_URL`, and **aborts the entire run unless the value is exactly `true`**
- `E2E_ALLOW_ANY_ENV=1` env var as the deliberate override (maintenance-window runs on production-grade instances)
- `TESTING.md`: guard semantics, opt-in procedure for disposable stacks, production-window procedure, non-mutating subset
- `agentic/skills/run-tests.md`: agent-facing rule ("treat any target you didn't bootstrap as production until proven otherwise — hostname is NOT a signal")
- `package-lock.json` synced with the already-declared-and-imported `dotenv` (bonus fix: `npm ci` was failing on the drift)

## Why

The suites mutate state — site-config (homepage/nav) and `E2E_*` entities — and their restore hooks do not run if a run is killed mid-flight. An E2E run against a production-grade instance rewrote its homepage (incident on 2026-08-26, #653). Hostnames can't distinguish targets: production often runs on `localhost`, identical to disposable stacks. The only reliable signal is the **instance itself declaring it is a test target**, which is what the site-config key provides. Fail-closed means every instance not explicitly opted in — production, shared staging, fresh deployments — is un-testable by default.

## How verified

- **Live-tested against a production-grade instance**: run with no key set → aborts before any test with the remediation message, exit 1, zero mutations
- **Override path**: `E2E_ALLOW_ANY_ENV=1` → warns and proceeds
- Public per-key endpoint behavior confirmed for both absent (`value: null`) and present keys
- Lockfile diff verified as the dotenv sync only

## Scope notes

No backend changes — uses the existing public site-config read route. Disposable stacks opt in with one `PATCH /v2/site-config/key/E2E_TEST_ENABLED {"value": true}` after seeding. Client-side guards are bypassable by editing the harness; a server-side config-write lock is a possible future hardening, out of scope here.

Refs #653 (E2E follow-ups: this closes the lockfile-sync item and implements the prevention the incident called for).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
