### PR TITLE
feat(frontend): render plugin tabs in the Vehicle API page Tab Bar 

### DIFF
--- a/frontend/src/components/molecules/ModelApiTabs.tsx
+++ b/frontend/src/components/molecules/ModelApiTabs.tsx
@@ -9,10 +9,11 @@
 import { FC, useMemo } from 'react'
 import DaTabItem from '@/components/atoms/DaTabItem'
 import { useParams } from 'react-router-dom'
-import { TbApi, TbPlus } from 'react-icons/tb'
+import { TbApi, TbFileImport, TbPlus } from 'react-icons/tb'
 import { Button } from '@/components/atoms/button'
 import { useQuery } from '@tanstack/react-query'
 import { getCustomApiSetById } from '@/services/customApiSet.service'
+import { ConfiguredPlugin } from '@/hooks/useConfiguredPlugins'
 
 interface ModelApiTabsProps {
   customApiSetIds?: string[]
@@ -20,6 +21,7 @@ interface ModelApiTabsProps {
   isModelOwner?: boolean
   covesaApiCount?: number // Count of COVESA APIs
   enableCustomApiSets?: boolean
+  plugins?: ConfiguredPlugin[]
 }
 
 const ModelApiTabs: FC<ModelApiTabsProps> = ({
@@ -28,8 +30,13 @@ const ModelApiTabs: FC<ModelApiTabsProps> = ({
   isModelOwner = false,
   covesaApiCount = 0,
   enableCustomApiSets = true,
+  plugins = [],
 }) => {
-  const { model_id, instance_id } = useParams<{ model_id: string; instance_id?: string }>()
+  const { model_id, instance_id, plugin_slug } = useParams<{
+    model_id: string
+    instance_id?: string
+    plugin_slug?: string
+  }>()
 
   // Normalize IDs to strings (handle MongoDB ObjectIds that might be objects)
   // Use useMemo to ensure stable reference and prevent unnecessary re-renders
@@ -61,7 +68,8 @@ const ModelApiTabs: FC<ModelApiTabsProps> = ({
   const sets = enableCustomApiSets ? setQueries.data || [] : []
 
   // Determine active tab
-  const isCovesaActive = !instance_id || instance_id === 'covesa'
+  const isCovesaActive =
+    !plugin_slug && (!instance_id || instance_id === 'covesa')
 
   return (
     <>
@@ -108,6 +116,18 @@ const ModelApiTabs: FC<ModelApiTabsProps> = ({
           </DaTabItem>
         )
       })}
+
+      {/* Plugin tabs */}
+      {plugins.map((p) => (
+        <DaTabItem
+          key={`plugin-${p.plugin}`}
+          active={plugin_slug === p.plugin}
+          to={`/model/${model_id}/api/plugin/${p.plugin}`}
+        >
+          <TbFileImport className="w-5 h-5 mr-2" />
+          {p.label}
+        </DaTabItem>
+      ))}
 
       {/* Plus button to add new instance */}
       {enableCustomApiSets && isModelOwner && onAddInstance && (

--- a/frontend/src/components/organisms/PluginPageRender.tsx
+++ b/frontend/src/components/organisms/PluginPageRender.tsx
@@ -1057,16 +1057,13 @@ const PluginPageRender: React.FC<PluginPageRenderProps> = ({ plugin_id, data, on
     return () => {
       cancelled = true
       log('Cleanup - unmounting plugin (keeping registration in map for cache)')
-      try {
-        const el = containerRef.current
-        // Unmount using the plugin-specific registration if available
-        const registration = pluginRegistrations.get(plugin_id)
-        if (registration?.unmount) {
-          registration.unmount(el)
-        } else {
-          ; (window as any)?.DAPlugins?.[GLOBAL_KEY]?.unmount?.(el)
-        }
-      } catch { }
+      // Note: for mount()/unmount()-style plugins, the `Wrapper` component (see
+      // above) owns calling unmount() on the exact node it mounted into, as part
+      // of its own useEffect cleanup. Calling registration.unmount() again here
+      // against containerRef.current (a different, outer, React-managed node)
+      // raced with React's own unmount of that subtree and could remove DOM
+      // nodes out from under React, causing an intermittent
+      // "Failed to execute 'removeChild'" error when switching tabs.
       if (injectedScriptRef.current?.parentNode) {
         injectedScriptRef.current.remove()
       }

--- a/frontend/src/components/organisms/ViewApiCovesa.tsx
+++ b/frontend/src/components/organisms/ViewApiCovesa.tsx
@@ -36,13 +36,7 @@ import usePermissionHook from '@/hooks/usePermissionHook'
 import { PERMISSIONS } from '@/data/permission'
 import { Spinner } from '@/components/atoms/spinner'
 import PluginPageRender from '@/components/organisms/PluginPageRender'
-import { getPluginBySlug } from '@/services/plugin.service'
-import { useSiteConfig } from '@/utils/siteConfig'
-
-interface VssPluginConfig {
-  label: string
-  plugin: string
-}
+import { useConfiguredPlugins } from '@/hooks/useConfiguredPlugins'
 
 const ViewApiCovesa = () => {
   const { model_id, api: apiParam } = useParams<{ model_id: string; api?: string }>()
@@ -67,46 +61,7 @@ const ViewApiCovesa = () => {
   const [url, setUrl] = useState('')
   const [showUpload, setShowUpload] = useState(false)
 
-  const vssPluginsConfig = useSiteConfig('VSS_PLUGINS')
-  const [availablePlugins, setAvailablePlugins] = useState<VssPluginConfig[]>([])
-
-  useEffect(() => {
-    let cancelled = false
-    const configs: VssPluginConfig[] = Array.isArray(vssPluginsConfig)
-      ? vssPluginsConfig
-      : []
-
-    const valid = configs.filter(
-      (entry) =>
-        entry &&
-        typeof entry.label === 'string' &&
-        typeof entry.plugin === 'string' &&
-        entry.label.trim() &&
-        entry.plugin.trim(),
-    )
-
-    if (valid.length === 0) {
-      setAvailablePlugins([])
-      return
-    }
-
-    const uniqueSlugs = [...new Set(valid.map((p) => p.plugin))]
-    Promise.allSettled(
-      uniqueSlugs.map((slug) => getPluginBySlug(slug).then(() => slug)),
-    ).then((results) => {
-      if (cancelled) return
-      const installedSlugs = new Set(
-        results
-          .filter((r): r is PromiseFulfilledResult<string> => r.status === 'fulfilled')
-          .map((r) => r.value),
-      )
-      setAvailablePlugins(valid.filter((p) => installedSlugs.has(p.plugin)))
-    })
-
-    return () => {
-      cancelled = true
-    }
-  }, [JSON.stringify(vssPluginsConfig)])
+  const availablePlugins = useConfiguredPlugins('VSS_PLUGINS')
 
   useEffect(() => {
     // Set selected API from route param or default to first API

--- a/frontend/src/configs/routes.tsx
+++ b/frontend/src/configs/routes.tsx
@@ -412,6 +412,14 @@ const routesConfig: RouteConfig[] = [
                 ),
               },
               {
+                path: 'api/plugin/:plugin_slug',
+                element: (
+                  <SuspenseProvider>
+                    <PageVehicleApi />
+                  </SuspenseProvider>
+                ),
+              },
+              {
                 path: 'plugin',
                 element: (
                   <SuspenseProvider>

--- a/frontend/src/hooks/useConfiguredPlugins.ts
+++ b/frontend/src/hooks/useConfiguredPlugins.ts
@@ -1,0 +1,68 @@
+// Copyright (c) 2025 Eclipse Foundation.
+//
+// This program and the accompanying materials are made available under the
+// terms of the MIT License which is available at
+// https://opensource.org/licenses/MIT.
+//
+// SPDX-License-Identifier: MIT
+
+import { useEffect, useState } from 'react'
+import { useSiteConfig } from '@/utils/siteConfig'
+import { getPluginBySlug } from '@/services/plugin.service'
+
+export interface ConfiguredPlugin {
+  label: string
+  plugin: string
+}
+
+// Reads a site config array of { label, plugin } entries and resolves it to
+// only the plugins that are actually installed.
+export function useConfiguredPlugins(configKey: string): ConfiguredPlugin[] {
+  const pluginsConfig = useSiteConfig(configKey)
+  const [availablePlugins, setAvailablePlugins] = useState<ConfiguredPlugin[]>(
+    [],
+  )
+
+  useEffect(() => {
+    let cancelled = false
+    const configs: ConfiguredPlugin[] = Array.isArray(pluginsConfig)
+      ? pluginsConfig
+      : []
+
+    const valid = configs.filter(
+      (entry) =>
+        entry &&
+        typeof entry.label === 'string' &&
+        typeof entry.plugin === 'string' &&
+        entry.label.trim() &&
+        entry.plugin.trim(),
+    )
+
+    if (valid.length === 0) {
+      setAvailablePlugins([])
+      return
+    }
+
+    const uniqueSlugs = [...new Set(valid.map((p) => p.plugin))]
+    Promise.allSettled(
+      uniqueSlugs.map((slug) => getPluginBySlug(slug).then(() => slug)),
+    ).then((results) => {
+      if (cancelled) return
+      const installedSlugs = new Set(
+        results
+          .filter(
+            (r): r is PromiseFulfilledResult<string> =>
+              r.status === 'fulfilled',
+          )
+          .map((r) => r.value),
+      )
+      setAvailablePlugins(valid.filter((p) => installedSlugs.has(p.plugin)))
+    })
+
+    return () => {
+      cancelled = true
+    }
+  }, [JSON.stringify(pluginsConfig)])
+
+  return availablePlugins
+}

--- a/frontend/src/pages/PageVehicleApi.tsx
+++ b/frontend/src/pages/PageVehicleApi.tsx
@@ -15,9 +15,11 @@ import ViewApiCovesa from '@/components/organisms/ViewApiCovesa'
 import ViewCustomApiSet from '@/components/organisms/ViewCustomApiSet'
 import ModelApiTabs from '@/components/molecules/ModelApiTabs'
 import CustomApiSetPicker from '@/components/organisms/CustomApiSetPicker'
+import PluginPageRender from '@/components/organisms/PluginPageRender'
 import { updateModelService } from '@/services/model.service'
 import useCurrentModel from '@/hooks/useCurrentModel'
 import usePermissionHook from '@/hooks/usePermissionHook'
+import { useConfiguredPlugins } from '@/hooks/useConfiguredPlugins'
 import { PERMISSIONS } from '@/data/permission'
 import { useQueryClient } from '@tanstack/react-query'
 import { useToast } from '@/components/molecules/toaster/use-toast'
@@ -639,12 +641,21 @@ const DEFAULT_USP_TREE = {
 }
 
 const PageVehicleApi = () => {
-  const { model_id, instance_id, api } = useParams<{ model_id: string; instance_id?: string; api?: string }>()
+  const { model_id, instance_id, api, plugin_slug } = useParams<{
+    model_id: string
+    instance_id?: string
+    api?: string
+    plugin_slug?: string
+  }>()
   const navigate = useNavigate()
   const queryClient = useQueryClient()
   const { toast } = useToast()
   const [isPickerOpen, setIsPickerOpen] = useState(false)
   const customApiSetsEnabled = !useSiteConfig('DISABLE_CUSTOM_API_SETS', false)
+  const modelApiPlugins = useConfiguredPlugins('MODEL_API_PLUGINS')
+  const activePlugin = plugin_slug
+    ? modelApiPlugins.find((p) => p.plugin === plugin_slug)
+    : undefined
 
   const { data: model, refetch: refetchModel } = useCurrentModel()
   const [hasWritePermission] = usePermissionHook([PERMISSIONS.WRITE_MODEL, model_id])
@@ -740,6 +751,7 @@ const PageVehicleApi = () => {
               onAddInstance={() => setIsPickerOpen(true)}
               isModelOwner={hasWritePermission}
               covesaApiCount={covesaApiCount}
+              plugins={modelApiPlugins}
             />
           </div>
           <div className="grow"></div>
@@ -748,7 +760,13 @@ const PageVehicleApi = () => {
 
       {/* Content Area */}
       <div className="flex-1 min-h-0 overflow-hidden">
-        {isCovesaTab || !customApiSetsEnabled ? (
+        {activePlugin ? (
+          <PluginPageRender
+            key={activePlugin.plugin}
+            plugin_id={activePlugin.plugin}
+            data={{ model: model || null, prototype: null }}
+          />
+        ) : isCovesaTab || !customApiSetsEnabled ? (
           <ViewApiCovesa />
         ) : instance_id ? (
           <ViewCustomApiSet key={instance_id} instanceId={instance_id} />

--- a/frontend/src/pages/SiteConfigManagement.tsx
+++ b/frontend/src/pages/SiteConfigManagement.tsx
@@ -243,6 +243,16 @@ export const PREDEFINED_SITE_CONFIGS: any[] = [
       'Plugin tabs to show on the Vehicle API (COVESA VSS) page. Each entry needs a "label" (tab display name) and "plugin" (plugin slug). Example: [{"label":"A2L Importer","plugin":"a2l-importer"}]. Only plugins that are installed will appear.',
     category: 'model_prototype',
   },
+  {
+    key: 'MODEL_API_PLUGINS',
+    scope: 'site',
+    value: [],
+    secret: false,
+    valueType: 'array',
+    description:
+      'Plugin tabs to show in the Vehicle API page Tab Bar (top-level, alongside COVESA API / custom API sets). Each entry needs a "label" (tab display name) and "plugin" (plugin slug). Example: [{"label":"My Plugin","plugin":"my-plugin"}]. Only plugins that are installed will appear.',
+    category: 'model_prototype',
+  },
 ]
 
 export const PREDEFINED_GENAI_CONFIG_KEYS: string[] = PREDEFINED_SITE_CONFIGS.filter(


### PR DESCRIPTION

## Summary

Add a new `MODEL_API_PLUGINS` site config that lets installed plugins appear as first-class, route-driven tabs in the Vehicle API page's top-level Tab Bar (`ModelApiTabs`), alongside "COVESA API" and custom API set tabs — the same mechanism `VSS_PLUGINS` already provides one level down, inside `ViewApiCovesa`'s internal tab row (opened as a modal).

## Motivation

Explain why this change is needed:

- What problem does it solve? Plugins configured via `VSS_PLUGINS` only ever open in a modal dialog nested inside the COVESA tab's own internal tabs — there was no way to expose a plugin as a peer of "COVESA API" / a custom API set in the page's main Tab Bar.
- What was difficult or missing before? The plugin-install-check + tab-rendering logic (read site config array → filter valid `{label, plugin}` entries → verify each slug is actually installed) lived inline inside `ViewApiCovesa.tsx`, with no reusable form and no route-level entry point for a plugin tab.
- Why is this approach useful? Reusing the existing route-per-tab pattern (`api`, `api/covesa/:api`, `api/:instance_id`) keeps plugin tabs consistent with how every other Tab Bar entry already behaves — a real URL, browser back/forward support, and inline content instead of a modal.

## Changes

- Added `frontend/src/hooks/useConfiguredPlugins.ts`: extracts the "read site-config array → filter valid entries → keep only installed plugin slugs" logic (previously inline in `ViewApiCovesa.tsx`) into a reusable hook parameterized by config key.
- Refactored `ViewApiCovesa.tsx` to call `useConfiguredPlugins('VSS_PLUGINS')` instead of its inline effect; its own internal plugin tabs/modal behavior is unchanged.
- Added a new `MODEL_API_PLUGINS` predefined site config (`frontend/src/pages/SiteConfigManagement.tsx`), `valueType: 'array'`, editable via the existing generic JSON-array config editor — no bespoke UI needed.
- Added route `api/plugin/:plugin_slug` (`frontend/src/configs/routes.tsx`), rendering `PageVehicleApi`, distinct from `api/:instance_id` (custom API sets) to avoid slug/id collisions.
- `ModelApiTabs.tsx`: accepts a new `plugins` prop and renders one tab per configured/installed plugin, active when `plugin_slug` matches; fixed `isCovesaActive` to also check `!plugin_slug` (previously both "COVESA API" and the active plugin tab could render `active=true` simultaneously on the plugin route, since `instance_id` is undefined there too).
- `PageVehicleApi.tsx`: fetches `MODEL_API_PLUGINS` via the new hook, passes it to `ModelApiTabs`, and renders `PluginPageRender` inline in the content area when the active route matches a configured plugin.
- `PluginPageRender.tsx`: removed a redundant, wrongly-targeted `registration.unmount(containerRef.current)` call in the main effect's cleanup. For `mount()`/`unmount()`-style plugins, the internal `Wrapper` component already calls `unmount()` on the correct node as part of its own `useEffect` cleanup; the outer cleanup was calling it a second time against a different (outer, React-owned) container, which could race with React's own unmount of that subtree and throw `Failed to execute 'removeChild' on 'Node': The node to be removed is not a child of this node` intermittently when switching tabs.

## Behavior

Describe the user/developer-facing behavior before and after the change.

Before:
- Plugins could only be surfaced via `VSS_PLUGINS`, appearing as tabs nested inside `ViewApiCovesa`'s own tab row and opening in a modal dialog.
- No way to add a plugin as a top-level, URL-addressable tab next to "COVESA API" / custom API sets.
- Switching into/out of a plugin tab could intermittently throw a `removeChild` DOM error for `mount()`/`unmount()`-style plugins.

After:
- Site admins can add entries to `MODEL_API_PLUGINS` (`{"label": "...", "plugin": "..."}`); each installed plugin shows up as a tab in the page's top Tab Bar.
- Clicking the tab navigates to `/model/:model_id/api/plugin/:plugin_slug`, the tab renders active, and the plugin loads inline in the content area (not a modal).
- Switching between "COVESA API", custom API sets, and plugin tabs works via normal routing; only one tab shows as active at a time.
- `VSS_PLUGINS` / `ViewApiCovesa`'s internal plugin modal continues to work unchanged.
- Tab switching no longer intermittently throws the `removeChild` DOM error.

## Testing

- [ ] Unit tests
- [ ] Integration tests
- [x] Manual testing
- [x] Existing test suite passes

Tested with:
- `cd frontend && npx tsc --noEmit` — clean.
- `cd frontend && npm run build` — succeeds (`vite build`, no new warnings).
- `npm run lint` could not be run in this environment (pre-existing ESLint v9 / legacy `.eslintrc.cjs` mismatch, unrelated to this change).
- Manual: added a `MODEL_API_PLUGINS` entry pointing at an installed plugin, confirmed the tab appears, navigates correctly, renders inline, and that tab-active state and repeated tab switching (including the plugin tab) no longer show the `removeChild` error or a stuck "COVESA API" highlight.

## Breaking Changes

None. `MODEL_API_PLUGINS` is a new, additive, opt-in site config (defaults to `[]`); `VSS_PLUGINS` and existing routes/tabs are unaffected.

## Additional Notes

Targets `main` directly (not stacked). The `PluginPageRender.tsx` cleanup fix is a small, targeted bug fix surfaced by this feature's route-driven tab switching, not a broader rework of the plugin script-injection mechanism.
