### PR TITLE
fix (ux): prototype tab code typing behavior

### DIFF
--- a/frontend/src/components/organisms/PrototypeTabCode.tsx
+++ b/frontend/src/components/organisms/PrototypeTabCode.tsx
@@ -106,7 +106,6 @@ const PrototypeTabCode: FC = () => {
     ],
     shallow,
   )
-  const [savedCode, setSavedCode] = useState<string | undefined>(undefined)
   const [code, setCode] = useState<string | undefined>(undefined)
   const [ticker, setTicker] = useState(0)
   const [activeTab, setActiveTab] = useState('api')
@@ -177,9 +176,7 @@ const PrototypeTabCode: FC = () => {
 
   useEffect(() => {
     if (!prototype) {
-      setSavedCode(undefined)
       savedCodeRef.current = undefined
-      codeRef.current = undefined
       setCode(undefined)
       setEditorType('code')
       setPreviousCode(undefined)
@@ -200,8 +197,6 @@ const PrototypeTabCode: FC = () => {
         setShowDiff(getDiffVisibleFromSession(prototype.id))
       }
       setCode(prototypeCode)
-      codeRef.current = prototypeCode
-      setSavedCode(prototypeCode)
       savedCodeRef.current = prototypeCode
     } else if (isExternal) {
       // External (plugin/AI) update — capture previous code for diff
@@ -210,13 +205,9 @@ const PrototypeTabCode: FC = () => {
       setPreviousCode(savedCodeRef.current)
       setShowDiff(true)
       setCode(prototypeCode)
-      codeRef.current = prototypeCode
-      setSavedCode(prototypeCode)
       savedCodeRef.current = prototypeCode
-    } else {
-      // Own save echoed via setActivePrototype — do not clobber in-progress edits
-      setSavedCode(prototypeCode)
     }
+    // Own save echoed via setActivePrototype — do not clobber in-progress edits
 
     const newEditorType = getEditorType(
       isInitial || isExternal ? prototypeCode : (localCode ?? prototypeCode),
@@ -230,24 +221,28 @@ const PrototypeTabCode: FC = () => {
       // Explicit save from editor (Save All or Ctrl+S) — always persist, do not skip
       dataToSave = codeToSave
     } else {
-      // Periodic auto-save — skip if unchanged
+      // Periodic / blur auto-save — skip if unchanged (use ref to avoid stale skip)
       const latest = codeRef.current
-      if (latest === undefined || latest === savedCode) return
+      if (latest === undefined || latest === savedCodeRef.current) return
       dataToSave = latest
     }
 
-    if (!prototype?.id) return
+    const prototypeId = prototype?.id
+    if (!prototypeId) return
 
     try {
-      await updatePrototypeService(prototype.id, {
+      await updatePrototypeService(prototypeId, {
         code: dataToSave || '',
       })
       // Mark as saved without setCode — preserves cursor and any edits typed during await
-      setSavedCode(dataToSave)
       savedCodeRef.current = dataToSave
-      const newPrototype = JSON.parse(JSON.stringify(prototype))
-      newPrototype.code = dataToSave || ''
-      setActivePrototype(newPrototype)
+      // Merge only `code` into the *current* store prototype. Cloning the render-closure
+      // prototype would revert fields (widget_config, extend, …) updated elsewhere
+      // while the editor was mounted (e.g. dashboard template apply → blur-save).
+      const current = useModelStore.getState().prototype
+      if (current?.id === prototypeId) {
+        setActivePrototype({ ...current, code: dataToSave || '' })
+      }
     } catch (err) {
       console.error('Error saving code:', err)
     }
@@ -426,7 +421,7 @@ const PrototypeTabCode: FC = () => {
               prototypeName={prototype.name}
               onChange={(data: string) => {
                 setCode(data)
-                // Do not set savedCode here — only when we actually persist (saveCodeToDb)
+                // Do not advance savedCodeRef here — only when we actually persist (saveCodeToDb)
                 // so that Save All / Ctrl+S still trigger the API when there are unsaved changes
               }}
               onSave={async (data: string) => {

--- a/frontend/src/components/organisms/PrototypeTabCode.tsx
+++ b/frontend/src/components/organisms/PrototypeTabCode.tsx
@@ -361,11 +361,12 @@ const PrototypeTabCode: FC = () => {
                           setShowDiff(true)
                         }
                         setCode(newCode)
-                        // Immediately advance savedCodeRef so that the next generation
-                        // (whether via this dialog or via plugin) correctly diffs against
-                        // this result rather than the stale pre-AI code.
-                        savedCodeRef.current = newCode
                         setIsOpenGenAI(false)
+                        // Persist immediately. Do not advance savedCodeRef here — that would
+                        // mark the editor "clean" and skip auto/blur save, leaving AI code
+                        // unsaved and vulnerable to being clobbered by a store refetch.
+                        // saveCodeToDb advances savedCodeRef only after the API succeeds.
+                        void saveCodeToDb(newCode)
                       }}
                     />
                   </Suspense>

--- a/frontend/src/components/organisms/PrototypeTabCode.tsx
+++ b/frontend/src/components/organisms/PrototypeTabCode.tsx
@@ -127,6 +127,8 @@ const PrototypeTabCode: FC = () => {
   const [showDiff, setShowDiff] = useState(false)
   // Ref to track last code saved by us — used to detect external (plugin/AI) code changes
   const savedCodeRef = useRef<string | undefined>(undefined)
+  // Latest editor code (avoids stale closures during async save)
+  const codeRef = useRef<string | undefined>(undefined)
 
   // Resize state
   const [rightPanelWidth, setRightPanelWidth] = useState<number | null>(null) // Will be calculated based on container
@@ -170,9 +172,14 @@ const PrototypeTabCode: FC = () => {
   }, [ticker])
 
   useEffect(() => {
+    codeRef.current = code
+  }, [code])
+
+  useEffect(() => {
     if (!prototype) {
       setSavedCode(undefined)
       savedCodeRef.current = undefined
+      codeRef.current = undefined
       setCode(undefined)
       setEditorType('code')
       setPreviousCode(undefined)
@@ -181,27 +188,39 @@ const PrototypeTabCode: FC = () => {
     }
 
     const prototypeCode = prototype.code || ''
+    const isInitial = savedCodeRef.current === undefined
+    const isExternal = !isInitial && prototypeCode !== savedCodeRef.current
+    const localCode = codeRef.current
 
-    if (savedCodeRef.current === undefined) {
+    if (isInitial) {
       // Initial mount — restore diff state from sessionStorage if available
       const restoredPrev = getPreviousCodeFromSession(prototype.id)
       if (restoredPrev !== undefined) {
         setPreviousCode(restoredPrev)
         setShowDiff(getDiffVisibleFromSession(prototype.id))
       }
-    } else if (prototypeCode !== savedCodeRef.current) {
+      setCode(prototypeCode)
+      codeRef.current = prototypeCode
+      setSavedCode(prototypeCode)
+      savedCodeRef.current = prototypeCode
+    } else if (isExternal) {
       // External (plugin/AI) update — capture previous code for diff
-      savePreviousCodeToSession(prototype.id, savedCodeRef.current)
+      savePreviousCodeToSession(prototype.id, savedCodeRef.current!)
       saveDiffVisibleToSession(prototype.id, true)
       setPreviousCode(savedCodeRef.current)
       setShowDiff(true)
+      setCode(prototypeCode)
+      codeRef.current = prototypeCode
+      setSavedCode(prototypeCode)
+      savedCodeRef.current = prototypeCode
+    } else {
+      // Own save echoed via setActivePrototype — do not clobber in-progress edits
+      setSavedCode(prototypeCode)
     }
 
-    setCode(prototypeCode)
-    setSavedCode(prototypeCode)
-    savedCodeRef.current = prototypeCode
-
-    const newEditorType = getEditorType(prototypeCode)
+    const newEditorType = getEditorType(
+      isInitial || isExternal ? prototypeCode : (localCode ?? prototypeCode),
+    )
     setEditorType(newEditorType)
   }, [prototype])
 
@@ -212,8 +231,9 @@ const PrototypeTabCode: FC = () => {
       dataToSave = codeToSave
     } else {
       // Periodic auto-save — skip if unchanged
-      if (code === undefined || code === savedCode) return
-      dataToSave = code
+      const latest = codeRef.current
+      if (latest === undefined || latest === savedCode) return
+      dataToSave = latest
     }
 
     if (!prototype?.id) return
@@ -222,8 +242,7 @@ const PrototypeTabCode: FC = () => {
       await updatePrototypeService(prototype.id, {
         code: dataToSave || '',
       })
-      // Only mark as saved after API succeeds
-      setCode(dataToSave)
+      // Mark as saved without setCode — preserves cursor and any edits typed during await
       setSavedCode(dataToSave)
       savedCodeRef.current = dataToSave
       const newPrototype = JSON.parse(JSON.stringify(prototype))


### PR DESCRIPTION
# Summary

Preserve the Monaco editor cursor position when prototype code auto-saves. Previously, saving raced with in-progress typing and forced the editor value to an older snapshot, which jumped the caret to the end of the file.

# Motivation

## What problem does it solve?

While editing code in the Prototype Code tab, the cursor jumped to the end of the file whenever an auto-save completed. That made continuous editing frustrating and error-prone (new keystrokes landed at the wrong place).

## What was difficult or missing before?

`saveCodeToDb` always called `setCode` after a successful API write, and the `[prototype]` effect always synced `prototype.code` back into editor state—including when that update was just our own save echoed through `setActivePrototype`. If the user typed during the async save, Monaco received a stale controlled `value`, ran `executeEdits` with `forceMoveMarkers`, and moved the cursor to the end.

## Why is this approach useful?

It keeps local editor state authoritative during save:

- After a successful save, only `savedCode` / refs / the store are updated—not the live `code` state.
- The prototype effect applies `setCode` only on initial load or true external (plugin/AI) updates.
- A `codeRef` avoids stale closures so auto-save persists the latest editor content.

Cursor position and mid-save edits are preserved without changing the save cadence or UX.

# Changes

- Updated `PrototypeTabCode.tsx` so successful saves no longer call `setCode`, avoiding overwrite of newer in-editor content.
- Updated the `[prototype]` effect to distinguish initial load, external updates, and own-save echoes; own-save echoes no longer clobber editor state.
- Added `codeRef` to track the latest editor value for auto-save and race-safe comparisons.
- Refactored save/sync flow so dirty detection still works when the user types during an in-flight save (next tick persists the newer content).

# Behavior

## Before:

- Edit in the middle of the file and keep typing.
- Auto-save (~3s) or blur-triggered save completes.
- Cursor jumps to the end of the file; characters typed during the race can appear at the wrong location.

## After:

- Edit in the middle of the file and keep typing through auto-save.
- Save completes in the background.
- Cursor stays where the user is typing; any characters entered during the save remain in place.
- Unsaved edits typed during the save are still detected as dirty and persisted on the next save cycle.

# Testing

- [ ] Unit tests
- [ ] Integration tests
- [x] Manual testing
- [ ] Existing test suite passes

## Tested with:

- Manual editing in the Prototype Code tab while auto-save ran.
- Continuous typing across multiple auto-save intervals to reproduce the prior race.
- Confirmed cursor no longer jumps to end of file after save.

# Breaking Changes

None.

# Additional Notes

- External code updates (plugin/AI) still flow through the prototype effect and replace editor content intentionally; that path is unchanged in purpose.
- Store `prototype.code` may briefly lag local editor content if the user types during an in-flight save; the next auto-save reconciles this.
- `CodeEditor.tsx` was left as a controlled Monaco editor; the fix is entirely in the save/sync ownership logic in `PrototypeTabCode.tsx`.
- Possible follow-up: apply the same “don’t clobber local state on own save” pattern to `ProjectEditor` if it shows a similar cursor/content reset.
