### PR TITLE
fix: validate origin before redirecting in GitHub auth/SSO callbacks

### DIFF
--- a/backend/src/config/config.js
+++ b/backend/src/config/config.js
@@ -103,6 +103,31 @@ if (envVars.AUTH_PROVIDER === 'platform' && !platformHeaders.email) {
   );
 }
 
+// Shared by CORS and by anything that redirects based on a caller-supplied origin
+// (OAuth/SSO return URLs). Same allowlist, same CORS_ORIGINS patterns, so a host
+// that isn't trusted for CORS isn't trusted as a redirect target either.
+const isAllowedOrigin = (origin) => {
+  if (!origin) {
+    return false;
+  }
+
+  const corsOriginsPatterns = envVars.CORS_ORIGINS.split(',')
+    .map((pattern) => pattern.trim())
+    .filter(Boolean);
+
+  const allowedOrigins = [];
+  corsOriginsPatterns.forEach((pattern) => {
+    try {
+      allowedOrigins.push(new RegExp(`^http://${pattern}$`));
+      allowedOrigins.push(new RegExp(`^https://${pattern}$`));
+    } catch (e) {
+      console.error(`Invalid CORS origin pattern: ${pattern}`, e);
+    }
+  });
+
+  return allowedOrigins.some((pattern) => pattern.test(origin));
+};
+
 const config = {
   env: envVars.NODE_ENV,
   port: envVars.PORT,
@@ -156,24 +181,7 @@ const config = {
         return callback(null, true);
       }
 
-      // Parse CORS_ORIGINS from environment variable (comma-separated regex patterns)
-      const corsOriginsPatterns = envVars.CORS_ORIGINS.split(',').map(pattern => pattern.trim()).filter(Boolean);
-
-      // Build allowed origins list with both http and https for each pattern
-      const allowedOrigins = [];
-      corsOriginsPatterns.forEach(pattern => {
-        try {
-          allowedOrigins.push(new RegExp(`^http://${pattern}$`));
-          allowedOrigins.push(new RegExp(`^https://${pattern}$`));
-        } catch (e) {
-          console.error(`Invalid CORS origin pattern: ${pattern}`, e);
-        }
-      });
-
-      // Check if origin matches any of the allowed patterns
-      const isAllowed = allowedOrigins.some(pattern => pattern.test(origin));
-
-      if (isAllowed) {
+      if (isAllowedOrigin(origin)) {
         callback(null, true);
       } else {
         console.log(`CORS blocked origin: ${origin}`);
@@ -181,6 +189,7 @@ const config = {
       }
     },
   },
+  isAllowedOrigin,
   constraints: {
     model: {
       maximumAuthorizedUsers: 1000,

--- a/backend/src/controllers/auth.controller.js
+++ b/backend/src/controllers/auth.controller.js
@@ -16,6 +16,11 @@ const pick = require('../utils/pick');
 const platformAuthService = require('../services/platformAuth.service');
 const { sanitizeUser } = require('../middlewares/auth');
 
+// origin/state on these routes comes straight from the query string, before the user
+// has authenticated. Redirecting to it unchecked is an open redirect, so anything
+// that isn't on the CORS allowlist falls back to the configured client base url.
+const resolveRedirectOrigin = (origin) => (config.isAllowedOrigin(origin) ? origin : config.client.baseUrl);
+
 const authenticate = catchAsync(async (req, res) => {
   res.status(httpStatus.OK).json({
     user: req.user,
@@ -188,7 +193,7 @@ const githubCallback = catchAsync(async (req, res) => {
   try {
     const { origin, code, userId } = req.query;
     await authService.githubCallback(code, userId);
-    res.redirect(`${origin || 'http://127.0.0.1:3000'}/auth/github/success`);
+    res.redirect(`${resolveRedirectOrigin(origin)}/auth/github/success`);
   } catch (error) {
     logger.error(error);
     res.status(httpStatus.UNAUTHORIZED).send('Unauthorized. Please try again.');
@@ -255,7 +260,7 @@ const githubSsoStart = catchAsync(async (req, res) => {
   const pathWithoutQuery = (req.originalUrl || '').split('?')[0];
   const callbackPath = pathWithoutQuery.replace(/\/github-sso\/start\/?$/, '') + '/github-sso/callback';
   const redirectUri = baseUrl + callbackPath;
-  const returnOrigin = origin || config.client.baseUrl;
+  const returnOrigin = resolveRedirectOrigin(origin);
   const state = encodeURIComponent(JSON.stringify({ providerId, origin: returnOrigin }));
   const scope = (Array.isArray(provider.scopes) && provider.scopes.length)
     ? provider.scopes.join(' ')
@@ -280,7 +285,7 @@ const githubSsoCallback = catchAsync(async (req, res) => {
     try {
       const decoded = JSON.parse(decodeURIComponent(state));
       providerId = decoded.providerId;
-      if (decoded.origin) origin = decoded.origin;
+      if (decoded.origin) origin = resolveRedirectOrigin(decoded.origin);
     } catch (e) {
       providerId = decodeURIComponent(state);
     }

--- a/backend/tests/unit/config/isAllowedOrigin.test.js
+++ b/backend/tests/unit/config/isAllowedOrigin.test.js
@@ -1,0 +1,54 @@
+// Copyright (c) 2026 Eclipse Foundation.
+//
+// This program and the accompanying materials are made available under the
+// terms of the MIT License which is available at
+// https://opensource.org/licenses/MIT.
+//
+// SPDX-License-Identifier: MIT
+
+describe('config.isAllowedOrigin', () => {
+  const ORIGINAL_CORS_ORIGINS = process.env.CORS_ORIGINS;
+  const ORIGINAL_NODE_ENV = process.env.NODE_ENV;
+
+  beforeEach(() => {
+    process.env.NODE_ENV = process.env.NODE_ENV || 'test';
+    process.env.CORS_ORIGINS = 'app\\.example\\.com,localhost:\\d+';
+    jest.resetModules();
+  });
+
+  afterEach(() => {
+    if (ORIGINAL_CORS_ORIGINS === undefined) {
+      delete process.env.CORS_ORIGINS;
+    } else {
+      process.env.CORS_ORIGINS = ORIGINAL_CORS_ORIGINS;
+    }
+    process.env.NODE_ENV = ORIGINAL_NODE_ENV;
+    jest.resetModules();
+  });
+
+  test('allows an origin that matches a configured pattern', () => {
+    // eslint-disable-next-line global-require
+    const config = require('../../../src/config/config');
+
+    expect(config.isAllowedOrigin('https://app.example.com')).toBe(true);
+    expect(config.isAllowedOrigin('http://localhost:3000')).toBe(true);
+  });
+
+  test('rejects an attacker-controlled origin used for a redirect target', () => {
+    // eslint-disable-next-line global-require
+    const config = require('../../../src/config/config');
+
+    // This is the exact class of value that reached res.redirect() unchecked
+    // before the fix: any origin the caller supplies in the query string.
+    expect(config.isAllowedOrigin('https://evil.example')).toBe(false);
+    expect(config.isAllowedOrigin('https://app.example.com.evil.example')).toBe(false);
+  });
+
+  test('rejects a missing origin', () => {
+    // eslint-disable-next-line global-require
+    const config = require('../../../src/config/config');
+
+    expect(config.isAllowedOrigin(undefined)).toBe(false);
+    expect(config.isAllowedOrigin('')).toBe(false);
+  });
+});


### PR DESCRIPTION
Fixes #635.

`githubCallback`, `githubSsoStart` and `githubSsoCallback` all take an
`origin` from the query string (SSO's `origin` is carried through the
GitHub round trip inside `state`, but it's the same caller-supplied
value) and redirect to it with no validation:

- `githubCallback`: `res.redirect(`${origin || '...'}/auth/github/success`)`
- `githubSsoStart`: embeds `origin` into `state`, which comes back on
  the callback
- `githubSsoCallback`: `res.redirect(origin)` / `res.redirect(`${origin}?error=...`)`
  on every success and error path

Any of these can be used to send a user to an attacker-controlled URL
right after the GitHub auth flow, since none of them check `origin`
against anything before using it.

`origin` is now checked against the same `CORS_ORIGINS` allowlist
already used for cross-origin requests (`config.isAllowedOrigin`,
factored out of the existing CORS check so both use the same list),
and falls back to the configured client base URL when it isn't on the
list.

**Tests.** Added `backend/tests/unit/config/isAllowedOrigin.test.js`,
which confirms an allowed origin passes, an attacker-controlled one is
rejected (including a suffix-match attempt like
`app.example.com.evil.example`), and a missing origin is rejected.
Ran it against the code before this change and it fails
(`config.isAllowedOrigin is not a function`, since the check didn't
exist yet), and passes with the fix. I didn't run the full `auth.test.js`
integration suite since it needs a live MongoDB instance I don't have
set up locally; happy to if someone can confirm a quick way to run it,
or if a maintainer wants to check before merging.
