### PR TITLE
fix(frontend): align create model/prototype dialogs and select UX

### DIFF
--- a/frontend/src/components/atoms/DaSelect.tsx
+++ b/frontend/src/components/atoms/DaSelect.tsx
@@ -47,8 +47,12 @@ const DaSelect = React.forwardRef<
       onValueChange={onValueChange}
     >
       <div data-id={dataId} className={cn('flex flex-col', wrapperClassName)}>
-        <DaText className="font-medium!">{label}</DaText>
-        {label && <div className="pb-1"></div>}
+        {label && (
+          <>
+            <DaText className="font-medium!">{label}</DaText>
+            <div className="pb-1"></div>
+          </>
+        )}
         <SelectTrigger
           ref={ref}
           {...props}
@@ -74,7 +78,7 @@ const DaSelectItem = React.forwardRef<
   <SelectPrimitive.Item
     ref={ref}
     className={clsx(
-      'focus:bg-accent relative flex w-full cursor-pointer select-none rounded bg-white py-1.5 pl-2 pr-8 text-da-gray-medium outline-none hover:bg-gray-100 data-disabled:pointer-events-none data-disabled:opacity-50',
+      'focus:bg-accent relative flex w-full min-w-0 cursor-pointer select-none rounded bg-white py-1.5 pl-2 pr-8 text-da-gray-medium outline-none hover:bg-gray-100 data-disabled:pointer-events-none data-disabled:opacity-50',
       helperText ? 'flex' : 'items-center',
       className,
     )}
@@ -86,7 +90,9 @@ const DaSelectItem = React.forwardRef<
       </SelectPrimitive.ItemIndicator>
     </span>
 
-    <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
+    <SelectPrimitive.ItemText className="block truncate">
+      {children}
+    </SelectPrimitive.ItemText>
     {helperText && (
       <DaText className={cn('da-label-small pl-4', helperClassName)}>
         {helperText}
@@ -128,7 +134,7 @@ const SelectContent = React.forwardRef<
     <SelectPrimitive.Content
       ref={ref}
       className={clsx(
-        'bg-popover relative z-1500 max-h-96 min-w-32 overflow-hidden rounded-md border shadow-sm data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1 data-[state=open]:animate-in data-[state=closed]:animate-out',
+        'bg-popover relative z-1500 max-h-96 w-[var(--radix-select-trigger-width)] overflow-hidden rounded-md border shadow-sm data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1 data-[state=open]:animate-in data-[state=closed]:animate-out',
         className,
       )}
       position="popper"
@@ -136,7 +142,7 @@ const SelectContent = React.forwardRef<
     >
       <SelectPrimitive.Viewport
         className={clsx(
-          'h-(--radix-select-trigger-height) w-full min-w-(--radix-select-trigger-width) bg-white p-1',
+          'h-[var(--radix-select-trigger-height)] w-full bg-white p-1',
         )}
       >
         {children}

--- a/frontend/src/components/atoms/input.tsx
+++ b/frontend/src/components/atoms/input.tsx
@@ -7,8 +7,8 @@ const Input = React.forwardRef<HTMLInputElement, React.ComponentProps<"input">>(
   // Check if className contains bg-white or !bg-white
   const hasWhiteBg = className?.includes('bg-white') || className?.includes('!bg-white')
   const baseClasses = hasWhiteBg
-    ? "file:text-muted-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input h-9 w-full min-w-0 rounded-md border px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm"
-    : "file:text-muted-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input h-9 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm"
+    ? "file:text-muted-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input h-9 w-full min-w-0 rounded-md border px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50"
+    : "file:text-muted-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input h-9 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50"
   
   return (
     <input

--- a/frontend/src/components/atoms/input.tsx
+++ b/frontend/src/components/atoms/input.tsx
@@ -1,3 +1,11 @@
+// Copyright (c) 2026 Eclipse Foundation.
+//
+// This program and the accompanying materials are made available under the
+// terms of the MIT License which is available at
+// https://opensource.org/licenses/MIT.
+//
+// SPDX-License-Identifier: MIT
+
 import * as React from "react"
 
 import { cn } from "@/lib/utils"

--- a/frontend/src/components/atoms/label.tsx
+++ b/frontend/src/components/atoms/label.tsx
@@ -1,3 +1,11 @@
+// Copyright (c) 2026 Eclipse Foundation.
+//
+// This program and the accompanying materials are made available under the
+// terms of the MIT License which is available at
+// https://opensource.org/licenses/MIT.
+//
+// SPDX-License-Identifier: MIT
+
 import * as React from 'react'
 import * as LabelPrimitive from '@radix-ui/react-label'
 

--- a/frontend/src/components/atoms/label.tsx
+++ b/frontend/src/components/atoms/label.tsx
@@ -11,7 +11,7 @@ function Label({
     <LabelPrimitive.Root
       data-slot="label"
       className={cn(
-        'flex text-primary items-center gap-2 text-sm leading-none font-medium select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50',
+        'flex text-primary items-center gap-2 text-base leading-none font-medium select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50',
         className,
       )}
       {...props}

--- a/frontend/src/components/atoms/select.tsx
+++ b/frontend/src/components/atoms/select.tsx
@@ -1,3 +1,11 @@
+// Copyright (c) 2026 Eclipse Foundation.
+//
+// This program and the accompanying materials are made available under the
+// terms of the MIT License which is available at
+// https://opensource.org/licenses/MIT.
+//
+// SPDX-License-Identifier: MIT
+
 "use client"
 
 import * as React from "react"

--- a/frontend/src/components/atoms/select.tsx
+++ b/frontend/src/components/atoms/select.tsx
@@ -5,11 +5,40 @@ import * as SelectPrimitive from "@radix-ui/react-select"
 import { CheckIcon, ChevronDownIcon, ChevronUpIcon } from "lucide-react"
 
 import { cn } from "@/lib/utils"
+import { subscribeSelectDismiss } from "@/lib/selectDismiss"
 
 function Select({
+  open: openProp,
+  defaultOpen,
+  onOpenChange,
   ...props
 }: React.ComponentProps<typeof SelectPrimitive.Root>) {
-  return <SelectPrimitive.Root data-slot="select" {...props} />
+  const [uncontrolledOpen, setUncontrolledOpen] = React.useState(
+    defaultOpen ?? false,
+  )
+  const isControlled = openProp !== undefined
+  const open = isControlled ? openProp : uncontrolledOpen
+  const onOpenChangeRef = React.useRef(onOpenChange)
+  onOpenChangeRef.current = onOpenChange
+
+  const handleOpenChange = React.useCallback((next: boolean) => {
+    if (!isControlled) setUncontrolledOpen(next)
+    onOpenChangeRef.current?.(next)
+  }, [isControlled])
+
+  // Allow dialogs to force-close nested Selects (Radix click/Escape hacks fail while nested).
+  React.useEffect(() => {
+    return subscribeSelectDismiss(() => handleOpenChange(false))
+  }, [handleOpenChange])
+
+  return (
+    <SelectPrimitive.Root
+      data-slot="select"
+      open={open}
+      onOpenChange={handleOpenChange}
+      {...props}
+    />
+  )
 }
 
 function SelectGroup({
@@ -37,7 +66,7 @@ function SelectTrigger({
       data-slot="select-trigger"
       data-size={size}
       className={cn(
-        "border-input data-[placeholder]:text-muted-foreground [&_svg:not([class*='text-'])]:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 dark:hover:bg-input/50 flex w-fit items-center justify-between gap-2 rounded-md border bg-transparent px-3 py-2 text-sm whitespace-nowrap shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:h-9 data-[size=sm]:h-8 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "border-input data-[placeholder]:text-muted-foreground [&_svg:not([class*='text-'])]:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 dark:hover:bg-input/50 flex w-fit items-center justify-between gap-2 rounded-md border bg-transparent px-3 py-2 text-base whitespace-nowrap shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:h-9 data-[size=sm]:h-8 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className
       )}
       {...props}
@@ -109,7 +138,7 @@ function SelectItem({
     <SelectPrimitive.Item
       data-slot="select-item"
       className={cn(
-        "focus:bg-muted focus:text-primary [&_svg:not([class*='text-'])]:text-muted-foreground relative flex w-full cursor-default items-center gap-2 rounded-sm py-1.5 pr-8 pl-2 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
+        "focus:bg-muted focus:text-primary [&_svg:not([class*='text-'])]:text-muted-foreground relative flex w-full cursor-default items-center gap-2 rounded-sm py-1.5 pr-8 pl-2 text-base outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
         className
       )}
       {...props}

--- a/frontend/src/components/molecules/CreateNewModelDialog.tsx
+++ b/frontend/src/components/molecules/CreateNewModelDialog.tsx
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Eclipse Foundation.
+// Copyright (c) 2026 Eclipse Foundation.
 //
 // This program and the accompanying materials are made available under the
 // terms of the MIT License which is available at

--- a/frontend/src/components/molecules/CreateNewModelDialog.tsx
+++ b/frontend/src/components/molecules/CreateNewModelDialog.tsx
@@ -1,0 +1,44 @@
+// Copyright (c) 2025 Eclipse Foundation.
+//
+// This program and the accompanying materials are made available under the
+// terms of the MIT License which is available at
+// https://opensource.org/licenses/MIT.
+//
+// SPDX-License-Identifier: MIT
+
+import { ReactNode } from 'react'
+import DaDialog from '@/components/molecules/DaDialog'
+import FormCreateModel from '@/components/molecules/forms/FormCreateModel'
+import { cn } from '@/lib/utils'
+
+export interface CreateNewModelDialogProps {
+  trigger?: ReactNode
+  open?: boolean
+  onOpenChange?: (open: boolean) => void
+  onClose?: () => void
+  className?: string
+  hideHeaderDivider?: boolean
+}
+
+const CreateNewModelDialog = ({
+  trigger,
+  open,
+  onOpenChange,
+  onClose,
+  className,
+  hideHeaderDivider,
+}: CreateNewModelDialogProps) => (
+  <DaDialog
+    open={open}
+    onOpenChange={onOpenChange}
+    onClose={onClose}
+    trigger={trigger}
+    dialogTitle="Create New Model"
+    hideHeaderDivider={hideHeaderDivider}
+    className={cn('w-115 max-w-[calc(100vw-40px)]', className)}
+  >
+    <FormCreateModel />
+  </DaDialog>
+)
+
+export default CreateNewModelDialog

--- a/frontend/src/components/molecules/DaConfirmPopup.tsx
+++ b/frontend/src/components/molecules/DaConfirmPopup.tsx
@@ -6,7 +6,7 @@
 //
 // SPDX-License-Identifier: MIT
 
-import React, { useState, ReactElement } from 'react'
+import React, { useState, useEffect, useRef, ReactElement } from 'react'
 import DaDialog from './DaDialog'
 import { Button } from '../atoms/button'
 import { Input } from '../atoms/input'
@@ -37,6 +37,16 @@ const DaConfirmPopup = ({
   const [isOpen, setIsOpen] = state ?? selfManaged
   const [inputValue, setInputValue] = useState('')
   const [isConfirming, setIsConfirming] = useState(false)
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  // DaDialog prevents Radix onOpenAutoFocus; focus the confirm field ourselves.
+  useEffect(() => {
+    if (!isOpen || !confirmText) return
+    const frame = requestAnimationFrame(() => {
+      inputRef.current?.focus()
+    })
+    return () => cancelAnimationFrame(frame)
+  }, [isOpen, confirmText])
 
   const handleConfirm = async () => {
     if (isConfirming) return
@@ -109,11 +119,13 @@ const DaConfirmPopup = ({
               proceed.
             </p>
             <Input
+              ref={inputRef}
               value={inputValue}
               onChange={(e) => setInputValue(e.target.value)}
               onKeyDown={(e) => e.key === 'Enter' && handleConfirm()}
               placeholder={`Type "${confirmText}" to confirm`}
               disabled={isConfirming}
+              autoFocus
             />
           </div>
         )}

--- a/frontend/src/components/molecules/DaDialog.tsx
+++ b/frontend/src/components/molecules/DaDialog.tsx
@@ -15,6 +15,82 @@ import {
 } from '@/components/atoms/dialog'
 import { cn } from '@/lib/utils'
 import { TbX } from 'react-icons/tb'
+import { dismissAllOpenSelects } from '@/lib/selectDismiss'
+
+// Radix Select content uses data-slot / role=listbox — not data-radix-select-content.
+const SELECT_OPEN_SELECTOR =
+  '[data-slot="select-content"][data-state="open"], [role="listbox"][data-state="open"], [data-radix-select-content][data-state="open"]'
+const SELECT_SURFACE_SELECTOR =
+  '[data-slot="select-content"], [data-radix-select-content], [data-radix-select-viewport], [data-slot="select-viewport"]'
+const SELECT_TRIGGER_SELECTOR =
+  '[data-slot="select-trigger"], button[role="combobox"]'
+
+const isSelectOpen = () => !!document.querySelector(SELECT_OPEN_SELECTOR)
+
+const dismissOpenSelects = () => {
+  if (!isSelectOpen()) return
+  dismissAllOpenSelects()
+}
+
+// Singleton listeners — multiple open DaDialogs / StrictMode must not stack handlers.
+let selectOutsideDismissSubscribers = 0
+let selectOutsideDismissPointerHandler: ((event: PointerEvent) => void) | null =
+  null
+let selectOutsideDismissKeyHandler: ((event: KeyboardEvent) => void) | null =
+  null
+
+const subscribeSelectOutsideDismiss = () => {
+  selectOutsideDismissSubscribers += 1
+  if (selectOutsideDismissSubscribers === 1) {
+    selectOutsideDismissPointerHandler = (event: PointerEvent) => {
+      if (!isSelectOpen()) return
+      if (event.button !== 0) return
+      const target = event.target as HTMLElement | null
+      if (!target) return
+      if (target.closest(SELECT_SURFACE_SELECTOR)) return
+      if (target.closest(SELECT_TRIGGER_SELECTOR)) return
+      dismissOpenSelects()
+    }
+    selectOutsideDismissKeyHandler = (event: KeyboardEvent) => {
+      if (event.key !== 'Escape') return
+      if (!isSelectOpen()) return
+      // Close select; stop dialog from also closing on the same Escape.
+      event.preventDefault()
+      event.stopPropagation()
+      dismissOpenSelects()
+    }
+    document.addEventListener(
+      'pointerdown',
+      selectOutsideDismissPointerHandler,
+      true,
+    )
+    document.addEventListener('keydown', selectOutsideDismissKeyHandler, true)
+  }
+  return () => {
+    selectOutsideDismissSubscribers = Math.max(
+      0,
+      selectOutsideDismissSubscribers - 1,
+    )
+    if (selectOutsideDismissSubscribers === 0) {
+      if (selectOutsideDismissPointerHandler) {
+        document.removeEventListener(
+          'pointerdown',
+          selectOutsideDismissPointerHandler,
+          true,
+        )
+        selectOutsideDismissPointerHandler = null
+      }
+      if (selectOutsideDismissKeyHandler) {
+        document.removeEventListener(
+          'keydown',
+          selectOutsideDismissKeyHandler,
+          true,
+        )
+        selectOutsideDismissKeyHandler = null
+      }
+    }
+  }
+}
 
 interface DaDialogProps {
   children: React.ReactNode
@@ -71,15 +147,10 @@ const DaDialog = ({
 
   const canClose = showCloseButton
 
-  const isSelectOpen = () =>
-    !!document.querySelector('[data-radix-select-content][data-state="open"]')
-
-  const dismissOpenSelects = () => {
-    if (!isSelectOpen()) return
-    document.dispatchEvent(
-      new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }),
-    )
-  }
+  useEffect(() => {
+    if (!isOpen) return
+    return subscribeSelectOutsideDismiss()
+  }, [isOpen])
 
   const closeDialog = () => {
     dismissOpenSelects()
@@ -117,26 +188,29 @@ const DaDialog = ({
         onOpenAutoFocus={(e) => e.preventDefault()}
         onPointerDownOutside={(e) => {
           const target = e.target as HTMLElement | null
-          const selectStillOpen = !!document.querySelector(
-            '[data-radix-select-content][data-state="open"]',
-          )
-          const isSelectSurface = !!target?.closest(
-            '[data-radix-select-content], [data-radix-select-viewport]',
-          )
-          if (selectStillOpen || isSelectSurface) {
+          const isSelectSurface = !!target?.closest(SELECT_SURFACE_SELECTOR)
+          if (isSelectSurface) {
             e.preventDefault()
+            return
+          }
+          if (isSelectOpen()) {
+            e.preventDefault()
+            dismissOpenSelects()
             return
           }
           if (preventOutsideClose) e.preventDefault()
         }}
         onEscapeKeyDown={(e) => {
-          if (isSelectOpen()) return
+          if (isSelectOpen()) {
+            e.preventDefault()
+            dismissOpenSelects()
+            return
+          }
           if (preventOutsideClose) e.preventDefault()
         }}
         aria-describedby={undefined}
       >
         {dialogTitle || description ? (
-          // Titled dialog: full header zone with inline close button.
           <div
             className={cn(
               'flex items-center justify-between gap-2 px-6 pt-3 shrink-0',
@@ -145,7 +219,7 @@ const DaDialog = ({
           >
             <div className="flex flex-col gap-0.5 min-w-0">
               {dialogTitle && (
-                <h2 className="text-base font-semibold text-primary leading-tight">{dialogTitle}</h2>
+                <h2 className="text-lg font-semibold text-primary leading-tight">{dialogTitle}</h2>
               )}
               {description && (
                 <p className="text-sm text-muted-foreground leading-snug">{description}</p>
@@ -155,22 +229,22 @@ const DaDialog = ({
               renderCloseButton('relative z-[60] shrink-0')}
           </div>
         ) : (
-          // Untitled dialog (e.g. self-titled forms): float the close button in the
-          // corner with no header bar so it doesn't add an empty title row.
           canClose &&
           renderCloseButton('absolute right-4 top-4 z-[60]')
         )}
 
-        <div
-          className={cn(
-            'flex-1 overflow-y-auto px-6 py-4',
-            // Neutralize a leading top margin on the first rendered child so forms
-            // that use `mt-*` for inter-field spacing don't double-pad under the header.
-            '[&>*:first-child]:mt-0! [&>form>*:first-child]:mt-0! [&>div>*:first-child]:mt-0!',
-            contentContainerClassName,
-          )}
-        >
-          {children}
+        <div className="flex-1 min-h-0 overflow-y-auto">
+          <div
+            className={cn(
+              'px-6 py-4',
+              // Keep focus rings/shadows inside the scroll content (not on the
+              // overflow element) so they are not cropped at the edges.
+              '[&>*:first-child]:mt-0! [&>form>*:first-child]:mt-0! [&>div>*:first-child]:mt-0!',
+              contentContainerClassName,
+            )}
+          >
+            {children}
+          </div>
         </div>
 
         {footer && (

--- a/frontend/src/components/molecules/NavBarActionsEditor.tsx
+++ b/frontend/src/components/molecules/NavBarActionsEditor.tsx
@@ -42,6 +42,12 @@ export const getNavBarActionPosition = (action: NavBarAction): NavBarActionPosit
 export const getNavBarActionOpenTarget = (action: NavBarAction): NavBarActionOpenTarget =>
   action.openTarget === '_self' ? '_self' : '_blank'
 
+/** Empty/whitespace URL falls back to home so the link does not reload the current page. */
+export const getNavBarActionUrl = (action: NavBarAction): string => {
+  const url = typeof action.url === 'string' ? action.url.trim() : ''
+  return url || '/'
+}
+
 export const partitionNavBarActions = (
   actions: NavBarAction[],
 ): { left: NavBarAction[]; right: NavBarAction[] } => ({

--- a/frontend/src/components/molecules/forms/FormCreateModel.tsx
+++ b/frontend/src/components/molecules/forms/FormCreateModel.tsx
@@ -225,6 +225,7 @@ const FormCreateModel = () => {
           onChange={(e) => handleChange('name', e.target.value)}
           placeholder="Model name"
           data-id="form-create-model-input-name"
+          autoFocus
         />
         {isDuplicateName && (
           <DaDuplicateNameHint
@@ -238,7 +239,7 @@ const FormCreateModel = () => {
 
       <div className="mt-4" />
 
-      <p className="text-base font-medium text-primary">Signal *</p>
+      <Label>Signal *</Label>
       <div className="border mt-1 rounded-lg p-2">
         <div className="flex items-stretch gap-2">
           {!data.api_data_url && (

--- a/frontend/src/components/molecules/forms/FormImportPrototype.tsx
+++ b/frontend/src/components/molecules/forms/FormImportPrototype.tsx
@@ -6,14 +6,15 @@
 //
 // SPDX-License-Identifier: MIT
 
-import { useMemo, useState } from 'react'
-import { TbCircleCheckFilled, TbFileImport } from 'react-icons/tb'
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { TbCircleCheckFilled, TbFileImport, TbLoader } from 'react-icons/tb'
 import { Button } from '@/components/atoms/button'
 import { Input } from '@/components/atoms/input'
+import { Label } from '@/components/atoms/label'
 import { Spinner } from '@/components/atoms/spinner'
 import DaImportFile from '@/components/atoms/DaImportFile'
 import DaDuplicateNameHint from '@/components/atoms/DaDuplicateNameHint'
-import CustomDialog from '@/components/molecules/CustomDialog'
+import DaDialog from '@/components/molecules/DaDialog'
 import { useToast } from '../toaster/use-toast'
 import useCurrentModel from '@/hooks/useCurrentModel'
 import {
@@ -38,6 +39,7 @@ const FormImportPrototype = () => {
   const navigate = useNavigate()
   const queryClient = useQueryClient()
   const { toast } = useToast()
+  const nameInputRef = useRef<HTMLInputElement>(null)
 
   const [isOpenImportDialog, setIsOpenImportDialog] = useState(false)
   const [selectedFile, setSelectedFile] = useState<File | null>(null)
@@ -67,6 +69,14 @@ const FormImportPrototype = () => {
     const match = importError.match(/like:\s*([^.,]+)/)
     return match?.[1]?.trim() ?? null
   }, [importError])
+
+  useEffect(() => {
+    if (!isOpenImportDialog || !extractedPrototype) return
+    const frame = requestAnimationFrame(() => {
+      nameInputRef.current?.focus()
+    })
+    return () => cancelAnimationFrame(frame)
+  }, [isOpenImportDialog, extractedPrototype])
 
   const handleFileChange = async (file: File) => {
     setSelectedFile(file)
@@ -184,6 +194,7 @@ const FormImportPrototype = () => {
   }
 
   const handleDialogOpenChange = (open: boolean) => {
+    if (isImporting && !open) return
     setIsOpenImportDialog(open)
     if (!open) {
       setSelectedFile(null)
@@ -215,29 +226,60 @@ const FormImportPrototype = () => {
         </Button>
       </DaImportFile>
 
-      <CustomDialog
+      <DaDialog
         open={isOpenImportDialog}
         onOpenChange={handleDialogOpenChange}
         dialogTitle="Import Prototype"
-        description="Confirm the prototype name before importing."
-        className="h-fit xl:h-fit overflow-hidden"
+        description="Please choose a name for the imported prototype."
+        hideHeaderDivider
+        preventOutsideClose={isImporting}
+        className="w-115 max-w-[calc(100vw-40px)]"
+        footer={
+          <>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => handleDialogOpenChange(false)}
+              disabled={isImporting}
+            >
+              Cancel
+            </Button>
+            <Button
+              size="sm"
+              disabled={
+                !selectedFile ||
+                !prototypeName.trim() ||
+                isImporting ||
+                !extractedPrototype ||
+                isDuplicatePrototypeName
+              }
+              onClick={() => void handleConfirmImport()}
+            >
+              {isImporting ? (
+                <TbLoader className="mr-1 text-lg animate-spin" />
+              ) : null}
+              Import
+            </Button>
+          </>
+        }
       >
-        <div className="flex flex-col space-y-4">
-          {selectedFile && (
-            <p className="text-sm text-muted-foreground">{selectedFile.name}</p>
-          )}
-          {extractedPrototype && (
-            <div className="flex flex-col">
+        <div className="flex flex-col gap-1.5">
+          {extractedPrototype ? (
+            <>
+              <Label>Prototype Name</Label>
               <Input
+                ref={nameInputRef}
                 value={prototypeName}
                 onChange={(e) => {
                   setPrototypeName(e.target.value)
                   setImportError(null)
                 }}
-                placeholder={
-                  extractedPrototype ? extractedPrototype.name : 'Prototype Name'
+                onKeyDown={(e) =>
+                  e.key === 'Enter' && void handleConfirmImport()
                 }
-                className="w-full"
+                placeholder="Prototype Name"
+                disabled={isImporting}
+                autoFocus
               />
               {(isDuplicatePrototypeName || isDuplicateImportError) && (
                 <DaDuplicateNameHint
@@ -253,37 +295,17 @@ const FormImportPrototype = () => {
                     setPrototypeName(name)
                     setImportError(null)
                   }}
-                  className="mt-2"
                 />
               )}
-            </div>
-          )}
-          {importError && !isDuplicatePrototypeName && !isDuplicateImportError && (
-            <div className="text-red-500 text-sm">{importError}</div>
-          )}
-          <Button
-            variant="default"
-            size="sm"
-            disabled={
-              !selectedFile ||
-              !prototypeName.trim() ||
-              isImporting ||
-              !extractedPrototype ||
-              isDuplicatePrototypeName
-            }
-            onClick={handleConfirmImport}
-          >
-            {isImporting ? (
-              <div className="flex items-center">
-                <Spinner className="mr-2 size-4" />
-                Importing...
-              </div>
-            ) : (
-              'Import'
+            </>
+          ) : null}
+          {importError &&
+            !isDuplicatePrototypeName &&
+            !isDuplicateImportError && (
+              <div className="text-sm text-destructive">{importError}</div>
             )}
-          </Button>
         </div>
-      </CustomDialog>
+      </DaDialog>
     </>
   )
 }

--- a/frontend/src/components/molecules/forms/FormNewPrototype.tsx
+++ b/frontend/src/components/molecules/forms/FormNewPrototype.tsx
@@ -9,8 +9,7 @@
 import { Button } from '@/components/atoms/button'
 import DaCheckbox from '@/components/atoms/DaCheckbox'
 import DaFileUploadButton from '@/components/atoms/DaFileUploadButton'
-import { DaInput } from '@/components/atoms/DaInput'
-import { DaSelect, DaSelectItem } from '@/components/atoms/DaSelect'
+import { Input } from '@/components/atoms/input'
 import { DaText } from '@/components/atoms/DaText'
 import { Label } from '@/components/atoms/label'
 import {
@@ -50,7 +49,6 @@ interface FormNewPrototypeProps {
     onClose?: () => void
     code?: string
     widget_config?: string
-    title?: string
     buttonText?: string
     onModelChange?: (modelId: string | null) => void
     /** Fired when creating a new model so the parent can preview the selected template layout. */
@@ -67,7 +65,6 @@ const FormNewPrototype = ({
     onClose,
     code,
     widget_config,
-    title,
     buttonText,
     onModelChange,
     onTemplatePreviewChange,
@@ -377,52 +374,55 @@ const FormNewPrototype = ({
     return (
         <form
             onSubmit={handleSubmit}
-            className="flex flex-col overflow-y-auto"
+            className="flex flex-col"
         >
-            <DaText variant="title" className="text-da-primary-500">
-                {title ?? 'New Prototype'}
-            </DaText>
-
             {/* Model selector */}
             {!isModelSelectorReady ? (
-                <div className="mt-4">
-                    <DaText variant="regular-medium">Model</DaText>
-                    <div className="flex h-10 border px-2 rounded-md shadow-sm mt-2 items-center">
+                <div className="mt-4 flex flex-col gap-1.5">
+                    <Label>Model</Label>
+                    <div className="flex h-10 border px-2 rounded-md shadow-sm items-center">
                         <TbLoader className="size-4 animate-spin mr-2" /> Loading models...
                     </div>
                 </div>
             ) : (
-                <DaSelect
-                    value={isCreatingNewModel ? 'new' : selectedModelId}
-                    label="Model"
-                    wrapperClassName="mt-4"
-                    onValueChange={(value) => {
-                        setError('')
-                        if (value === 'new') {
-                            setUserSelection({ type: 'new' })
-                            onModelChange?.(null)
-                            // Template preview is applied by the create-mode effect once templates load.
-                        } else {
-                            setUserSelection({ type: 'existing', modelId: value })
-                            onModelChange?.(value)
-                            onTemplatePreviewChange?.(null)
-                        }
-                    }}
-                >
-                    <DaSelectItem value="new">+ Create New Model</DaSelectItem>
-                    {modelList.map((model: ModelLite) => (
-                        <DaSelectItem key={model.id} value={model.id}>
-                            {model.name}
-                        </DaSelectItem>
-                    ))}
-                </DaSelect>
+                <div className="mt-4 flex flex-col gap-1.5">
+                    <Label>Model</Label>
+                    <Select
+                        value={isCreatingNewModel ? 'new' : selectedModelId}
+                        onValueChange={(value) => {
+                            setError('')
+                            if (value === 'new') {
+                                setUserSelection({ type: 'new' })
+                                onModelChange?.(null)
+                                // Template preview is applied by the create-mode effect once templates load.
+                            } else {
+                                setUserSelection({ type: 'existing', modelId: value })
+                                onModelChange?.(value)
+                                onTemplatePreviewChange?.(null)
+                            }
+                        }}
+                    >
+                        <SelectTrigger className="w-full">
+                            <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent className="w-[var(--radix-select-trigger-width)]">
+                            <SelectItem value="new">+ Create New Model</SelectItem>
+                            {modelList.map((model: ModelLite) => (
+                                <SelectItem key={model.id} value={model.id}>
+                                    {model.name}
+                                </SelectItem>
+                            ))}
+                        </SelectContent>
+                    </Select>
+                </div>
             )}
 
             {isCreatingNewModel && (
                 <div className="mt-4 flex flex-col gap-3 border rounded-lg p-3">
                     {/* Model Name */}
-                    <div>
-                        <DaInput
+                    <div className="flex flex-col gap-1.5">
+                        <Label>Model Name *</Label>
+                        <Input
                             name="newModelName"
                             value={newModelName}
                             onChange={(e) => {
@@ -430,8 +430,6 @@ const FormNewPrototype = ({
                             setError('')
                             }}
                             placeholder="Model name"
-                            label="Model Name *"
-                            inputClassName="bg-white"
                         />
                         {isDuplicateModelName && (
                             <DaDuplicateNameHint
@@ -446,9 +444,9 @@ const FormNewPrototype = ({
                     </div>
 
                     {/* Signal */}
-                    <div>
-                        <Label className="text-sm font-medium text-primary">Signal *</Label>
-                        <div className="border rounded-lg p-2 mt-1">
+                    <div className="flex flex-col gap-1.5">
+                        <Label>Signal *</Label>
+                        <div className="border rounded-lg p-2">
                             <div className="flex items-stretch gap-2">
                                 {!newModelApiDataUrl && (
                                     <>
@@ -500,11 +498,11 @@ const FormNewPrototype = ({
                     </div>
 
                     {/* Template */}
-                    <div>
-                        <Label className="text-sm font-medium">
+                    <div className="flex flex-col gap-1.5">
+                        <Label>
                             {defaultTemplate ? 'Template' : 'Start from Template (Optional)'}
                         </Label>
-                        <div className="mt-1 space-y-1.5 max-h-36 overflow-y-auto">
+                        <div className="space-y-1.5 max-h-36 overflow-y-auto">
                             {!defaultTemplate && (
                                 <div
                                     onClick={() => setNewModelTemplateId(null)}
@@ -556,19 +554,20 @@ const FormNewPrototype = ({
                 </div>
             )}
 
-            <DaInput
-                name="prototypeName"
-                value={prototypeName}
-                onChange={(e) => {
-                    setPrototypeName(e.target.value)
-                    setError('')
-                }}
-                placeholder="Prototype Name"
-                label="Prototype Name"
-                className="mt-4"
-                data-id="prototype-name-input"
-                labelClassName="font-medium"
-            />
+            <div className="mt-4 flex flex-col gap-1.5">
+                <Label>Prototype Name *</Label>
+                <Input
+                    name="prototypeName"
+                    value={prototypeName}
+                    onChange={(e) => {
+                        setPrototypeName(e.target.value)
+                        setError('')
+                    }}
+                    placeholder="Prototype Name"
+                    data-id="prototype-name-input"
+                    autoFocus
+                />
+            </div>
             {isDuplicatePrototypeName && (
                 <DaDuplicateNameHint
                     message="A prototype with this name already exists"
@@ -582,28 +581,35 @@ const FormNewPrototype = ({
 
             {(isLoadingTemplates || templateOptions.length > 0) &&
                 (isLoadingTemplates ? (
-                    <div className="mt-4">
-                        <DaText variant="regular-medium">Prototype Template *</DaText>
-                        <div className="flex h-10 border px-2 rounded-md shadow-sm mt-2 items-center">
+                    <div className="mt-4 flex flex-col gap-1.5">
+                        <Label>Prototype Template *</Label>
+                        <div className="flex h-10 border px-2 rounded-md shadow-sm items-center">
                             <TbLoader className="size-4 animate-spin mr-2" /> Loading
                             templates...
                         </div>
                     </div>
                 ) : (
-                    <DaSelect
-                        value={selectedTemplateId}
-                        onValueChange={setSelectedTemplateId}
-                        label="Prototype Template *"
-                        wrapperClassName="mt-4"
-                        dataId="project-template-select"
-                        className="w-full"
-                    >
-                        {templateOptions.map((t) => (
-                            <DaSelectItem key={t.id} value={t.id}>
-                                {t.name}
-                            </DaSelectItem>
-                        ))}
-                    </DaSelect>
+                    <div className="mt-4 flex flex-col gap-1.5">
+                        <Label>Prototype Template *</Label>
+                        <Select
+                            value={selectedTemplateId}
+                            onValueChange={setSelectedTemplateId}
+                        >
+                            <SelectTrigger
+                                className="w-full"
+                                data-id="project-template-select"
+                            >
+                                <SelectValue />
+                            </SelectTrigger>
+                            <SelectContent className="w-[var(--radix-select-trigger-width)]">
+                                {templateOptions.map((t) => (
+                                    <SelectItem key={t.id} value={t.id}>
+                                        {t.name}
+                                    </SelectItem>
+                                ))}
+                            </SelectContent>
+                        </Select>
+                    </div>
                 ))}
 
             <div className="mt-4 select-none">

--- a/frontend/src/components/organisms/ActionButtonsTab.tsx
+++ b/frontend/src/components/organisms/ActionButtonsTab.tsx
@@ -113,9 +113,11 @@ const ActionButtonEditor = ({
             {config.label || config.plugin}
           </p>
           <p className="text-xs text-muted-foreground font-mono truncate">
-            {config.builtin
-              ? `Builtin: ${config.builtin}`
-              : `Plugin: ${config.plugin}`}
+            {config.builtin === 'staging' && config.renderPlugin
+              ? `plugin: ${config.renderPlugin}`
+              : config.builtin
+                ? `builtin: ${config.builtin}`
+                : `plugin: ${config.plugin}`}
           </p>
         </div>
         <Button

--- a/frontend/src/components/organisms/HomeButtonList.tsx
+++ b/frontend/src/components/organisms/HomeButtonList.tsx
@@ -9,10 +9,9 @@
 import useSelfProfileQuery from '@/hooks/useSelfProfile'
 import { useMemo } from 'react'
 import { useNavigate } from 'react-router-dom'
-import DaDialog from '../molecules/DaDialog'
 import { DaActionCard } from '../molecules/DaActionCard'
 import { FaCar } from 'react-icons/fa'
-import FormCreateModel from '../molecules/forms/FormCreateModel'
+import CreateNewModelDialog from '../molecules/CreateNewModelDialog'
 import { TbCode, TbPackageImport } from 'react-icons/tb'
 // import FormCreatePrototype from '../molecules/forms/FormCreatePrototype'
 // import FormImportPrototype from '../molecules/forms/FormImportPrototype'
@@ -49,9 +48,8 @@ const HomeButtonList = ({ items, requiredLogin }: HomeButtonListProps) => {
           {items?.map((button, index) => {
             if (button.type === 'new-model')
               return (
-                <DaDialog
+                <CreateNewModelDialog
                   key={index}
-                  dialogTitle="Create New Model"
                   trigger={
                     <DaActionCard
                       title={button.title || 'New model'}
@@ -64,9 +62,7 @@ const HomeButtonList = ({ items, requiredLogin }: HomeButtonListProps) => {
                       className="w-full"
                     />
                   }
-                >
-                  <FormCreateModel />
-                </DaDialog>
+                />
               )
 
             if (button.type === 'new-prototype')

--- a/frontend/src/components/organisms/HomeModelList.tsx
+++ b/frontend/src/components/organisms/HomeModelList.tsx
@@ -46,7 +46,7 @@ import {
 import DaImportFile from '../atoms/DaImportFile'
 import DaDialog from '../molecules/DaDialog'
 import DaConfirmPopup from '../molecules/DaConfirmPopup'
-import FormCreateModel from '../molecules/forms/FormCreateModel'
+import CreateNewModelDialog from '../molecules/CreateNewModelDialog'
 
 import { getLastViewedMap } from '@/utils/modelLastViewed'
 import { cn } from '@/lib/utils'
@@ -476,9 +476,10 @@ const HomeModelList = ({ title }: HomeModelListProps) => {
                   Importing model ...
                 </p>
               )}
-              <DaDialog
+              <CreateNewModelDialog
                 open={createDialogOpen}
                 onOpenChange={setCreateDialogOpen}
+                hideHeaderDivider
                 trigger={
                   <Button
                     variant="outline"
@@ -491,9 +492,7 @@ const HomeModelList = ({ title }: HomeModelListProps) => {
                     </span>
                   </Button>
                 }
-              >
-                <FormCreateModel />
-              </DaDialog>
+              />
             </>
           )}
         </div>

--- a/frontend/src/components/organisms/HomeModelList.tsx
+++ b/frontend/src/components/organisms/HomeModelList.tsx
@@ -6,7 +6,7 @@
 //
 // SPDX-License-Identifier: MIT
 
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { ModelLite } from '@/types/model.type'
 import {
@@ -35,6 +35,7 @@ import {
 } from '../atoms/tooltip'
 import { Button } from '../atoms/button'
 import { Input } from '../atoms/input'
+import { Label } from '../atoms/label'
 import { DaModelCard } from '../molecules/DaModelCard'
 import DaSkeletonGrid from '../molecules/DaSkeletonGrid'
 import {
@@ -47,6 +48,7 @@ import DaImportFile from '../atoms/DaImportFile'
 import DaDialog from '../molecules/DaDialog'
 import DaConfirmPopup from '../molecules/DaConfirmPopup'
 import CreateNewModelDialog from '../molecules/CreateNewModelDialog'
+import DaDuplicateNameHint from '../atoms/DaDuplicateNameHint'
 
 import { getLastViewedMap } from '@/utils/modelLastViewed'
 import { cn } from '@/lib/utils'
@@ -202,9 +204,36 @@ const HomeModelList = ({ title }: HomeModelListProps) => {
     })
   }, [user])
 
-  const { isImporting, handleImportModelZip } = useImportModel({
+  const ownedModelNames = useMemo(
+    () => (groups?.owned ?? []).map((model) => model.name).filter(Boolean),
+    [groups?.owned],
+  )
+
+  const {
+    isImporting,
+    handleImportModelZip,
+    importNameDialogOpen,
+    importModelName,
+    setImportModelName,
+    importNameError,
+    setImportNameError,
+    isDuplicateImportModelName,
+    suggestedImportModelName,
+    resetImportNameDialog,
+    handleConfirmImportName,
+  } = useImportModel({
     onSuccess: refetchModels,
+    existingModelNames: ownedModelNames,
   })
+  const importNameInputRef = useRef<HTMLInputElement>(null)
+
+  useEffect(() => {
+    if (!importNameDialogOpen) return
+    const frame = requestAnimationFrame(() => {
+      importNameInputRef.current?.focus()
+    })
+    return () => cancelAnimationFrame(frame)
+  }, [importNameDialogOpen])
 
   const handleRenameModel = useCallback(async () => {
     if (!renameModelId || !renameValue.trim()) return
@@ -625,6 +654,74 @@ const HomeModelList = ({ title }: HomeModelListProps) => {
               Save
             </Button>
           </div>
+        </div>
+      </DaDialog>
+
+      <DaDialog
+        open={importNameDialogOpen}
+        onOpenChange={(open) => {
+          if (!open) resetImportNameDialog()
+        }}
+        dialogTitle="Import Model"
+        description="Please choose a name for the imported model."
+        hideHeaderDivider
+        preventOutsideClose={isImporting}
+        className="w-115 max-w-[calc(100vw-40px)]"
+        footer={
+          <>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={resetImportNameDialog}
+              disabled={isImporting}
+            >
+              Cancel
+            </Button>
+            <Button
+              size="sm"
+              onClick={() => void handleConfirmImportName()}
+              disabled={
+                isImporting ||
+                !importModelName.trim() ||
+                isDuplicateImportModelName
+              }
+            >
+              {isImporting ? (
+                <TbLoader className="mr-1 text-lg animate-spin" />
+              ) : null}
+              Import
+            </Button>
+          </>
+        }
+      >
+        <div className="flex flex-col gap-1.5">
+          <Label>Model Name</Label>
+          <Input
+            ref={importNameInputRef}
+            value={importModelName}
+            onChange={(e) => {
+              setImportModelName(e.target.value)
+              setImportNameError('')
+            }}
+            onKeyDown={(e) =>
+              e.key === 'Enter' && void handleConfirmImportName()
+            }
+            placeholder="Model name"
+            disabled={isImporting}
+            autoFocus
+          />
+          {(importNameError || isDuplicateImportModelName) && (
+            <DaDuplicateNameHint
+              message={
+                importNameError || 'A model with this name already exists'
+              }
+              suggestedName={suggestedImportModelName}
+              onApplySuggestion={(name) => {
+                setImportModelName(name)
+                setImportNameError('')
+              }}
+            />
+          )}
         </div>
       </DaDialog>
 

--- a/frontend/src/components/organisms/NavigationBar.tsx
+++ b/frontend/src/components/organisms/NavigationBar.tsx
@@ -47,6 +47,7 @@ import useAuthStore from '@/stores/authStore'
 import {
   partitionNavBarActions,
   getNavBarActionOpenTarget,
+  getNavBarActionUrl,
   type NavBarAction,
 } from '@/components/molecules/NavBarActionsEditor'
 
@@ -150,11 +151,12 @@ const NavigationBar = ({ }) => {
     }
 
     const openTarget = getNavBarActionOpenTarget(action)
+    const href = getNavBarActionUrl(action)
 
     return (
       <a
         key={index}
-        href={action.url}
+        href={href}
         target={openTarget}
         {...(openTarget === '_blank' ? { rel: 'noopener noreferrer' } : {})}
         className="da-primary-nav-action flex items-center gap-0 px-1 py-1 rounded-md text-sm font-medium transition-colors hover:bg-muted dark:hover:bg-muted/50"

--- a/frontend/src/components/organisms/TemplateForm.tsx
+++ b/frontend/src/components/organisms/TemplateForm.tsx
@@ -1,3 +1,11 @@
+// Copyright (c) 2026 Eclipse Foundation.
+//
+// This program and the accompanying materials are made available under the
+// terms of the MIT License which is available at
+// https://opensource.org/licenses/MIT.
+//
+// SPDX-License-Identifier: MIT
+
 import { useEffect, useMemo, useState, useRef } from 'react'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import {

--- a/frontend/src/components/organisms/TemplateForm.tsx
+++ b/frontend/src/components/organisms/TemplateForm.tsx
@@ -196,6 +196,7 @@ export default function TemplateForm({
             variant: stagingItem.variant,
             hidden: stagingItem.hidden,
             corners: stagingItem.corners,
+            renderPlugin: stagingItem.renderPlugin,
           }
         : {}
       setPrototypeStagingConfig(stagingItemConfig)
@@ -300,6 +301,7 @@ export default function TemplateForm({
             variant: stagingItem2.variant,
             hidden: stagingItem2.hidden,
             corners: stagingItem2.corners,
+            renderPlugin: stagingItem2.renderPlugin,
           }
         : {}
       setPrototypeStagingConfig(stagingItemConfig2)

--- a/frontend/src/hooks/useImportModel.ts
+++ b/frontend/src/hooks/useImportModel.ts
@@ -6,7 +6,7 @@
 //
 // SPDX-License-Identifier: MIT
 
-import { useCallback, useState } from 'react'
+import { useCallback, useMemo, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { useQueryClient } from '@tanstack/react-query'
 import { isAxiosError } from 'axios'
@@ -18,10 +18,13 @@ import { zipToModel } from '@/lib/zipUtils'
 import { visibilityFromModelTemplate } from '@/utils/modelVisibility'
 import { addLog } from '@/services/log.service'
 import useSelfProfileQuery from '@/hooks/useSelfProfile'
+import useDuplicateNameCheck from '@/hooks/useDuplicateNameCheck'
 import { useToast } from '@/components/molecules/toaster/use-toast'
 
 interface UseImportModelOptions {
   onSuccess?: () => void | Promise<void>
+  /** Names of models owned by the current user — used for client-side duplicate checks. */
+  existingModelNames?: string[]
 }
 
 const useImportModel = (options?: UseImportModelOptions) => {
@@ -30,11 +33,48 @@ const useImportModel = (options?: UseImportModelOptions) => {
   const { data: user } = useSelfProfileQuery()
   const { toast } = useToast()
   const [isImporting, setIsImporting] = useState(false)
+  const [pendingImport, setPendingImport] = useState<any | null>(null)
+  const [importNameDialogOpen, setImportNameDialogOpen] = useState(false)
+  const [importModelName, setImportModelName] = useState('')
+  const [importNameError, setImportNameError] = useState('')
+
+  const existingModelNames = useMemo(
+    () => options?.existingModelNames ?? [],
+    [options?.existingModelNames],
+  )
+
+  const {
+    isDuplicate: isDuplicateImportModelName,
+    suggestedName: suggestedImportModelName,
+  } = useDuplicateNameCheck(importModelName, existingModelNames)
+
+  const resetImportNameDialog = useCallback(() => {
+    setPendingImport(null)
+    setImportModelName('')
+    setImportNameError('')
+    setImportNameDialogOpen(false)
+  }, [])
+
+  const openImportNameDialog = useCallback(
+    (importedModel: any, preferredName?: string, errorMessage?: string) => {
+      const originalName = importedModel?.model?.name || 'New Imported Model'
+      setPendingImport(importedModel)
+      setImportModelName(preferredName?.trim() || originalName)
+      setImportNameError(errorMessage || '')
+      setImportNameDialogOpen(true)
+      setIsImporting(false)
+    },
+    [],
+  )
 
   const createNewModel = useCallback(
-    async (importedModel: any) => {
+    async (importedModel: any, overrideName?: string) => {
       if (!importedModel?.model) return
       try {
+        const modelName =
+          overrideName?.trim() ||
+          importedModel.model.name ||
+          'New Imported Model'
         const newModel: ModelCreate = {
           custom_apis: importedModel.model.custom_apis
             ? JSON.stringify(importedModel.model.custom_apis)
@@ -42,11 +82,14 @@ const useImportModel = (options?: UseImportModelOptions) => {
           cvi: importedModel.model.cvi,
           main_api: importedModel.model.main_api || 'Vehicle',
           model_home_image_file:
-            importedModel.model.model_home_image_file || '/ref/E-Car_Full_Vehicle.png',
+            importedModel.model.model_home_image_file ||
+            '/ref/E-Car_Full_Vehicle.png',
           model_files: importedModel.model.model_files || {},
-          name: importedModel.model.name || 'New Imported Model',
+          name: modelName,
           extended_apis: importedModel.model.extended_apis || [],
-          ...(importedModel.model.api_version && { api_version: importedModel.model.api_version }),
+          ...(importedModel.model.api_version && {
+            api_version: importedModel.model.api_version,
+          }),
           visibility: 'private',
         }
 
@@ -55,7 +98,10 @@ const useImportModel = (options?: UseImportModelOptions) => {
             importedModel.model.custom_template
         } else {
           try {
-            const templatesData = await listModelTemplates({ limit: 100, page: 1 })
+            const templatesData = await listModelTemplates({
+              limit: 100,
+              page: 1,
+            })
             const defaultTemplate = templatesData?.results?.find(
               (t) => t.is_default,
             )
@@ -100,10 +146,24 @@ const useImportModel = (options?: UseImportModelOptions) => {
           )
         }
         await options?.onSuccess?.()
-        queryClient.invalidateQueries({ queryKey: ['modelsList', user?.id ?? 'anonymous'] })
+        queryClient.invalidateQueries({
+          queryKey: ['modelsList', user?.id ?? 'anonymous'],
+        })
+        resetImportNameDialog()
         navigate(`/model/${createdModelId}`)
       } catch (err) {
         console.error('Error creating model from zip: ', err)
+        if (isAxiosError(err) && err.response?.status === 409) {
+          openImportNameDialog(
+            importedModel,
+            overrideName?.trim() ||
+              importedModel.model?.name ||
+              'New Imported Model',
+            err.response.data?.message ||
+              'A model with this name already exists',
+          )
+          return
+        }
         const description = isAxiosError(err)
           ? err.response?.data?.message ?? 'Something went wrong'
           : err instanceof Error
@@ -118,8 +178,34 @@ const useImportModel = (options?: UseImportModelOptions) => {
         setIsImporting(false)
       }
     },
-    [user, options?.onSuccess, navigate, queryClient, toast],
+    [
+      user,
+      options?.onSuccess,
+      navigate,
+      queryClient,
+      toast,
+      openImportNameDialog,
+      resetImportNameDialog,
+    ],
   )
+
+  const handleConfirmImportName = useCallback(async () => {
+    if (
+      !pendingImport ||
+      !importModelName.trim() ||
+      isDuplicateImportModelName
+    ) {
+      return
+    }
+    setImportNameError('')
+    setIsImporting(true)
+    await createNewModel(pendingImport, importModelName.trim())
+  }, [
+    pendingImport,
+    importModelName,
+    isDuplicateImportModelName,
+    createNewModel,
+  ])
 
   const handleImportModelZip = useCallback(
     async (file: File) => {
@@ -135,6 +221,20 @@ const useImportModel = (options?: UseImportModelOptions) => {
           setIsImporting(false)
           return
         }
+
+        const proposedName = model.model?.name || 'New Imported Model'
+        const duplicate = existingModelNames.some(
+          (name) => name.toLowerCase() === proposedName.toLowerCase(),
+        )
+        if (duplicate) {
+          openImportNameDialog(
+            model,
+            proposedName,
+            'A model with this name already exists',
+          )
+          return
+        }
+
         await createNewModel(model)
       } catch (err) {
         console.error('Failed to import model zip: ', err)
@@ -149,10 +249,22 @@ const useImportModel = (options?: UseImportModelOptions) => {
         setIsImporting(false)
       }
     },
-    [createNewModel, toast],
+    [createNewModel, toast, existingModelNames, openImportNameDialog],
   )
 
-  return { isImporting, handleImportModelZip }
+  return {
+    isImporting,
+    handleImportModelZip,
+    importNameDialogOpen,
+    importModelName,
+    setImportModelName,
+    importNameError,
+    setImportNameError,
+    isDuplicateImportModelName,
+    suggestedImportModelName,
+    resetImportNameDialog,
+    handleConfirmImportName,
+  }
 }
 
 export default useImportModel

--- a/frontend/src/layouts/NewPrototypeLayout.tsx
+++ b/frontend/src/layouts/NewPrototypeLayout.tsx
@@ -10,7 +10,7 @@ import { FC, useCallback, useEffect, useState } from 'react'
 import { useNavigate, useSearchParams } from 'react-router-dom'
 import { Button } from '@/components/atoms/button'
 import DaDialog from '@/components/molecules/DaDialog'
-import FormCreateModel from '@/components/molecules/forms/FormCreateModel'
+import CreateNewModelDialog from '@/components/molecules/CreateNewModelDialog'
 import FormNewPrototype from '@/components/molecules/forms/FormNewPrototype'
 import NewPrototypeTabs from '@/components/molecules/NewPrototypeTabs'
 import {
@@ -221,7 +221,9 @@ const NewPrototypeLayout: FC = () => {
         preventOutsideClose
         onOpenChange={setOpenNewPrototypeDialog}
         onClose={handleLeavePage}
-        className="w-115 max-w-[calc(100vw-40px)] max-h-[90vh] overflow-auto"
+        dialogTitle="New Prototype"
+        hideHeaderDivider
+        className="w-115 max-w-[calc(100vw-40px)] max-h-[90vh]"
       >
         <FormNewPrototype
           onClose={() => setOpenNewPrototypeDialog(false)}
@@ -231,17 +233,13 @@ const NewPrototypeLayout: FC = () => {
         />
       </DaDialog>
 
-      <DaDialog
+      <CreateNewModelDialog
         open={openCreateModelDialog}
         onOpenChange={(open) => {
           setOpenCreateModelDialog(open)
           if (!open) handleLeavePage()
         }}
-        dialogTitle="Create New Model"
-        className="w-115 max-w-[calc(100vw-40px)]"
-      >
-        <FormCreateModel />
-      </DaDialog>
+      />
     </div>
   )
 }

--- a/frontend/src/lib/selectDismiss.ts
+++ b/frontend/src/lib/selectDismiss.ts
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Eclipse Foundation.
+// Copyright (c) 2026 Eclipse Foundation.
 //
 // This program and the accompanying materials are made available under the
 // terms of the MIT License which is available at

--- a/frontend/src/lib/selectDismiss.ts
+++ b/frontend/src/lib/selectDismiss.ts
@@ -1,0 +1,24 @@
+// Copyright (c) 2025 Eclipse Foundation.
+//
+// This program and the accompanying materials are made available under the
+// terms of the MIT License which is available at
+// https://opensource.org/licenses/MIT.
+//
+// SPDX-License-Identifier: MIT
+
+type SelectDismissListener = () => void
+
+const listeners = new Set<SelectDismissListener>()
+
+/** Register a Select instance to close when dismissAllOpenSelects() is called. */
+export function subscribeSelectDismiss(listener: SelectDismissListener) {
+  listeners.add(listener)
+  return () => {
+    listeners.delete(listener)
+  }
+}
+
+/** Close all registered open Selects via React state (not DOM click hacks). */
+export function dismissAllOpenSelects() {
+  listeners.forEach((listener) => listener())
+}

--- a/frontend/src/pages/PageHome.tsx
+++ b/frontend/src/pages/PageHome.tsx
@@ -10,8 +10,7 @@ import { useState, useEffect } from 'react'
 import { useSearchParams } from 'react-router-dom'
 import { configManagementService } from '@/services/configManagement.service'
 import { Spinner } from '@/components/atoms/spinner'
-import DaDialog from '@/components/molecules/DaDialog'
-import FormCreateModel from '@/components/molecules/forms/FormCreateModel'
+import CreateNewModelDialog from '@/components/molecules/CreateNewModelDialog'
 import { getHomeComponent } from '@/utils/homeComponentMap'
 
 const PageHome = () => {
@@ -64,7 +63,7 @@ const PageHome = () => {
         return <Component key={index} {...element} />
       })}
 
-      <DaDialog
+      <CreateNewModelDialog
         open={openCreateModelDialog}
         onOpenChange={(v) => {
           setOpenCreateModelDialog(v)
@@ -73,11 +72,7 @@ const PageHome = () => {
             setSearchParams(searchParams, { replace: true })
           }
         }}
-        className="w-115 max-w-[calc(100vw-40px)]"
-        dialogTitle="Create New Model"
-      >
-        <FormCreateModel />
-      </DaDialog>
+      />
     </div>
   )
 }

--- a/frontend/src/pages/PageModelList.tsx
+++ b/frontend/src/pages/PageModelList.tsx
@@ -9,6 +9,7 @@ import { useState, useRef, useCallback, useMemo, useEffect } from 'react'
 import { useQueryClient } from '@tanstack/react-query'
 import { Button } from '@/components/atoms/button'
 import { Input } from '@/components/atoms/input'
+import { Label } from '@/components/atoms/label'
 import { HiPlus } from 'react-icons/hi'
 import { TbLoader, TbPackageExport, TbRefresh, TbSearch } from 'react-icons/tb'
 import DaDialog from '@/components/molecules/DaDialog'
@@ -551,42 +552,18 @@ const PageModelList = () => {
                         onOpenChange={(open) => {
                           if (!open) resetImportNameDialog()
                         }}
-                        dialogTitle="Import model - Choose a name"
+                        dialogTitle="Import Model"
                         description="Please choose a name for the imported model."
-                        
-                      >
-                        <div className="flex flex-col gap-4">
-                          <div>
-                            <Input
-                              value={importModelName}
-                              onChange={(e) => {
-                                setImportModelName(e.target.value)
-                                setImportNameError('')
-                              }}
-                              onKeyDown={(e) =>
-                                e.key === 'Enter' && void handleConfirmImportName()
-                              }
-                              placeholder="Model name"
-                            />
-                            {(importNameError || isDuplicateImportModelName) && (
-                              <DaDuplicateNameHint
-                                message={
-                                  importNameError ||
-                                  'A model with this name already exists'
-                                }
-                                suggestedName={suggestedImportModelName}
-                                onApplySuggestion={(name) => {
-                                  setImportModelName(name)
-                                  setImportNameError('')
-                                }}
-                              />
-                            )}
-                          </div>
-                          <div className="flex justify-end gap-2">
+                        hideHeaderDivider
+                        preventOutsideClose={isImporting}
+                        className="w-115 max-w-[calc(100vw-40px)]"
+                        footer={
+                          <>
                             <Button
                               variant="outline"
                               size="sm"
                               onClick={resetImportNameDialog}
+                              disabled={isImporting}
                             >
                               Cancel
                             </Button>
@@ -604,7 +581,37 @@ const PageModelList = () => {
                               ) : null}
                               Import
                             </Button>
-                          </div>
+                          </>
+                        }
+                      >
+                        <div className="flex flex-col gap-1.5">
+                          <Label>Model Name</Label>
+                          <Input
+                            value={importModelName}
+                            onChange={(e) => {
+                              setImportModelName(e.target.value)
+                              setImportNameError('')
+                            }}
+                            onKeyDown={(e) =>
+                              e.key === 'Enter' && void handleConfirmImportName()
+                            }
+                            placeholder="Model name"
+                            disabled={isImporting}
+                            autoFocus
+                          />
+                          {(importNameError || isDuplicateImportModelName) && (
+                            <DaDuplicateNameHint
+                              message={
+                                importNameError ||
+                                'A model with this name already exists'
+                              }
+                              suggestedName={suggestedImportModelName}
+                              onApplySuggestion={(name) => {
+                                setImportModelName(name)
+                                setImportNameError('')
+                              }}
+                            />
+                          )}
                         </div>
                       </DaDialog>
                     </div>

--- a/frontend/src/pages/PageModelList.tsx
+++ b/frontend/src/pages/PageModelList.tsx
@@ -12,7 +12,7 @@ import { Input } from '@/components/atoms/input'
 import { HiPlus } from 'react-icons/hi'
 import { TbLoader, TbPackageExport, TbRefresh, TbSearch } from 'react-icons/tb'
 import DaDialog from '@/components/molecules/DaDialog'
-import FormCreateModel from '@/components/molecules/forms/FormCreateModel'
+import CreateNewModelDialog from '@/components/molecules/CreateNewModelDialog'
 import DaImportFile from '@/components/atoms/DaImportFile'
 import { buildPrototypeImportPayload, zipToModel } from '@/lib/zipUtils'
 import { createModelService } from '@/services/model.service'
@@ -531,10 +531,9 @@ const PageModelList = () => {
                         </p>
                       )}
 
-                      <DaDialog
+                      <CreateNewModelDialog
                         open={createDialogOpen}
                         onOpenChange={setCreateDialogOpen}
-                        dialogTitle="Create New Model"
                         trigger={
                           <Button
                             variant="default"
@@ -545,9 +544,7 @@ const PageModelList = () => {
                             Create New Model
                           </Button>
                         }
-                      >
-                        <FormCreateModel />
-                      </DaDialog>
+                      />
 
                       <DaDialog
                         open={importNameDialogOpen}

--- a/frontend/src/pages/PagePrototypeLibrary.tsx
+++ b/frontend/src/pages/PagePrototypeLibrary.tsx
@@ -170,6 +170,7 @@ const PagePrototypeLibrary = () => {
                       open={open}
                       onOpenChange={setOpen}
                       dialogTitle="New Prototype"
+                      hideHeaderDivider
                       trigger={
                         <Button
                           data-id="btn-create-new-prototype"


### PR DESCRIPTION

## Summary

Improves the Create New Model and New Prototype dialogs so they share consistent header/field styling, autofocus the name inputs, reuse one create-model dialog component, and fix select dropdown UX (width, outside-click/Escape dismiss, focus-ring clipping).

## Motivation

### What problem does it solve?

Create Model and New Prototype flows looked and behaved inconsistently: different title styles, mixed label/input components, missing dialog titles in some entry points, selects that overflowed the dialog or would not close on outside click/Escape, and focus rings that were cropped by overflow containers.

### What was difficult or missing before?

- Create New Model was copy-pasted across Home, Model List, Home buttons, and `/new-prototype` with slightly different dialog props.
- New Prototype rendered its own in-form title instead of the shared dialog header.
- Nested Radix Selects inside `DaDialog` did not reliably dismiss on outside click or Escape.
- Long model names widened the select menu past the field/dialog.
- Focus `box-shadow` / ring was clipped by `overflow` on the dialog content and form.

### Why is this approach useful?

Centralizing the create-model dialog and aligning both forms on shared `DaDialog` / `Label` / `Input` / `Select` primitives reduces drift, and a small select-dismiss bus + singleton outside/Escape handlers fix nested modal behavior without fighting Radix event layers via DOM click hacks.

## Changes

- Added `CreateNewModelDialog` shared wrapper (`dialogTitle`, default width, `FormCreateModel`) and wired Home / Model List / Home buttons / PageHome / NewPrototypeLayout to it.
- Updated New Prototype to use `DaDialog` header title (no divider), shared field labels/inputs/selects, autofocus on Prototype Name, and required asterisk on that label.
- Updated Create Model name field autofocus and Signal label to use shared `Label`.
- Improved shared typography: larger dialog titles, field labels (`text-base`), and input/select text (`text-base`).
- Constrained `DaSelect` / `Select` dropdown width to the trigger and truncated long option text.
- Added `selectDismiss` bus and taught `Select` to close via React state; `DaDialog` dismisses open selects on outside pointerdown and Escape (dialog stays open when appropriate).
- Refactored dialog content layout so padding sits inside the scroll area (and removed form-level `overflow-y-auto`) to avoid cropping focus rings.
- Added tests for … *(none in this change; manual verification only)*.

## Behavior

### Before:

- Create Model dialog title/props differed by entry point; some flows omitted a proper header.
- New Prototype title lived inside the form with a different style from Create Model.
- Name fields did not consistently autofocus when the dialog opened.
- Model select menus could grow wider than the field/dialog.
- Clicking outside or pressing Escape often left the select open inside the dialog.
- Focus ring / box shadow on inputs was clipped on the top/bottom (and sometimes edges).

### After:

- All Create New Model entry points use the same titled dialog component.
- New Prototype and Create Model share dialog header and field label/input styling.
- Opening either dialog focuses the primary name input; Prototype Name shows a required `*`.
- Select menus match the trigger width; long names truncate.
- Outside click or Escape closes an open select without necessarily closing the dialog.
- Focus rings render fully around focused fields.

## Testing

- [ ] Unit tests
- [ ] Integration tests
- [x] Manual testing
- [ ] Existing test suite passes *(not re-run as a full suite for this PR)*

### Tested with:

- Manual check of New Prototype (`/new-prototype`) and Create New Model (home / model list / add model).
- Autofocus on name fields when dialogs open.
- Model select: width constrained; outside click and Escape dismiss the dropdown; dialog remains open where `preventOutsideClose` applies.
- Focus ring visibility on Prototype Name and other inputs after overflow fixes.
- Visual alignment of titles, labels, and inputs between Create Model and New Prototype.

## Breaking Changes

None.

## Additional Notes

- Nested Select-in-Dialog dismiss uses a lightweight module bus (`frontend/src/lib/selectDismiss.ts`) because programmatic trigger `.click()` / synthetic Escape did not close Radix Select while nested in the modal layer.
- `Select` is now lightly controlled when used uncontrolled by callers (internal open state + dismiss subscription). Call sites that already pass `open` / `onOpenChange` continue to work.
- `DaSelect` width clamping remains for any remaining legacy usages; New Prototype Model/Template fields use the shared `Select` atom.
- Possible follow-up: Playwright coverage for create-model / new-prototype dialog open → autofocus → select dismiss; consider extracting a shared “create prototype dialog” wrapper similar to `CreateNewModelDialog`.
